### PR TITLE
Fix boolean widget rendering

### DIFF
--- a/django_filters/widgets.py
+++ b/django_filters/widgets.py
@@ -98,24 +98,42 @@ class LookupTypeWidget(forms.MultiWidget):
         return value
 
 
-class BooleanWidget(forms.Widget):
+class BooleanWidget(forms.Select):
     """Convert true/false values into the internal Python True/False.
     This can be used for AJAX queries that pass true/false from JavaScript's
     internal types through.
     """
+    def __init__(self, attrs=None):
+        choices = (('', _('Unknown')),
+                   ('true', _('Yes')),
+                   ('false', _('No')))
+        super(BooleanWidget, self).__init__(attrs, choices)
+
+    def render(self, name, value, attrs=None):
+        try:
+            value = {
+                True: 'true',
+                False: 'false',
+                '1': 'true',
+                '0': 'false'
+            }[value]
+        except KeyError:
+            value = ''
+        return super(BooleanWidget, self).render(name, value, attrs)
+
     def value_from_datadict(self, data, files, name):
-        """
-        """
-        value = super(BooleanWidget, self).value_from_datadict(
-            data, files, name)
+        value = data.get(name, None)
+        if isinstance(value, string_types):
+            value = value.lower()
 
-        if value is not None:
-            if value.lower() == 'true':
-                value = True
-            elif value.lower() == 'false':
-                value = False
-
-        return value
+        return {
+            '1': True,
+            '0': False,
+            'true': True,
+            'false': False,
+            True: True,
+            False: False,
+        }.get(value, None)
 
 
 class CSVWidget(forms.TextInput):

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -149,6 +149,15 @@ class RangeWidgetTests(TestCase):
 class BooleanWidgetTests(TestCase):
     """
     """
+    def test_widget_render(self):
+        w = BooleanWidget()
+        self.assertHTMLEqual(w.render('price', ''), """
+            <select name="price">
+                <option selected="selected" value="">Unknown</option>
+                <option value="true">Yes</option>
+                <option value="false">No</option>
+            </select>""")
+
     def test_widget_value_from_datadict(self):
         """
         """


### PR DESCRIPTION
The `BooleanWidget` class currently inherits from `Widget` and does not have a render method, causing form rendering to fail.

Fixes #383.