### PR TITLE
Revert docs theme back to 'default'

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,7 +91,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'classic'
+html_theme = 'default'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
I'm not sure why this was changed in 7ca5ed622785f2a07f5855710ae7f1bf0f5ea38d. 'default' will use the modern read-the-docs theme. 'classic' goes back the old school docs style.