### PR TITLE
Add support for DurationField.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Version 0.14.0 (unreleased)
+---------------------------
+
+* Add support for filtering on DurationField (new in Django 1.8).
+
+
 Version 0.13.0 (2016-03-11)
 ---------------------------
 

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -26,6 +26,7 @@ __all__ = [
     'ModelMultipleChoiceFilter', 'NumberFilter', 'NumericRangeFilter', 'RangeFilter',
     'DateRangeFilter', 'DateFromToRangeFilter', 'DateTimeFromToRangeFilter',
     'TimeRangeFilter', 'AllValuesFilter', 'MethodFilter', 'UUIDFilter',
+    'DurationFilter',
 ]
 
 
@@ -245,6 +246,10 @@ class IsoDateTimeFilter(DateTimeFilter):
 
 class TimeFilter(Filter):
     field_class = forms.TimeField
+
+
+class DurationFilter(Filter):
+    field_class = forms.DurationField
 
 
 class ModelChoiceFilter(Filter):

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -18,7 +18,8 @@ from django.utils.translation import ugettext as _
 from .compat import remote_field, remote_model
 from .filters import (Filter, CharFilter, BooleanFilter, BaseInFilter, BaseRangeFilter,
                       ChoiceFilter, DateFilter, DateTimeFilter, TimeFilter, ModelChoiceFilter,
-                      ModelMultipleChoiceFilter, NumberFilter, UUIDFilter)
+                      ModelMultipleChoiceFilter, NumberFilter, UUIDFilter,
+                      DurationFilter)
 from .utils import try_dbfield, get_model_field, resolve_field
 
 
@@ -194,6 +195,9 @@ FILTER_FOR_DBFIELD_DEFAULTS = {
     },
     models.TimeField: {
         'filter_class': TimeFilter
+    },
+    models.DurationField: {
+        'filter_class': DurationFilter
     },
     models.OneToOneField: {
         'filter_class': ModelChoiceFilter,

--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -245,6 +245,15 @@ Example. ::
             fields = ['published']
 
 
+``DurationFilter``
+~~~~~~~~~~~~~~~~~~
+
+Matches on a duration.  Used with ``DurationField`` by default.
+
+Supports both Django ('%d %H:%M:%S.%f') and ISO 8601 formatted durations (but
+only the sections that are accepted by Python's timedelta, so no year, month,
+and week designators, e.g. 'P3DT10H22M').
+
 
 ``ModelChoiceFilter``
 ~~~~~~~~~~~~~~~~~~~~~

--- a/tests/models.py
+++ b/tests/models.py
@@ -182,3 +182,13 @@ class Business(models.Model):
 
 class UUIDTestModel(models.Model):
     uuid = models.UUIDField()
+
+
+class SpacewalkRecord(models.Model):
+    """Cumulative space walk record.
+
+    See: https://en.wikipedia.org/wiki/List_of_cumulative_spacewalk_records
+
+    """
+    astronaut = models.CharField(max_length=100)
+    duration = models.DurationField()

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -20,6 +20,7 @@ from django_filters.filters import DateRangeFilter
 from django_filters.filters import DateFromToRangeFilter
 from django_filters.filters import DateTimeFromToRangeFilter
 # from django_filters.filters import DateTimeFilter
+from django_filters.filters import DurationFilter
 from django_filters.filters import MethodFilter
 from django_filters.filters import MultipleChoiceFilter
 from django_filters.filters import ModelMultipleChoiceFilter
@@ -43,6 +44,7 @@ from .models import Profile
 from .models import Node
 from .models import DirectedNode
 from .models import STATUS_CHOICES
+from .models import SpacewalkRecord
 
 
 class CharFilterTests(TestCase):
@@ -298,6 +300,100 @@ class DateTimeFilterTests(TestCase):
             1,
             "%s isn't matching %s when cleaned" % (check_dt, ten_min_ago))
         self.assertQuerysetEqual(f.qs, [2], lambda o: o.pk)
+
+
+class DurationFilterTests(TestCase):
+    """Duration filter tests.
+
+    The preferred format for durations in Django is '%d %H:%M:%S.%f'.
+    See django.utils.dateparse.parse_duration
+
+    Django is not fully ISO 8601 compliant (yet): year, month, and
+    week designators are not supported, so a duration string
+    like "P3Y6M4DT12H30M5S" cannot be used.
+    See https://en.wikipedia.org/wiki/ISO_8601#Durations
+
+    """
+    def setUp(self):
+        self.r1 = SpacewalkRecord.objects.create(
+            astronaut="Anatoly Solovyev",
+            duration=datetime.timedelta(hours=82, minutes=22))
+        self.r2 = SpacewalkRecord.objects.create(
+            astronaut="Michael Lopez-Alegria",
+            duration=datetime.timedelta(hours=67, minutes=40))
+        self.r3 = SpacewalkRecord.objects.create(
+            astronaut="Jerry L. Ross",
+            duration=datetime.timedelta(hours=58, minutes=32))
+        self.r4 = SpacewalkRecord.objects.create(
+            astronaut="John M. Grunsfeld",
+            duration=datetime.timedelta(hours=58, minutes=30))
+        self.r5 = SpacewalkRecord.objects.create(
+            astronaut="Richard Mastracchio",
+            duration=datetime.timedelta(hours=53, minutes=4))
+
+    def test_filtering(self):
+
+        class F(FilterSet):
+            class Meta:
+                model = SpacewalkRecord
+                fields = ['duration']
+
+        qs = SpacewalkRecord.objects.all()
+
+        # Django style: 3 days, 10 hours, 22 minutes.
+        f = F({'duration': '3 10:22:00'}, queryset=qs)
+        self.assertQuerysetEqual(f.qs, [self.r1], lambda x: x)
+
+        # ISO 8601: 3 days, 10 hours, 22 minutes.
+        f = F({'duration': 'P3DT10H22M'}, queryset=qs)
+        self.assertQuerysetEqual(f.qs, [self.r1], lambda x: x)
+
+        # Django style: 82 hours, 22 minutes.
+        f = F({'duration': '82:22:00'}, queryset=qs)
+        self.assertQuerysetEqual(f.qs, [self.r1], lambda x: x)
+
+        # ISO 8601: 82 hours, 22 minutes.
+        f = F({'duration': 'PT82H22M'}, queryset=qs)
+        self.assertQuerysetEqual(f.qs, [self.r1], lambda x: x)
+
+    def test_filtering_with_single_lookup_expr_dictionary(self):
+
+        class F(FilterSet):
+            class Meta:
+                model = SpacewalkRecord
+                fields = {'duration': ['gt', 'gte', 'lt', 'lte']}
+
+        qs = SpacewalkRecord.objects.order_by('-duration')
+
+        f = F({'duration__gt': 'PT58H30M'}, queryset=qs)
+        self.assertQuerysetEqual(
+            f.qs, [self.r1, self.r2, self.r3], lambda x: x)
+
+        f = F({'duration__gte': 'PT58H30M'}, queryset=qs)
+        self.assertQuerysetEqual(
+            f.qs, [self.r1, self.r2, self.r3, self.r4], lambda x: x)
+
+        f = F({'duration__lt': 'PT58H30M'}, queryset=qs)
+        self.assertQuerysetEqual(
+            f.qs, [self.r5], lambda x: x)
+
+        f = F({'duration__lte': 'PT58H30M'}, queryset=qs)
+        self.assertQuerysetEqual(
+            f.qs, [self.r4, self.r5], lambda x: x)
+
+    def test_filtering_with_multiple_lookup_exprs(self):
+
+        class F(FilterSet):
+            min_duration = DurationFilter(name='duration', lookup_expr='gte')
+            max_duration = DurationFilter(name='duration', lookup_expr='lte')
+
+            class Meta:
+                model = SpacewalkRecord
+
+        qs = SpacewalkRecord.objects.order_by('duration')
+
+        f = F({'min_duration': 'PT55H', 'max_duration': 'PT60H'}, queryset=qs)
+        self.assertQuerysetEqual(f.qs, [self.r4, self.r3], lambda x: x)
 
 
 class ModelChoiceFilterTests(TestCase):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -27,6 +27,7 @@ from django_filters.filters import (
     DateFilter,
     DateTimeFilter,
     TimeFilter,
+    DurationFilter,
     ModelChoiceFilter,
     ModelMultipleChoiceFilter,
     NumberFilter,
@@ -473,6 +474,14 @@ class TimeFilterTests(TestCase):
         f = TimeFilter()
         field = f.field
         self.assertIsInstance(field, forms.TimeField)
+
+
+class DurationFilterTests(TestCase):
+
+    def test_default_field(self):
+        f = DurationFilter()
+        field = f.field
+        self.assertIsInstance(field, forms.DurationField)
 
 
 class ModelChoiceFilterTests(TestCase):

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -86,6 +86,7 @@ class DbFieldDefaultFiltersTests(TestCase):
             models.SmallIntegerField,
             models.TextField,
             models.TimeField,
+            models.DurationField,
             models.URLField,
             models.ForeignKey,
             models.OneToOneField,


### PR DESCRIPTION
Since Django 1.8, it's possible to store periods of time:

https://docs.djangoproject.com/en/dev/ref/models/fields/#durationfield

This pull request adds support for filtering on this new field.