### PR TITLE
Fix MultipleChoiceFilter for non-required fields

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -105,7 +105,7 @@ class MultipleChoiceFilter(Filter):
 
     def filter(self, qs, value):
         value = value or ()
-        if len(value) == len(self.field.choices):
+        if self.required and len(value) == len(self.field.choices):
             return qs
         q = Q()
         for v in value:


### PR DESCRIPTION
MultipleChoiceFilter skips filtering if the number of choices of the filter are equal to the number of choices of the field. The reason behind this is probably that if all choices are allowed then filtering doesn't make any sense. That is correct of the field is required to have a value, but not if the field can be empty. In that case it will fail to filter out the records that don't have any value at all. This patch fixes MultipleChoiceFilter so that it only optimises the case were a value is required.
