### PR TITLE
Fix some formatting in docs.

### DIFF
--- a/docs/ref/widgets.txt
+++ b/docs/ref/widgets.txt
@@ -12,8 +12,8 @@ one method that you can overide for additional customizability.
 ``option_string()`` should return a string with 3 Python keyword argument
 placeholders::
 
-    1. ``attrs``: This is a string with all the attributes that will be on the
-       final ``<a>`` tag.
-    2. ``query_string``: This is the query string for use in the ``href``
-       option on the ``<a>`` elemeent.
-    3. ``label``: This is the text to be displayed to the user.
+1. ``attrs``: This is a string with all the attributes that will be on the
+   final ``<a>`` tag.
+2. ``query_string``: This is the query string for use in the ``href``
+   option on the ``<a>`` elemeent.
+3. ``label``: This is the text to be displayed to the user.


### PR DESCRIPTION
The indentation was causing the whole block to render as a `<pre>`.
