### PR TITLE
Fixed a case where MultipleChoiceFilter returns all results by mistake

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -40,7 +40,7 @@ class Filter(object):
         self.required = required
         self.extra = kwargs
         self.distinct = distinct
-        self.exclude = exclude
+        self.exclude = excludeMultipleChoiceFilter
 
         self.creation_counter = Filter.creation_counter
         Filter.creation_counter += 1
@@ -105,8 +105,6 @@ class MultipleChoiceFilter(Filter):
 
     def filter(self, qs, value):
         value = value or ()
-        if len(value) == len(self.field.choices):
-            return qs
         q = Q()
         for v in value:
             q |= Q(**{self.name: v})


### PR DESCRIPTION
In case the choices field is not required (null=True, blank=True on the model), there's no way to get all items that has _some_ choice.  My change removes the "get all" optimization but supports this use-case.
