### PR TITLE
Test and Docs showing explict ChoiceFilter declaration

### DIFF
--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -24,6 +24,30 @@ This filter matches a boolean, either ``True`` or ``False``, used with
 This filter matches an item of any type by choices, used with any field that
 has ``choices``.
 
+
+Requires ``choices`` ``kwarg`` to be passed if explicitly declared on the ``FilterSet``. For example::
+
+    class User(models.Model):
+        username = models.CharField(max_length=255)
+        first_name = SubCharField(max_length=100)
+        last_name = SubSubCharField(max_length=100)
+
+        status = models.IntegerField(choices=STATUS_CHOICES, default=0)
+
+    STATUS_CHOICES = (
+        (0, 'Regular'),
+        (1, 'Manager'),
+        (2, 'Admin'),
+    )
+
+    class F(FilterSet):
+        status = ChoiceFilter(choices=STATUS_CHOICES)
+        class Meta:
+            model = User
+            fields = ['status']
+
+
+
 ``TypedChoiceFilter``
 ~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Closes #30 

If you explicitly declare a ChoiceFilter you **must** pass `choices`:

```
    STATUS_CHOICES = (...)
    class F(FilterSet):
        status = ChoiceFilter(choices=STATUS_CHOICES)
        class Meta:
            model = User
            fields = ['status']
```
