### PR TITLE
Deprecate MethodFilter in favor of 'Filter.method'

### DIFF
--- a/docs/migration.txt
+++ b/docs/migration.txt
@@ -8,6 +8,42 @@ release has also been created to help with migration. It is compatible with
 both the existing and new APIs and will raise warnings for deprecated behavior.
 
 
+MethodFilter and Filter.action replaced by Filter.method
+--------------------------------------------------------
+Details: https://github.com/carltongibson/django-filter/pull/382
+
+The functionality of ``MethodFilter`` and ``Filter.action`` has been merged
+together and replaced by the ``Filter.method`` paramater. The ``method``
+parameter takes either a callable or the name of a ``FilterSet`` method. The
+signature now takes an additional ``name`` argument that is the name of the
+model field to be filtered on.
+
+Since ``method`` is now a parameter of all filters, inputs are validated and
+cleaned by its ``field_class``. The function will receive the cleaned value
+instead of the raw value.
+
+.. code-block:: python
+
+    # 0.x
+    class UserFilter(FilterSet):
+        last_login = filters.MethodFilter()
+
+        def filter_last_login(self, qs, value):
+            # try to convert value to datetime, which may fail.
+            if value and looks_like_a_date(value):
+                value = datetime(value)
+
+            return qs.filter(last_login=value})
+
+
+    # 1.0
+    class UserFilter(FilterSet):
+        last_login = filters.CharFilter(method='filter_last_login')
+
+        def filter_last_login(self, qs, name, value):
+            return qs.filter(**{name: value})
+
+
 QuerySet methods are no longer proxied
 --------------------------------------
 Details: https://github.com/carltongibson/django-filter/pull/440

--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -43,13 +43,51 @@ additional ones that django-filter provides which may be useful:
     * :ref:`RangeWidget <range-widget>` -- this widget is used with ``RangeFilter``
       to generate two form input elements using a single field.
 
-``action``
+.. _filter-method:
+
+``method``
 ~~~~~~~~~~
 
-An optional callable that tells the filter how to handle the queryset.  It
-recieves a ``QuerySet`` and the value to filter on and should return a
-``Queryset`` that is filtered appropriately. `action` will default to
-``filter_{value-of-name-attribute}``
+An optional argument that tells the filter how to handle the queryset. It can
+accept either a callable or the name of a method on the ``FilterSet``. The
+method receives a ``QuerySet``, the name of the model field to filter on, and
+the value to filter with. It should return a ``Queryset`` that is filtered
+appropriately.
+
+The passed in value is validated and cleaned by the filter's ``field_class``,
+so raw value transformation and empty value checking should be unnecessary.
+
+.. code-block:: python
+
+    class F(FilterSet):
+        """Filter for Books by if books are published or not"""
+        published = BooleanFilter(name='published_on', method='filter_published')
+
+        def filter_published(self, queryset, name, value):
+            # construct the full lookup expression.
+            lookup = '__'.join([name, 'isnull'])
+            return queryset.filter(**{lookup: False})
+
+            # alternatively, it may not be necessary to construct the lookup.
+            return queryset.filter(published_on__isnull=False)
+
+        class Meta:
+            model = Book
+            fields = ['published']
+
+
+    # Callables may also be defined out of the class scope.
+    def filter_not_empty(queryset, name, value):
+        lookup = '__'.join([name, 'isnull'])
+        return queryset.filter(**{lookup: False})
+
+    class F(FilterSet):
+        """Filter for Books by if books are published or not"""
+        published = BooleanFilter(name='published_on', method=filter_not_empty)
+
+        class Meta:
+            model = Book
+            fields = ['published']
 
 ``lookup_expr``
 ~~~~~~~~~~~~~~~

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -245,7 +245,7 @@ filtering. View more information in the :ref:`method reference <filter-method>`.
 .. code-block:: python
 
     class F(django_filters.FilterSet):
-        username = MethodFilter(action='my_custom_filter')
+        username = CharFilter(method='my_custom_filter')
 
         class Meta:
             model = User

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -236,71 +236,25 @@ default filters for all the models fields of the same kind using
             }
 
 
-Custom filtering with MethodFilter
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Customize filtering with ``Filter.method``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you want fine control over each individual filter attribute, you can use
-the ``MethodFilter`` filter.
+You can control the behavior of a filter by specifying a ``method`` to perform
+filtering. View more information in the :ref:`method reference <filter-method>`.
 
-By passing in the name of a custom defined filter function as an ``action``,
-the filter attribute gets linked to the custom filter function.
-Here is an example of overriding the filter function of the
-filter attribute ``username``
-::
+.. code-block:: python
 
     class F(django_filters.FilterSet):
-            username = MethodFilter(action='my_custom_filter')
+        username = MethodFilter(action='my_custom_filter')
 
-            class Meta:
-                model = User
-                fields = ['username']
+        class Meta:
+            model = User
+            fields = ['username']
 
-            def my_custom_filter(self, queryset, value):
-                return queryset.filter(
-                    username=value
-                )
-
-
-The filter function can also be defined outside of the filter class scope.
-Though you would need to pass in the actual function value, not it's name.
-::
-
-        def my_custom_filter(queryset, value):
-            return queryset.filter(
-                username=value
-            )
-
-        class F(django_filters.FilterSet):
-	    # Notice: In this case, action accepts a func, not a string
-            username = MethodFilter(action=my_custom_filter)
-
-            class Meta:
-                model = User
-                fields = ['username']
-
-
-Lastly, when using a ``MethodFilter``, there is no need to define an action.
-You may simply do the following and ``filter_username`` will be auto-detected
-and used. ::
-
-        class F(FilterSet):
-            username = MethodFilter()
-
-            class Meta:
-                model = User
-                fields = ['username']
-
-            def filter_username(self, queryset, value):
-                return queryset.filter(
-                    username__contains='ke'
-                )
-
-Under the hood, if ``action`` is not defined, ``django_filter``
-searches for a class method with a name that follows the pattern
-``filter_{{ATTRIBUTE_NAME}}``. For example, if the attribute name is
-``email``, then the filter class will be scanned for the filter function
-``filter_email``. If no action is provided, and no filter class
-function is found, then the filter attribute will be left unfiltered.
+        def my_custom_filter(self, queryset, name, value):
+            return queryset.filter(**{
+                name: value,
+            })
 
 
 The view

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,12 +1,24 @@
 
+import functools
 import warnings
+import mock
 from django.test import TestCase
 
 from django_filters import FilterSet
-from django_filters.filters import CharFilter
+from django_filters.filters import Filter, CharFilter, MethodFilter
 from .models import User
 from .models import NetworkSetting
 from .models import SubnetMaskField
+
+
+def silence(f):
+    @functools.wraps(f)
+    def wrapped(*args, **kwargs):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            f(*args, **kwargs)
+
+    return wrapped
 
 
 class UserFilter(FilterSet):
@@ -51,6 +63,177 @@ class FilterSetContainerDeprecationTests(TestCase):
             UserFilter().count()
 
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+
+class MethodFilterDeprecationTests(TestCase):
+
+    def test_notification(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                username = MethodFilter()
+
+                class Meta:
+                    model = User
+                    fields = []
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+    # old tests
+    @silence
+    def test_filtering(self):
+        User.objects.create(username='alex')
+        User.objects.create(username='jacob')
+        User.objects.create(username='aaron')
+
+        class F(FilterSet):
+            username = MethodFilter(action='filter_username')
+
+            class Meta:
+                model = User
+                fields = ['username']
+
+            def filter_username(self, queryset, value):
+                return queryset.filter(
+                    username=value
+                )
+
+        self.assertEqual(list(F().qs), list(User.objects.all()))
+        self.assertEqual(list(F({'username': 'alex'}).qs),
+                         [User.objects.get(username='alex')])
+        self.assertEqual(list(F({'username': 'jose'}).qs),
+                         list())
+
+    @silence
+    def test_filtering_external(self):
+        User.objects.create(username='alex')
+        User.objects.create(username='jacob')
+        User.objects.create(username='aaron')
+
+        def filter_username(queryset, value):
+            return queryset.filter(
+                username=value
+            )
+
+        class F(FilterSet):
+            username = MethodFilter(action=filter_username)
+
+            class Meta:
+                model = User
+                fields = ['username']
+
+        self.assertEqual(list(F().qs), list(User.objects.all()))
+        self.assertEqual(list(F({'username': 'alex'}).qs),
+                         [User.objects.get(username='alex')])
+        self.assertEqual(list(F({'username': 'jose'}).qs),
+                         list())
+
+    @silence
+    def test_filtering_default_attribute_action(self):
+        User.objects.create(username='mike')
+        User.objects.create(username='jake')
+        User.objects.create(username='aaron')
+
+        class F(FilterSet):
+            username = MethodFilter()
+
+            class Meta:
+                model = User
+                fields = ['username']
+
+            def filter_username(self, queryset, value):
+                return queryset.filter(
+                    username__contains='ke'
+                )
+
+        self.assertEqual(list(F().qs), list(User.objects.all()))
+        self.assertEqual(list(F({'username': 'mike'}).qs),
+                         [User.objects.get(username='mike'),
+                          User.objects.get(username='jake')],)
+        self.assertEqual(list(F({'username': 'jake'}).qs),
+                         [User.objects.get(username='mike'),
+                          User.objects.get(username='jake')])
+        self.assertEqual(list(F({'username': 'aaron'}).qs),
+                         [User.objects.get(username='mike'),
+                          User.objects.get(username='jake')])
+
+    @silence
+    def test_filtering_default(self):
+        User.objects.create(username='mike')
+        User.objects.create(username='jake')
+        User.objects.create(username='aaron')
+
+        class F(FilterSet):
+            username = MethodFilter()
+            email = MethodFilter()
+
+            class Meta:
+                model = User
+                fields = ['username']
+
+        self.assertEqual(list(F().qs), list(User.objects.all()))
+        self.assertEqual(list(F({'username': 'mike'}).qs),
+                         list(User.objects.all()))
+        self.assertEqual(list(F({'username': 'jake'}).qs),
+                         list(User.objects.all()))
+        self.assertEqual(list(F({'username': 'aaron'}).qs),
+                         list(User.objects.all()))
+
+
+class FilterActionDeprecationTests(TestCase):
+
+    def test_notification(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                username = CharFilter(action=lambda x: x)
+
+                class Meta:
+                    model = User
+                    fields = []
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+    def test_filter_using_action(self):
+        qs = mock.NonCallableMock(spec=[])
+        action = mock.Mock(spec=['filter'])
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            f = Filter(action=action)
+            result = f.filter(qs, 'value')
+            action.assert_called_once_with(qs, 'value')
+            self.assertNotEqual(qs, result)
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+    def test_filtering_with_action(self):
+        User.objects.create(username='alex', status=1)
+        User.objects.create(username='jacob', status=2)
+        User.objects.create(username='aaron', status=2)
+        User.objects.create(username='carl', status=0)
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                username = CharFilter(action=lambda qs, value: (
+                    qs.filter(**{'username__startswith': value})
+                ))
+
+                class Meta:
+                    model = User
+                    fields = ['username']
+
+        f = F({'username': 'a'}, queryset=User.objects.all())
+        self.assertQuerysetEqual(
+            f.qs, ['alex', 'aaron'], lambda o: o.username, False)
 
 
 class FilterSetMetaDeprecationTests(TestCase):

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -21,7 +21,6 @@ from django_filters.filters import DateFromToRangeFilter
 from django_filters.filters import DateTimeFromToRangeFilter
 # from django_filters.filters import DateTimeFilter
 from django_filters.filters import DurationFilter
-from django_filters.filters import MethodFilter
 from django_filters.filters import MultipleChoiceFilter
 from django_filters.filters import ModelMultipleChoiceFilter
 from django_filters.filters import NumberFilter
@@ -153,7 +152,6 @@ class ChoiceFilterTests(TestCase):
         f = F({'status': '0'})
         self.assertQuerysetEqual(f.qs, ['carl'], lambda o: o.username, False)
 
-
     def test_filtering_on_explicitly_defined_field(self):
         """
         Test for #30.
@@ -167,6 +165,7 @@ class ChoiceFilterTests(TestCase):
 
         class F(FilterSet):
             status = ChoiceFilter(choices=STATUS_CHOICES)
+
             class Meta:
                 model = User
                 fields = ['status']
@@ -184,7 +183,6 @@ class ChoiceFilterTests(TestCase):
 
         f = F({'status': '0'})
         self.assertQuerysetEqual(f.qs, ['carl'], lambda o: o.username, False)
-
 
 
 class MultipleChoiceFilterTests(TestCase):
@@ -893,24 +891,23 @@ class AllValuesMultipleFilterTests(TestCase):
                          list())
 
 
-class MethodFilterTests(TestCase):
+class FilterMethodTests(TestCase):
+
+    def setUp(self):
+        User.objects.create(username='alex')
+        User.objects.create(username='jacob')
+        User.objects.create(username='aaron')
 
     def test_filtering(self):
-        User.objects.create(username='alex')
-        User.objects.create(username='jacob')
-        User.objects.create(username='aaron')
-
         class F(FilterSet):
-            username = MethodFilter(action='filter_username')
+            username = CharFilter(method='filter_username')
 
             class Meta:
                 model = User
                 fields = ['username']
 
-            def filter_username(self, queryset, value):
-                return queryset.filter(
-                    username=value
-                )
+            def filter_username(self, queryset, name, value):
+                return queryset.filter(**{name: value})
 
         self.assertEqual(list(F().qs), list(User.objects.all()))
         self.assertEqual(list(F({'username': 'alex'}).qs),
@@ -918,18 +915,12 @@ class MethodFilterTests(TestCase):
         self.assertEqual(list(F({'username': 'jose'}).qs),
                          list())
 
-    def test_filtering_external(self):
-        User.objects.create(username='alex')
-        User.objects.create(username='jacob')
-        User.objects.create(username='aaron')
-
-        def filter_username(queryset, value):
-            return queryset.filter(
-                username=value
-            )
+    def test_filtering_callable(self):
+        def filter_username(queryset, name, value):
+            return queryset.filter(**{name: value})
 
         class F(FilterSet):
-            username = MethodFilter(action=filter_username)
+            username = CharFilter(method=filter_username)
 
             class Meta:
                 model = User
@@ -940,57 +931,6 @@ class MethodFilterTests(TestCase):
                          [User.objects.get(username='alex')])
         self.assertEqual(list(F({'username': 'jose'}).qs),
                          list())
-
-
-    def test_filtering_default_attribute_action(self):
-        User.objects.create(username='mike')
-        User.objects.create(username='jake')
-        User.objects.create(username='aaron')
-
-        class F(FilterSet):
-            username = MethodFilter()
-
-            class Meta:
-                model = User
-                fields = ['username']
-
-            def filter_username(self, queryset, value):
-                return queryset.filter(
-                    username__contains='ke'
-                )
-
-        self.assertEqual(list(F().qs), list(User.objects.all()))
-        self.assertEqual(list(F({'username': 'mike'}).qs),
-                         [User.objects.get(username='mike'),
-                          User.objects.get(username='jake')],)
-        self.assertEqual(list(F({'username': 'jake'}).qs),
-                         [User.objects.get(username='mike'),
-                          User.objects.get(username='jake')])
-        self.assertEqual(list(F({'username': 'aaron'}).qs),
-                         [User.objects.get(username='mike'),
-                          User.objects.get(username='jake')])
-
-
-    def test_filtering_default(self):
-        User.objects.create(username='mike')
-        User.objects.create(username='jake')
-        User.objects.create(username='aaron')
-
-        class F(FilterSet):
-            username = MethodFilter()
-            email = MethodFilter()
-
-            class Meta:
-                model = User
-                fields = ['username']
-
-        self.assertEqual(list(F().qs), list(User.objects.all()))
-        self.assertEqual(list(F({'username': 'mike'}).qs),
-                         list(User.objects.all()))
-        self.assertEqual(list(F({'username': 'jake'}).qs),
-                         list(User.objects.all()))
-        self.assertEqual(list(F({'username': 'aaron'}).qs),
-                         list(User.objects.all()))
 
 
 class O2ORelationshipTests(TestCase):
@@ -1681,19 +1621,6 @@ class MiscFilterSetTests(TestCase):
 
         f = F({'username': 'alex', 'status': '2'}, queryset=qs)
         self.assertQuerysetEqual(f.qs, [], lambda o: o.pk)
-
-    def test_filter_with_action(self):
-        class F(FilterSet):
-            username = CharFilter(action=lambda qs, value: (
-                qs.filter(**{'username__startswith': value})))
-
-            class Meta:
-                model = User
-                fields = ['username']
-
-        f = F({'username': 'a'}, queryset=User.objects.all())
-        self.assertQuerysetEqual(
-            f.qs, ['alex', 'aaron'], lambda o: o.username, False)
 
     def test_filter_with_initial(self):
         class F(FilterSet):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -193,12 +193,12 @@ class FilterTests(TestCase):
         qs.filter.assert_called_once_with(somefield__exact='value')
         self.assertNotEqual(qs, result)
 
-    def test_filter_using_action(self):
+    def test_filter_using_method(self):
         qs = mock.NonCallableMock(spec=[])
-        action = mock.Mock(spec=['filter'])
-        f = Filter(action=action)
+        method = mock.Mock()
+        f = Filter(method=method)
         result = f.filter(qs, 'value')
-        action.assert_called_once_with(qs, 'value')
+        method.assert_called_once_with(qs, None, 'value')
         self.assertNotEqual(qs, result)
 
     def test_filtering_uses_distinct(self):


### PR DESCRIPTION
We discussed this briefly in the discussion [here](https://github.com/rpkilby/django-filter/pull/1#discussion_r53557371) and decided to go ahead and give it a shot. It would be nice to get this in the next release, but I'm not too concerned with it. Still have some todo's left.

Usage:

```py
class UserFilter(FilterSet):
    username = filters.CharFilter(method='filter_username')

    def filter_username(self, qs, name, value):
        return qs.filter(**{name: value})
```

Improvements:
- The new API provides a better default for input validation. The existing `MethodFilter` side steps validation and while you can technically add it to the filter, it's semi-tedious and undocumented.
- Filter methods will now receive the cleaned input instead of the raw input. eg, `IsoDateTimeFilter` will return a `datetime` object instead of a string.
- Adding the model field's name to the method signature allows for the possibility of creating generic filter methods. e.g., `qs.filter(**{name: value})`
- The name argument is also useful for handling relationship traversals (which is useful for drf-filters if it will ever be merged in).
- It is no longer necessary to have an empty value check in the filter method.
- `Filter.method` asserts that its value can be resolved into a callable. The current `MethodFilter` implementation just silently fails if it cannot find a method. I believe this can cause situations that are non-obvious to debug.

Changes:
- Deprecates `Filter.action` in favor of `Filter.method`. 
- Deprecates `MethodFilter` in favor of `Filter.method`.
- `Filter.method` argument introduces a similar API that combines `action` and `MethodFilter`.

Other change notes:
- The existing `MethodFilter` sidesteps value validation, as it has no `field_class`. The only way around this is to subclass `MethodFilter`. eg,
  ```py
  class CharMethodFilter(CharFilter, MethodFilter):
      pass

  # or

  class CharMethodFilter(MethodFilter):
      field_class = forms.CharField
  ```
  If for whatever reason someone did want to sidestep validation with the `Filter.method` implementation, all they would need to do is:
  ```py
  class UserFilter(FilterSet):
      username = filters.Filter(method='filter_username')
  ```
-  `filter_{name}` method name magic is no longer possible, but no longer relevant either. You need to pass the `method` argument anyway in order to indicate that you want to perform method filtering.
- Uses new signature of `(qs, name, value)`. `name` is a new argument that is the filter's model field name. This argument will be necessary in the future if we want to merge in drf-filters, because the value changes across relationship traversals. eg, you can't hardcode `is_published` if that filter is traversed across a `post` relationship. The `name` would become `post__is_published`.


TODO:
- [x] Deprecate old method signature in favor of `(qs, field_name, value)`.
- [x] Add 'method' tests.
- [x] Test with filters that override `filter` method.
- [x] Update usage docs.
- [x] Rebase off of 451.