### PR TITLE
Improved build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
-  - "pypy"
-  - "pypy3"
+  #- "pypy"
+  #- "pypy3"
 
 env:
   - DJANGO='https://github.com/django/django/archive/master.tar.gz'
@@ -35,10 +35,10 @@ matrix:
       env: DJANGO='django>=1.4.0,<1.5.0'
     - python: "3.4"
       env: DJANGO='django>=1.4.0,<1.5.0'
-    - python: "pypy"
-      env: DJANGO='django>=1.4.0,<1.5.0'
-    - python: "pypy3"
-      env: DJANGO='django>=1.4.0,<1.5.0'
+    #- python: "pypy"
+    #  env: DJANGO='django>=1.4.0,<1.5.0'
+    #- python: "pypy3"
+    #  env: DJANGO='django>=1.4.0,<1.5.0'
     - python: "2.6"
       env: DJANGO='django>=1.7.0,<1.8.0'
     - python: "2.6"


### PR DESCRIPTION
Added PyPy and PyPy 3.
Allowed failures for the latest django develop version.
Loosened the django version to use the latest minor version.
The matrix should fast finish since it's large.
Used travis_retry in order to avoid build failures due to networking issues.
