### PR TITLE
Add lookup expression transform handling

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -424,7 +424,7 @@ class BaseFilterSet(object):
         default = {
             'name': name,
             'label': capfirst(f.verbose_name),
-            'lookup_type': lookup_expr
+            'lookup_expr': lookup_expr
         }
 
         if f.choices:

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -10,7 +10,6 @@ from django.forms.forms import NON_FIELD_ERRORS
 from django.core.validators import EMPTY_VALUES
 from django.db import models
 from django.db.models.constants import LOOKUP_SEP
-from django.db.models.fields import FieldDoesNotExist
 from django.db.models.fields.related import ForeignObjectRel
 from django.utils import six
 from django.utils.text import capfirst
@@ -20,7 +19,7 @@ from .compat import remote_field, remote_model
 from .filters import (Filter, CharFilter, BooleanFilter,
                       ChoiceFilter, DateFilter, DateTimeFilter, TimeFilter, ModelChoiceFilter,
                       ModelMultipleChoiceFilter, NumberFilter, UUIDFilter)
-from .utils import try_dbfield
+from .utils import try_dbfield, get_model_field
 
 
 ORDER_BY_FIELD = 'o'
@@ -56,25 +55,6 @@ def get_declared_filters(bases, attrs, with_base_filters=True):
                 filters = list(base.declared_filters.items()) + filters
 
     return OrderedDict(filters)
-
-
-def get_model_field(model, f):
-    parts = f.split(LOOKUP_SEP)
-    opts = model._meta
-    for name in parts[:-1]:
-        try:
-            rel = opts.get_field(name)
-        except FieldDoesNotExist:
-            return None
-        if isinstance(rel, ForeignObjectRel):
-            opts = rel.related_model._meta
-        else:
-            opts = remote_model(rel)._meta
-    try:
-        rel = opts.get_field(parts[-1])
-    except FieldDoesNotExist:
-        return None
-    return rel
 
 
 def filters_for_model(model, fields=None, exclude=None, filter_for_field=None,

--- a/django_filters/utils.py
+++ b/django_filters/utils.py
@@ -1,0 +1,22 @@
+
+from django.db import models
+
+
+def try_dbfield(fn, field_class):
+    """
+    Try ``fn`` with the DB ``field_class`` by walking its
+    MRO until a result is found.
+
+    ex::
+        _try_dbfield(field_dict.get, models.CharField)
+
+    """
+    # walk the mro, as field_class could be a derived model field.
+    for cls in field_class.mro():
+        # skip if cls is models.Field
+        if cls is models.Field:
+            continue
+
+        data = fn(cls)
+        if data:
+            return data

--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -171,7 +171,7 @@ than a maximum where only one limit value is provided. This filter is designed t
 the Postgres Numerical Range Fields, including `IntegerRangeField`, `BigIntegerRangeField` and `FloatRangeField`,
 available since Django 1.8. The default widget used is the `RangeField`.
 
-RangeField lookup_types can be used, including `overlap`, `contains`, and `contained_by`. More lookups can be
+RangeField lookup_exprs can be used, including `overlap`, `contains`, and `contained_by`. More lookups can be
 found in the Django docs ([https://docs.djangoproject.com/en/1.8/ref/contrib/postgres/fields/#querying-range-fields](https://docs.djangoproject.com/en/1.8/ref/contrib/postgres/fields/#querying-range-fields)).
 
 If the lower limit value is provided, the filter automatically defaults to `__startswith` as the lookup
@@ -285,15 +285,17 @@ recieves a ``QuerySet`` and the value to filter on and should return a
 ``Queryset`` that is filtered appropriately. `action` will default to
 ``filter_{value-of-name-attribute}``
 
-``lookup_type``
+``lookup_expr``
 ~~~~~~~~~~~~~~~
 
-The type of lookup that should be performed using the [Django ORM](https://docs.djangoproject.com/en/dev/ref/models/querysets/#field-lookups "Django's ORM Lookups").
+The lookup expression that should be performed using `Django's ORM`_.
 All the normal options are allowed, and should be provided as a string.  You can also
 provide either ``None`` or a ``list`` or a ``tuple``.  If ``None`` is provided,
 then the user can select the lookup type from all the ones available in the Django
 ORM.  If a ``list`` or ``tuple`` is provided, then the user can select from those
 options.
+
+.. _`Django's ORM`: https://docs.djangoproject.com/en/dev/ref/models/querysets/#field-lookups
 
 ``distinct``
 ~~~~~~~~~~~~

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -40,16 +40,21 @@ declarative syntax::
     import django_filters
 
     class ProductFilter(django_filters.FilterSet):
-        price = django_filters.NumberFilter(lookup_type='lt')
+        price = django_filters.NumberFilter(lookup_expr='lt')
         class Meta:
             model = Product
             fields = ['price', 'release_date']
 
-Filters take a ``lookup_type`` argument which specifies what lookup type to
-use with `Django's ORM`_.  So here when a user entered a price it would show all
-Products with a price less than that.
+Filters take a ``lookup_expr`` argument which specifies what lookup expression to
+use with `Django's ORM`_. A detailed explanation of lookup expressions is provided in Django's
+`lookup reference`_. django-filter expects an expression to contain only transforms and a final
+lookup. ex, ``year__gte``.
 
 .. _`Django's ORM`: https://docs.djangoproject.com/en/dev/ref/models/querysets/#field-lookups
+
+.. _`lookup reference`: https://docs.djangoproject.com/en/dev/ref/models/lookups/#module-django.db.models.lookups
+
+In the above filter, when a user enters a price it would show all Products with a price less than that.
 
 **It's quite common to forget to set lookup type for `CharField`s/`TextField`s
 and wonder why search for "foo" doesn't return result for "foobar". It's because
@@ -57,7 +62,7 @@ default lookup type is exact text, but you probably want `icontains` lookup
 field.**
 
 The FilterSet Meta class fields can additionally be set using a Dictionary to
-specify multiple ``lookup_type`` filters without significant code duplication::
+specify multiple ``lookup_expr`` filters without significant code duplication::
 
     import django_filters
 
@@ -65,7 +70,7 @@ specify multiple ``lookup_type`` filters without significant code duplication::
         class Meta:
             model = Product
             fields = {'price': ['lt', 'gt'],
-                      'release_date': ['exact'],
+                      'release_date': ['exact', 'year__gt'],
                      }
 
 The above would generate 'price__lt', 'price__gt' and 'release_date' filters.
@@ -105,7 +110,7 @@ default filters for all the models fields of the same kind using
             models.CharField: {
                 'filter_class': django_filters.CharFilter,
                 'extra': lambda f: {
-                    'lookup_type': 'icontains',
+                    'lookup_expr': 'icontains',
                 }
             }
         }
@@ -239,7 +244,7 @@ the user can filter on can also be sorted on. An example or ordering using a lis
     import django_filters
 
     class ProductFilter(django_filters.FilterSet):
-        price = django_filters.NumberFilter(lookup_type='lt')
+        price = django_filters.NumberFilter(lookup_expr='lt')
         class Meta:
             model = Product
             fields = ['price', 'release_date']
@@ -380,11 +385,11 @@ Choices help text
 
 If you want the ``ChoiceField`` created from `LOOKUP_TYPES` to have human-friendly options you can do the following:
 
-:: 
+::
 
     # filters.py
     from django_filters import filters
-    
+
     filters.LOOKUP_TYPES = [
         ('', '---------'),
         ('exact', 'Is equal to'),

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -45,16 +45,19 @@ declarative syntax::
             model = Product
             fields = ['price', 'release_date']
 
-Filters take a ``lookup_expr`` argument which specifies what lookup expression to
-use with `Django's ORM`_. A detailed explanation of lookup expressions is provided in Django's
-`lookup reference`_. django-filter expects an expression to contain only transforms and a final
-lookup. ex, ``year__gte``.
+Filters take a ``lookup_expr`` argument which specifies what lookup expression
+to use with `Django's ORM`_. A detailed explanation of lookup expressions is
+provided in Django's `lookup reference`_. django-filter supports expressions
+containing both transforms and a final lookup in version 1.9 of Django and
+above. ex, ``year__gte``. For Django version 1.8, transforms expressions are
+not supported.
 
 .. _`Django's ORM`: https://docs.djangoproject.com/en/dev/ref/models/querysets/#field-lookups
 
 .. _`lookup reference`: https://docs.djangoproject.com/en/dev/ref/models/lookups/#module-django.db.models.lookups
 
-In the above filter, when a user enters a price it would show all Products with a price less than that.
+In the above filter, when a user enters a price it would show all Products
+with a price less than that.
 
 **It's quite common to forget to set lookup type for `CharField`s/`TextField`s
 and wonder why search for "foo" doesn't return result for "foobar". It's because

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -5,6 +5,7 @@ import datetime
 import mock
 import unittest
 
+import django
 from django.test import TestCase, override_settings
 from django.utils import six
 from django.utils.timezone import now
@@ -1242,6 +1243,7 @@ class NonSymmetricalSelfReferentialRelationshipTests(TestCase):
 
 class TransformedQueryExpressionFilterTests(TestCase):
 
+    @unittest.skipIf(django.VERSION < (1, 9), "version does not support transformed lookup expressions")
     @override_settings(USE_TZ=False)
     def test_filtering(self):
         # use naive datetimes, as pytz is required to perform

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -446,9 +446,9 @@ class NumberFilterTests(TestCase):
         f = F({'price': 10}, queryset=Book.objects.all())
         self.assertQuerysetEqual(f.qs, ['Ender\'s Game'], lambda o: o.title)
 
-    def test_filtering_with_single_lookup_type(self):
+    def test_filtering_with_single_lookup_expr(self):
         class F(FilterSet):
-            price = NumberFilter(lookup_type='lt')
+            price = NumberFilter(lookup_expr='lt')
 
             class Meta:
                 model = Book
@@ -458,7 +458,7 @@ class NumberFilterTests(TestCase):
         self.assertQuerysetEqual(
             f.qs, ['Ender\'s Game', 'Rainbow Six'], lambda o: o.title)
 
-    def test_filtering_with_single_lookup_type_dictionary(self):
+    def test_filtering_with_single_lookup_expr_dictionary(self):
         class F(FilterSet):
             class Meta:
                 model = Book
@@ -468,9 +468,9 @@ class NumberFilterTests(TestCase):
         self.assertQuerysetEqual(
             f.qs, ['Ender\'s Game', 'Rainbow Six'], lambda o: o.title)
 
-    def test_filtering_with_multiple_lookup_types(self):
+    def test_filtering_with_multiple_lookup_exprs(self):
         class F(FilterSet):
-            price = NumberFilter(lookup_type=['lt', 'gt'])
+            price = NumberFilter(lookup_expr=['lt', 'gt'])
 
             class Meta:
                 model = Book
@@ -487,7 +487,7 @@ class NumberFilterTests(TestCase):
                                  lambda o: o.title, ordered=False)
 
         class F(FilterSet):
-            price = NumberFilter(lookup_type=['lt', 'gt', 'exact'])
+            price = NumberFilter(lookup_expr=['lt', 'gt', 'exact'])
 
             class Meta:
                 model = Book

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 from datetime import date, time, timedelta
 import mock
+import warnings
 import unittest
 
 import django
@@ -186,6 +187,16 @@ class FilterTests(TestCase):
         f.filter(qs, 'value')
         result = qs.distinct.assert_called_once_with()
         self.assertNotEqual(qs, result)
+
+    def test_lookup_type_deprecation(self):
+        """
+        Make sure user is alerted when using deprecated ``lookup_type``.
+        """
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            Filter(lookup_type='exact')
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
 
 
 class CustomFilterWithBooleanCheckTests(TestCase):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -45,7 +45,7 @@ class FilterTests(TestCase):
 
     def test_creation(self):
         f = Filter()
-        self.assertEqual(f.lookup_type, 'exact')
+        self.assertEqual(f.lookup_expr, 'exact')
         self.assertEqual(f.exclude, False)
 
     def test_creation_order(self):
@@ -65,26 +65,26 @@ class FilterTests(TestCase):
         self.assertIsInstance(field, forms.Field)
         self.assertEqual(field.help_text, 'This is an exclusion filter')
 
-    def test_field_with_single_lookup_type(self):
-        f = Filter(lookup_type='iexact')
+    def test_field_with_single_lookup_expr(self):
+        f = Filter(lookup_expr='iexact')
         field = f.field
         self.assertIsInstance(field, forms.Field)
 
-    def test_field_with_none_lookup_type(self):
-        f = Filter(lookup_type=None)
+    def test_field_with_none_lookup_expr(self):
+        f = Filter(lookup_expr=None)
         field = f.field
         self.assertIsInstance(field, LookupTypeField)
         choice_field = field.fields[1]
         self.assertEqual(len(choice_field.choices), len(LOOKUP_TYPES))
 
-    def test_field_with_lookup_type_and_exlusion(self):
-        f = Filter(lookup_type=None, exclude=True)
+    def test_field_with_lookup_expr_and_exlusion(self):
+        f = Filter(lookup_expr=None, exclude=True)
         field = f.field
         self.assertIsInstance(field, LookupTypeField)
         self.assertEqual(field.help_text, 'This is an exclusion filter')
 
-    def test_field_with_list_lookup_type(self):
-        f = Filter(lookup_type=('istartswith', 'iendswith'))
+    def test_field_with_list_lookup_expr(self):
+        f = Filter(lookup_expr=('istartswith', 'iendswith'))
         field = f.field
         self.assertIsInstance(field, LookupTypeField)
         choice_field = field.fields[1]
@@ -153,22 +153,22 @@ class FilterTests(TestCase):
 
     def test_filtering_with_list_value(self):
         qs = mock.Mock(spec=['filter'])
-        f = Filter(name='somefield', lookup_type=['some_lookup_type'])
-        result = f.filter(qs, Lookup('value', 'some_lookup_type'))
-        qs.filter.assert_called_once_with(somefield__some_lookup_type='value')
+        f = Filter(name='somefield', lookup_expr=['some_lookup_expr'])
+        result = f.filter(qs, Lookup('value', 'some_lookup_expr'))
+        qs.filter.assert_called_once_with(somefield__some_lookup_expr='value')
         self.assertNotEqual(qs, result)
 
     def test_filtering_skipped_with_list_value_with_blank(self):
         qs = mock.Mock()
-        f = Filter(name='somefield', lookup_type=['some_lookup_type'])
-        result = f.filter(qs, Lookup('', 'some_lookup_type'))
+        f = Filter(name='somefield', lookup_expr=['some_lookup_expr'])
+        result = f.filter(qs, Lookup('', 'some_lookup_expr'))
         self.assertListEqual(qs.method_calls, [])
         self.assertEqual(qs, result)
 
     def test_filtering_skipped_with_list_value_with_blank_lookup(self):
-        return  # Now field is required to provide valid lookup_type if it provides any
+        return  # Now field is required to provide valid lookup_expr if it provides any
         qs = mock.Mock(spec=['filter'])
-        f = Filter(name='somefield', lookup_type=None)
+        f = Filter(name='somefield', lookup_expr=None)
         result = f.filter(qs, Lookup('value', ''))
         qs.filter.assert_called_once_with(somefield__exact='value')
         self.assertNotEqual(qs, result)
@@ -278,9 +278,9 @@ class BooleanFilterTests(TestCase):
         self.assertListEqual(qs.method_calls, [])
         self.assertEqual(qs, result)
 
-    def test_filtering_lookup_type(self):
+    def test_filtering_lookup_expr(self):
         qs = mock.Mock(spec=['filter'])
-        f = BooleanFilter(name='somefield', lookup_type='isnull')
+        f = BooleanFilter(name='somefield', lookup_expr='isnull')
         result = f.filter(qs, True)
         qs.filter.assert_called_once_with(somefield__isnull=True)
         self.assertNotEqual(qs, result)
@@ -541,10 +541,10 @@ class NumericRangeFilterTests(TestCase):
         result = f.filter(qs, None)
         self.assertEqual(qs, result)
 
-    def test_field_with_lookup_type(self):
+    def test_field_with_lookup_expr(self):
         qs = mock.Mock()
         value = mock.Mock(start=20, stop=30)
-        f = NumericRangeFilter(lookup_type=('overlap'))
+        f = NumericRangeFilter(lookup_expr=('overlap'))
         f.filter(qs, value)
         qs.filter.assert_called_once_with(None__overlap=(20, 30))
 
@@ -605,10 +605,10 @@ class RangeFilterTests(TestCase):
         result = f.filter(qs, None)
         self.assertEqual(qs, result)
 
-    def test_filtering_ignores_lookup_type(self):
+    def test_filtering_ignores_lookup_expr(self):
         qs = mock.Mock()
         value = mock.Mock(start=20, stop=30)
-        f = RangeFilter(lookup_type='gte')
+        f = RangeFilter(lookup_expr='gte')
         f.filter(qs, value)
         qs.filter.assert_called_once_with(None__range=(20, 30))
 
@@ -738,10 +738,10 @@ class DateFromToRangeFilterTests(TestCase):
         result = f.filter(qs, None)
         self.assertEqual(qs, result)
 
-    def test_filtering_ignores_lookup_type(self):
+    def test_filtering_ignores_lookup_expr(self):
         qs = mock.Mock()
         value = mock.Mock(start=date(2015, 4, 7), stop=date(2015, 9, 6))
-        f = DateFromToRangeFilter(lookup_type='gte')
+        f = DateFromToRangeFilter(lookup_expr='gte')
         f.filter(qs, value)
         qs.filter.assert_called_once_with(
             None__range=(date(2015, 4, 7), date(2015, 9, 6)))
@@ -782,10 +782,10 @@ class TimeRangeFilterTests(TestCase):
         result = f.filter(qs, None)
         self.assertEqual(qs, result)
 
-    def test_filtering_ignores_lookup_type(self):
+    def test_filtering_ignores_lookup_expr(self):
         qs = mock.Mock()
         value = mock.Mock(start=time(10, 15), stop=time(12, 30))
-        f = TimeRangeFilter(lookup_type='gte')
+        f = TimeRangeFilter(lookup_expr='gte')
         f.filter(qs, value)
         qs.filter.assert_called_once_with(
             None__range=(time(10, 15), time(12, 30)))
@@ -810,7 +810,7 @@ class AllValuesFilterTests(TestCase):
 
 
 class LookupTypesTests(TestCase):
-    def test_custom_lookup_types(self):
+    def test_custom_lookup_exprs(self):
         filters.LOOKUP_TYPES = [
             ('', '---------'),
             ('exact', 'Is equal to'),
@@ -825,7 +825,7 @@ class LookupTypesTests(TestCase):
             ('not_contains', 'Does not contain'),
         ]
 
-        f = Filter(lookup_type=None)
+        f = Filter(lookup_expr=None)
         field = f.field
         choice_field = field.fields[1]
         choices = choice_field.choices

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -171,6 +171,12 @@ class FilterSetFilterForFieldTests(TestCase):
         self.assertIsNotNone(result.extra['queryset'])
         self.assertEqual(result.extra['queryset'].model, Worker)
 
+    def test_transformed_lookup_expr(self):
+        f = Comment._meta.get_field('date')
+        result = FilterSet.filter_for_field(f, 'date', 'year__gte')
+        self.assertIsInstance(result, NumberFilter)
+        self.assertEqual(result.name, 'date')
+
     @unittest.skip('todo')
     def test_filter_overrides(self):
         pass

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -9,7 +9,6 @@ from django.test import TestCase
 
 from django_filters.filterset import FilterSet
 from django_filters.filterset import FILTER_FOR_DBFIELD_DEFAULTS
-from django_filters.filterset import get_model_field
 from django_filters.filters import CharFilter
 from django_filters.filters import NumberFilter
 from django_filters.filters import ChoiceFilter
@@ -47,14 +46,6 @@ class HelperMethodsTests(TestCase):
     @unittest.skip('todo')
     def test_get_declared_filters(self):
         pass
-
-    def test_get_model_field_none(self):
-        result = get_model_field(User, 'unknown__name')
-        self.assertIsNone(result)
-
-    def test_get_model_field(self):
-        result = get_model_field(Business, 'hiredworker__worker')
-        self.assertEqual(result, HiredWorker._meta.get_field('worker'))
 
     @unittest.skip('todo')
     def test_filters_for_model(self):

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -171,6 +171,7 @@ class FilterSetFilterForFieldTests(TestCase):
         self.assertIsNotNone(result.extra['queryset'])
         self.assertEqual(result.extra['queryset'].model, Worker)
 
+    @unittest.skipIf(django.VERSION < (1, 9), "version does not support transformed lookup expressions")
     def test_transformed_lookup_expr(self):
         f = Comment._meta.get_field('date')
         result = FilterSet.filter_for_field(f, 'date', 'year__gte')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,19 @@
+
+from django.test import TestCase
+
+from django_filters.utils import get_model_field
+
+from .models import User
+from .models import HiredWorker
+from .models import Business
+
+
+class GetModelFieldTests(TestCase):
+
+    def test_non_existent_field(self):
+        result = get_model_field(User, 'unknown__name')
+        self.assertIsNone(result)
+
+    def test_related_field(self):
+        result = get_model_field(Business, 'hiredworker__worker')
+        self.assertEqual(result, HiredWorker._meta.get_field('worker'))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,7 @@
 
+import unittest
+
+import django
 from django.test import TestCase
 from django.db import models
 from django.db.models.constants import LOOKUP_SEP
@@ -40,6 +43,7 @@ class ResolveFieldTests(TestCase):
             self.assertIsInstance(field, models.CharField)
             self.assertEqual(lookup, term)
 
+    @unittest.skipIf(django.VERSION < (1, 9), "version does not support transformed lookup expressions")
     def test_resolve_transformed_lookups(self):
         """
         Check that chained field transforms are correctly resolved.
@@ -91,6 +95,7 @@ class ResolveFieldTests(TestCase):
                 self.assertIsInstance(field, models.IntegerField)
                 self.assertEqual(resolved_lookup, lookup)
 
+    @unittest.skipIf(django.VERSION < (1, 9), "version does not support transformed lookup expressions")
     def test_resolve_implicit_exact_lookup(self):
         # Use a DateTimeField, so we can check multiple transforms.
         # eg, date__year__gte

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,13 @@
 
 from django.test import TestCase
+from django.db import models
+from django.db.models.constants import LOOKUP_SEP
+from django.core.exceptions import FieldError
 
-from django_filters.utils import get_model_field
+from django_filters.utils import get_model_field, resolve_field
 
 from .models import User
+from .models import Article
 from .models import HiredWorker
 from .models import Business
 
@@ -17,3 +21,97 @@ class GetModelFieldTests(TestCase):
     def test_related_field(self):
         result = get_model_field(Business, 'hiredworker__worker')
         self.assertEqual(result, HiredWorker._meta.get_field('worker'))
+
+
+class ResolveFieldTests(TestCase):
+
+    def test_resolve_plain_lookups(self):
+        """
+        Check that the standard query terms can be correctly resolved.
+        eg, an 'EXACT' lookup on a user's username
+        """
+        model_field = User._meta.get_field('username')
+        lookups = model_field.class_lookups.keys()
+
+        # This is simple - the final ouput of an untransformed field is itself.
+        # The lookups are the default lookups registered to the class.
+        for term in lookups:
+            field, lookup = resolve_field(model_field, term)
+            self.assertIsInstance(field, models.CharField)
+            self.assertEqual(lookup, term)
+
+    def test_resolve_transformed_lookups(self):
+        """
+        Check that chained field transforms are correctly resolved.
+        eg, a 'date__year__gte' lookup on an article's 'published' timestamp.
+        """
+        # Use a DateTimeField, so we can check multiple transforms.
+        # eg, date__year__gte
+        model_field = Article._meta.get_field('published')
+
+        standard_lookups = [
+            'exact',
+            'iexact',
+            'gte',
+            'gt',
+            'lte',
+            'lt',
+        ]
+
+        date_lookups = [
+            'year',
+            'month',
+            'day',
+            'week_day',
+        ]
+
+        datetime_lookups = date_lookups + [
+            'hour',
+            'minute',
+            'second',
+        ]
+
+        # ex: 'date__gt'
+        for lookup in standard_lookups:
+            field, resolved_lookup = resolve_field(model_field, LOOKUP_SEP.join(['date', lookup]))
+            self.assertIsInstance(field, models.DateField)
+            self.assertEqual(resolved_lookup, lookup)
+
+        # ex: 'year__iexact'
+        for part in datetime_lookups:
+            for lookup in standard_lookups:
+                field, resolved_lookup = resolve_field(model_field, LOOKUP_SEP.join([part, lookup]))
+                self.assertIsInstance(field, models.IntegerField)
+                self.assertEqual(resolved_lookup, lookup)
+
+        # ex: 'date__year__lte'
+        for part in date_lookups:
+            for lookup in standard_lookups:
+                field, resolved_lookup = resolve_field(model_field, LOOKUP_SEP.join(['date', part, lookup]))
+                self.assertIsInstance(field, models.IntegerField)
+                self.assertEqual(resolved_lookup, lookup)
+
+    def test_resolve_implicit_exact_lookup(self):
+        # Use a DateTimeField, so we can check multiple transforms.
+        # eg, date__year__gte
+        model_field = Article._meta.get_field('published')
+
+        field, lookup = resolve_field(model_field, 'date')
+        self.assertIsInstance(field, models.DateField)
+        self.assertEqual(lookup, 'exact')
+
+        field, lookup = resolve_field(model_field, 'date__year')
+        self.assertIsInstance(field, models.IntegerField)
+        self.assertEqual(lookup, 'exact')
+
+    def test_invalid_lookup_expression(self):
+        model_field = Article._meta.get_field('published')
+
+        with self.assertRaises(FieldError):
+            field, lookup = resolve_field(model_field, 'invalid_lookup')
+
+    def test_invalid_transformed_lookup_expression(self):
+        model_field = Article._meta.get_field('published')
+
+        with self.assertRaises(FieldError):
+            field, lookup = resolve_field(model_field, 'date__invalid_lookup')


### PR DESCRIPTION
This adds the ability to use transforms in lookup expressions. eg, 
```py
class ArticleFilter(FilterSet):
    class Meta:
        model = Article
        fields = {
            'published_at': ['year', 'year__gt', 'year__lt'],
        }
```

Currently, the above filters are incorrectly created as `DateTimeFilter`s, as only the model field is used during evaluation. Transforms potentially alter the type of the final `output_field`, which is now taken into account.

I tried to separate changes into individual commits as much as possible. idk if reviewing the individual commits would provide a better picture of what the PR is doing.

Summary of changes:
- Some code factored out/restructured into utility module
- Added transform handling
- `lookup_type` refactored as `lookup_expr`, as this is now more correct (since django 1.7). `lookup_type` is only the final part of an overall expression, which includes field parts and transforms. More info in the first section [here](https://docs.djangoproject.com/en/1.9/ref/models/lookups/#module-django.db.models.lookups). Note that in the PR, `lookup_expr`s only include transforms and a final lookup, as the field parts are already separated out.
- Added deprecation warnings for `lookup_type` usage.

Other notes:
- `LookupTypeField` is left as is. Open to suggestion, but think a fix is more appropriate for a separate PR. The behavior continues to work as expected, although it is technically incorrect. It currently generates filters for all `LOOKUP_TYPES` (which is an alias for `QUERY_TERMS`), but this isn't really a valid way of generating lookups anymore. 
  - Not all lookups are appropriate for all fields (eg, date lookups on integer fields). Lookups are now registered on the model field, which is the way this should be generated instead of `QUERY_TERMS`.
  - It does not include transformed lookups (`year__gte`), and so is incomplete.
  - I would rather punt/leave be, as the module-level `LOOKUP_TYPES` (which is an alias for `QUERY_TERMS`) is problematic to fix. It also acts as an override for adding custom lookups, however this is now field specific, so....
- Am currently reworking #297, which handles `isnull`, `in`, `range`, and other lookup overrides. This PR is the basis for that.

Edit:
This would close #321 as well.