### PR TITLE
Override labels of order_by options

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -255,7 +255,10 @@ class BaseFilterSet(object):
     def get_ordering_field(self):
         if self._meta.order_by:
             if isinstance(self._meta.order_by, (list, tuple)):
-                choices = [(f, capfirst(f)) for f in self._meta.order_by]
+                if isinstance(self._meta.order_by[0], (list, tuple)):
+                    choices = [(f[0], f[1]) for f in self._meta.order_by]
+                else:
+                    choices = [(f, capfirst(f)) for f in self._meta.order_by]
             else:
                 choices = [(f, capfirst(f)) for f in self.filters]
             return forms.ChoiceField(label="Ordering", required=False, choices=choices)

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -91,6 +91,14 @@ You can also allow the user to control ordering, this is done by providing the
 it can be a ``bool`` which, if True, indicates that all fields that have
 the user can filter on can also be sorted on.
 
+If ``order_by`` is a list of lists, the inner lists must be in name/label 
+pairs. This lets you override the display names of your ordering fields::
+
+    order_by = (
+        ('name', 'Company Name'),
+        ('average_rating', 'Stars'),
+        )
+
 The inner ``Meta`` class also takes an optional ``form`` argument.  This is a
 form class from which ``FilterSet.form`` will subclass.  This works similar to
 the ``form`` option on a ``ModelAdmin.``


### PR DESCRIPTION
This simple patch lets you override the label for the options in your order_by tuple. This is handy if you have a column called average_rating you want to order by; previously this would show to the user as 'Average_rating'. Now, you can override that and call it 'Average Rating' or anything else that pleases you.
