### PR TITLE
Add Meta.fields compatibility with annotated fields from the default query

### DIFF
--- a/django_filters/utils.py
+++ b/django_filters/utils.py
@@ -60,7 +60,16 @@ def get_model_field(model, field_name):
     try:
         return opts.get_field(parts[-1])
     except FieldDoesNotExist:
+        pass
+
+    annotations = get_model_annotations(opts.model)
+    if annotations is None or parts[-1] not in annotations:
         return None
+
+    # get output_field and bind model so it behaves like a proper model field.
+    field = annotations[parts[-1]].output_field
+    field.model = opts.model
+    return field
 
 
 def resolve_field(model_field, lookup_expr):

--- a/django_filters/utils.py
+++ b/django_filters/utils.py
@@ -29,6 +29,10 @@ def try_dbfield(fn, field_class):
             return data
 
 
+def get_model_annotations(model):
+    return model._default_manager.get_queryset().query._annotations
+
+
 def get_model_field(model, field_name):
     """
     Get a ``model`` field, traversing relationships

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1437,6 +1437,27 @@ class NonSymmetricalSelfReferentialRelationshipTests(TestCase):
         self.assertQuerysetEqual(f.qs, [2], lambda o: o.pk)
 
 
+class AnnotatedFieldTests(TestCase):
+    # Meta.fields should support annotated fields so long as default queryset
+    # for the model contains the annotations.
+
+    @classmethod
+    def setUpTestData(cls):
+        User.objects.create(username='alex', first_name='Alex', last_name='Gaynor')
+        User.objects.create(username='carl', first_name='Carl', last_name='Gibson')
+
+    def test_filtering(self):
+        class F(FilterSet):
+            class Meta:
+                model = User
+                fields = {'full_name': ['icontains']}
+
+        qs = User.objects.all()
+        f = F({'full_name__icontains': 'alex'}, queryset=qs)
+        self.assertEqual(len(f.qs), 1)
+        self.assertQuerysetEqual(f.qs, [1], lambda o: o.pk)
+
+
 # use naive datetimes, as pytz is required to perform
 # date lookups when timezones are involved.
 @override_settings(USE_TZ=False)


### PR DESCRIPTION
This is a little convoluted, but I think it would be a valuable addition. 

#### Context:
Field annotations give us the flexibility of computed properties on our models. eg, you could have a user stats model that aggregates the comment count per user. You could then filter the user stats for the more prolific commenters on a blog. 

While these annotations can be filtered on, they are not proper model fields and cannot be resolved during `Meta.fields` processing. However, there is effectively a 'default queryset' which can be used to retrieve these annotations.

#### Proposal:
Allow `Meta.fields` to parse annotations under the following conditions:
- the annotation is performed in the default manager's `get_queryset()` method.
- the manager must be enabled for related fields with `use_for_related_fields`.

**Update:**
Apparently filtering annotations across relationships is not currently supported. Filed a bug [here](https://code.djangoproject.com/ticket/26393). The updated `Meta.fields` handling can correctly generate the related filter class, but its unusable.

TODO:
- [x] Add failing usecase.
- [x] implement
- [x] test
- [ ] docs
- [ ] wait for feedback on [26393](https://code.djangoproject.com/ticket/26393).