### PR TITLE
experiment with form errors to skip filtering on invalid data

### DIFF
--- a/tests/filterset_tests.py
+++ b/tests/filterset_tests.py
@@ -425,7 +425,7 @@ class FilterSetOrderingTests(TestCase):
         # user_ids = list(User.objects.all().values_list('pk', flat=True))
         self.qs = User.objects.all().order_by('id')
 
-    def test_ordering_unset(self):
+    def test_ordering_when_unbound(self):
         class F(FilterSet):
             class Meta:
                 model = User
@@ -434,7 +434,7 @@ class FilterSetOrderingTests(TestCase):
         
         f = F(queryset=self.qs)
         self.assertQuerysetEqual(
-            f.qs, ['alex', 'jacob', 'aaron', 'carl'], lambda o: o.username)
+            f.qs, ['carl', 'alex', 'jacob', 'aaron'], lambda o: o.username)
 
     def test_ordering(self):
         class F(FilterSet):
@@ -447,7 +447,7 @@ class FilterSetOrderingTests(TestCase):
         self.assertQuerysetEqual(
             f.qs, ['carl', 'alex', 'jacob', 'aaron'], lambda o: o.username)
 
-    def test_ordering_on_unknown_value_is_ignored(self):
+    def test_ordering_on_unknown_value_results_in_default_ordering(self):
         class F(FilterSet):
             class Meta:
                 model = User
@@ -456,7 +456,7 @@ class FilterSetOrderingTests(TestCase):
         
         f = F({'o': 'username'}, queryset=self.qs)
         self.assertQuerysetEqual(
-            f.qs, ['alex', 'jacob', 'aaron', 'carl'], lambda o: o.username)
+            f.qs, ['carl', 'alex', 'jacob', 'aaron'], lambda o: o.username)
 
     def test_ordering_on_differnt_field(self):
         class F(FilterSet):


### PR DESCRIPTION
This pull-request would need a bit more work to be considered complete, but it is an alternate implementation to address issue #84.  I mainly wanted to see if we could make use of Django's built-in form behavior better (which I think this does).

To summarize, I've altered the form instantiation to always create a bound form (using the initial field data and merging in any submitted data) and cleaning it immediately.  Then in the `qs` method, the default behavior for an invalid form will be to simply return a `none` queryset.  I also added a `strict` flag for the FilterSet, which defaults to True.  If the strict flag is False, then the filtering will be performed, but only with the valid values from the form's cleaned_data.
