### PR TITLE
python lower than 2.6.5 will raise TypeError when dict keys are not str

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -382,7 +382,11 @@ class BaseFilterSet(object):
         filter_class = data.get('filter_class')
         default.update(data.get('extra', lambda f: {})(f))
         if filter_class is not None:
-            return filter_class(**default)
+            try:
+                return filter_class(**default)
+            except TypeError:
+                return filter_class(**dict(
+                    (str(k), v) for (k, v) in default.iteritems()))
 
     @classmethod
     def filter_for_reverse_field(cls, f, name):


### PR DESCRIPTION
I'm not sure this is of interest to anyone other than myself (since it seems the world has moved on to newer python interpreters).

Without this change, the method will raise since the keys in the kwargs are unicode, not str. This became legal in 2.6.5, but for 2.6.4 (and below?) this is the best I could come up with.
