### PR TITLE
Clean up tests and get rid of RuntimeWarning

### DIFF
--- a/django_filters/fields.py
+++ b/django_filters/fields.py
@@ -5,14 +5,12 @@ from datetime import datetime, time
 from collections import namedtuple
 
 from django import forms
-from django.conf import settings
 from django.utils.dateparse import parse_datetime
-from django.utils import timezone
 
 from django.utils.encoding import force_str
-from django.utils.timezone import make_aware
 from django.utils.translation import ugettext_lazy as _
 
+from .utils import handle_timezone
 from .widgets import RangeWidget, LookupTypeWidget, CSVWidget
 
 
@@ -44,13 +42,11 @@ class DateRangeField(RangeField):
         if data_list:
             start_date, stop_date = data_list
             if start_date:
-                start_date = datetime.combine(start_date, time.min)
-                if settings.USE_TZ:
-                    start_date = make_aware(start_date)
+                start_date = handle_timezone(
+                    datetime.combine(start_date, time.min))
             if stop_date:
-                stop_date = datetime.combine(stop_date, time.max)
-                if settings.USE_TZ:
-                    stop_date = make_aware(stop_date)
+                stop_date = handle_timezone(
+                    datetime.combine(stop_date, time.max))
             return slice(start_date, stop_date)
         return None
 
@@ -111,7 +107,6 @@ class IsoDateTimeField(forms.DateTimeField):
     """
     ISO_8601 = 'iso-8601'
     input_formats = [ISO_8601]
-    default_timezone = timezone.get_default_timezone() if settings.USE_TZ else None
 
     def strptime(self, value, format):
         value = force_str(value)
@@ -120,14 +115,7 @@ class IsoDateTimeField(forms.DateTimeField):
             parsed = parse_datetime(value)
             if parsed is None:  # Continue with other formats if doesn't match
                 raise ValueError
-
-            # Handle timezone awareness. Copied from:
-            # https://github.com/tomchristie/django-rest-framework/blob/3.2.0/rest_framework/fields.py#L965-L969
-            if settings.USE_TZ and not timezone.is_aware(parsed):
-                return timezone.make_aware(parsed, self.default_timezone)
-            elif not settings.USE_TZ and timezone.is_aware(parsed):
-                return timezone.make_naive(parsed, timezone.UTC())
-            return parsed
+            return handle_timezone(parsed)
         return super(IsoDateTimeField, self).strptime(value, format)
 
 

--- a/django_filters/fields.py
+++ b/django_filters/fields.py
@@ -10,6 +10,7 @@ from django.utils.dateparse import parse_datetime
 from django.utils import timezone
 
 from django.utils.encoding import force_str
+from django.utils.timezone import make_aware
 from django.utils.translation import ugettext_lazy as _
 
 from .widgets import RangeWidget, LookupTypeWidget, CSVWidget
@@ -44,8 +45,12 @@ class DateRangeField(RangeField):
             start_date, stop_date = data_list
             if start_date:
                 start_date = datetime.combine(start_date, time.min)
+                if settings.USE_TZ:
+                    start_date = make_aware(start_date)
             if stop_date:
                 stop_date = datetime.combine(stop_date, time.max)
+                if settings.USE_TZ:
+                    stop_date = make_aware(stop_date)
             return slice(start_date, stop_date)
         return None
 

--- a/django_filters/utils.py
+++ b/django_filters/utils.py
@@ -1,9 +1,10 @@
-
+from django.conf import settings
 from django.db import models
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.expressions import Expression
 from django.db.models.fields import FieldDoesNotExist
 from django.db.models.fields.related import ForeignObjectRel
+from django.utils import timezone
 
 from .compat import remote_model
 
@@ -93,3 +94,11 @@ def resolve_field(model_field, lookup_expr):
             return lhs.output_field, final_lookup.lookup_name
         lhs = query.try_transform(lhs, name, lookups)
         lookups = lookups[1:]
+
+
+def handle_timezone(value):
+    if settings.USE_TZ and timezone.is_naive(value):
+        return timezone.make_aware(value, timezone.get_default_timezone())
+    elif not settings.USE_TZ and timezone.is_aware(value):
+        return timezone.make_naive(value, timezone.UTC())
+    return value

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -8,7 +8,7 @@ import unittest
 import django
 from django import forms
 from django.test import TestCase, override_settings
-from django.utils.timezone import make_aware
+from django.utils.timezone import make_aware, get_default_timezone
 
 from django_filters.widgets import RangeWidget
 from django_filters.fields import (
@@ -170,7 +170,7 @@ class IsoDateTimeFieldTests(TestCase):
     def test_datetime_timezone_awareness(self):
         # parsed datetimes should obey USE_TZ
         f = IsoDateTimeField()
-        r = make_aware(self.reference_dt, f.default_timezone)
+        r = make_aware(self.reference_dt, get_default_timezone())
 
         d = f.strptime(self.reference_str + "+01:00", IsoDateTimeField.ISO_8601)
         self.assertTrue(isinstance(d.tzinfo, tzinfo))
@@ -185,10 +185,6 @@ class IsoDateTimeFieldTests(TestCase):
         # parsed datetimes should obey USE_TZ
         f = IsoDateTimeField()
         r = self.reference_dt.replace()
-
-        # It's necessary to override this here, since the field class is parsed
-        # when USE_TZ = True.
-        f.default_timezone = None
 
         d = f.strptime(self.reference_str + "+01:00", IsoDateTimeField.ISO_8601)
         self.assertTrue(d.tzinfo is None)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -752,39 +752,6 @@ class DateFromToRangeFilterTests(TestCase):
         qs.filter.assert_called_once_with(
             None__range=(date(2015, 4, 7), date(2015, 9, 6)))
 
-    def test_filtering_queryset(self):
-        class F(FilterSet):
-            published = DateFromToRangeFilter(name='date')
-            class Meta:
-                model = Comment
-                fields = ['date']
-        adam = User.objects.create(username='adam')
-        kwargs = {'text': 'test', 'author': adam, 'time': '10:00'}
-        Comment.objects.create(date=date(2016, 1, 1), **kwargs)
-        Comment.objects.create(date=date(2016, 1, 2), **kwargs)
-        Comment.objects.create(date=date(2016, 1, 3), **kwargs)
-        Comment.objects.create(date=date(2016, 1, 3), **kwargs)
-        results = F(data={
-            'published_0': '2016-01-02',
-            'published_1': '2016-01-03'})
-        self.assertEqual(len(results.qs), 3)
-
-    @override_settings(USE_TZ=False)
-    def test_filtering_ignores_time(self):
-        class F(FilterSet):
-            published = DateFromToRangeFilter()
-            class Meta:
-                model = Article
-                fields = ['published']
-        Article.objects.create(published=datetime(2016, 1, 1, 10, 0))
-        Article.objects.create(published=datetime(2016, 1, 2, 12, 45))
-        Article.objects.create(published=datetime(2016, 1, 3, 18, 15))
-        Article.objects.create(published=datetime(2016, 1, 3, 19, 30))
-        results = F(data={
-            'published_0': '2016-01-02',
-            'published_1': '2016-01-03'})
-        self.assertEqual(len(results.qs), 3)
-
 
 class DateTimeFromToRangeFilterTests(TestCase):
 
@@ -830,22 +797,6 @@ class DateTimeFromToRangeFilterTests(TestCase):
         f.filter(qs, value)
         qs.filter.assert_called_once_with(
             None__range=(datetime(2015, 4, 7, 8, 30), datetime(2015, 9, 6, 11, 45)))
-
-    @override_settings(USE_TZ=False)
-    def test_filtering_queryset(self):
-        class F(FilterSet):
-            published = DateTimeFromToRangeFilter()
-            class Meta:
-                model = Article
-                fields = ['published']
-        Article.objects.create(published=datetime(2016, 1, 1, 10, 0))
-        Article.objects.create(published=datetime(2016, 1, 2, 12, 45))
-        Article.objects.create(published=datetime(2016, 1, 3, 18, 15))
-        Article.objects.create(published=datetime(2016, 1, 3, 19, 30))
-        results = F(data={
-            'published_0': '2016-01-02 10:00',
-            'published_1': '2016-01-03 19:00'})
-        self.assertEqual(len(results.qs), 2)
 
 
 class TimeRangeFilterTests(TestCase):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -6,11 +6,10 @@ import mock
 import warnings
 import unittest
 
-import django
 from django import forms
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
-from django_filters import filters, FilterSet
+from django_filters import filters
 from django_filters.fields import (
     Lookup,
     RangeField,
@@ -44,7 +43,7 @@ from django_filters.filters import (
     UUIDFilter,
     LOOKUP_TYPES)
 
-from tests.models import Book, User, Article, Comment
+from tests.models import Book, User
 
 
 class FilterTests(TestCase):


### PR DESCRIPTION
This PR:
 - gets rid of `RuntimeWarning` (refs https://github.com/carltongibson/django-filter/issues/329#issuecomment-187189112) 
 - moves tests to a more appropriate file
 - adds `TimeRangeFilterTests`