### PR TITLE
Change option label to match a translated one

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -151,7 +151,7 @@ _truncate = lambda dt: dt.replace(hour=0, minute=0, second=0)
 
 class DateRangeFilter(ChoiceFilter):
     options = {
-        '': (_('Any Date'), lambda qs, name: qs.all()),
+        '': (_('Any date'), lambda qs, name: qs.all()),
         1: (_('Today'), lambda qs, name: qs.filter(**{
             '%s__year' % name: now().year,
             '%s__month' % name: now().month,


### PR DESCRIPTION
Option label 'Any Date' is not included in any .po file but 'Any date' is in
django.contrib.admin. Changing this, language translation now works fine.

See [current django.contrib.admin django.po file](https://github.com/django/django/blob/master/django/contrib/admin/locale/en/LC_MESSAGES/django.po#L52).
