### PR TITLE
State minimal django version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Requirements
 ------------
 
 * Python 2.6+
-* Django 1.4.3+
+* Django 1.4.2+
 
 Installation
 ------------


### PR DESCRIPTION
django.utils.six is available from Django 1.4.2
