### PR TITLE
Add support for non-symmetrical m2m fields

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -66,6 +66,7 @@ def get_model_field(model, f):
     except FieldDoesNotExist:
         return None
     if not direct:
+        if not rel.field.rel.symmetrical: return rel.field
         return rel.field.rel.to_field
     return rel
 


### PR DESCRIPTION
Django-filter raises and exception on ManyToManyField that has the symmetrical option set to False. Here is a patch that fixed it for my case (sounds logical to me, but I'm not an expert on Django's ORM).

Camille.
