### PR TITLE
Allow overriding of DateRangeField's and TimeRangeField's fields

### DIFF
--- a/django_filters/fields.py
+++ b/django_filters/fields.py
@@ -32,10 +32,7 @@ class RangeField(forms.MultiValueField):
 
 class DateRangeField(RangeField):
 
-    def __init__(self, *args, **kwargs):
-        fields = (
-            forms.DateField(),
-            forms.DateField())
+    def __init__(self, fields=2 * (forms.DateField(), ), *args, **kwargs):
         super(DateRangeField, self).__init__(fields, *args, **kwargs)
 
     def compress(self, data_list):
@@ -51,10 +48,7 @@ class DateRangeField(RangeField):
 
 class TimeRangeField(RangeField):
 
-    def __init__(self, *args, **kwargs):
-        fields = (
-            forms.TimeField(),
-            forms.TimeField())
+    def __init__(self, fields=2 * (forms.TimeField(), ), *args, **kwargs):
         super(TimeRangeField, self).__init__(fields, *args, **kwargs)
 
 


### PR DESCRIPTION
This makes the following usage possible:

```python
date = django_filters.DateFromToRangeFilter(
    fields=2 * (forms.DateField(), ),
    widget=forms.MultiWidget(2 * (forms.DateInput(attrs={'type': 'date'}), ))
)
```

without this patch the best I could come up with is:

```python
class HTML5DateRangeField(RangeField):

    def compress(self, data_list):
        if data_list:
            start_date, stop_date = data_list
            if start_date:
                start_date = datetime.combine(start_date, time.min)
            if stop_date:
                stop_date = datetime.combine(stop_date, time.max)
            return slice(start_date, stop_date)
        return None


class HTML5DateFromToRangeFilter(django_filters.RangeFilter):
    field_class = HTML5DateRangeField


date = HTML5DateFromToRangeFilter(
    fields=2 * (forms.DateField(), ),
    widget=forms.MultiWidget(2 * (forms.DateInput(attrs={'type': 'date'}), ))
)
```

Also, this makes the API more consistent.