### PR TITLE
Fix typo in FilterView documentation

### DIFF
--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -203,7 +203,7 @@ Generic View
 
 In addition to the above usage there is also a class-based generic view
 included in django-filter, which lives at ``django_filters.views.FilterView``.
-You must provide either a ``model`` or ``filter_class`` argument, similar to
+You must provide either a ``model`` or ``filterset_class`` argument, similar to
 ``ListView`` in Django itself::
 
     # urls.py


### PR DESCRIPTION
It's filtered_class and not filter_class. Fixes #135
