### PR TITLE
Fix expected failures

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -297,7 +297,7 @@ class RangeFilter(Filter):
 
 
 def _truncate(dt):
-    return dt.replace(hour=0, minute=0, second=0)
+    return dt.date()
 
 
 class DateRangeFilter(ChoiceFilter):

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -302,7 +302,7 @@ def _truncate(dt):
 
 class DateRangeFilter(ChoiceFilter):
     options = {
-        '': (_('Any date'), lambda qs, name: qs.all()),
+        '': (_('Any date'), lambda qs, name: qs),
         1: (_('Today'), lambda qs, name: qs.filter(**{
             '%s__year' % name: now().year,
             '%s__month' % name: now().month,

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -336,6 +336,8 @@ class DateRangeFilter(ChoiceFilter):
             value = int(value)
         except (ValueError, TypeError):
             value = ''
+
+        assert value in self.options
         qs = self.options[value][1](qs, self.name)
         if self.distinct:
             qs = qs.distinct()

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -63,8 +63,11 @@ def filters_for_model(model, fields=None, exclude=None, filter_for_field=None,
     field_dict = OrderedDict()
     opts = model._meta
     if fields is None:
-        fields = [f.name for f in sorted(opts.fields + opts.many_to_many)
-                  if not isinstance(f, models.AutoField)]
+        fields = [
+            f.name for f in sorted(opts.fields + opts.many_to_many)
+            if not isinstance(f, models.AutoField) and
+            not (getattr(remote_field(f), 'parent_link', False))
+        ]
     # Loop through the list of fields.
     for f in fields:
         # Skip the field if excluded.

--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -299,7 +299,7 @@ the Postgres Numerical Range Fields, including `IntegerRangeField`, `BigIntegerR
 available since Django 1.8. The default widget used is the `RangeField`.
 
 RangeField lookup_exprs can be used, including `overlap`, `contains`, and `contained_by`. More lookups can be
-found in the Django docs ([https://docs.djangoproject.com/en/1.8/ref/contrib/postgres/fields/#querying-range-fields](https://docs.djangoproject.com/en/1.8/ref/contrib/postgres/fields/#querying-range-fields)).
+found in the Django docs (https://docs.djangoproject.com/en/1.8/ref/contrib/postgres/fields/#querying-range-fields).
 
 If the lower limit value is provided, the filter automatically defaults to `__startswith` as the lookup
 type and if only the upper limit value is provided, the filter uses `__endswith`.

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -653,8 +653,6 @@ class RangeFilterTests(TestCase):
                                  lambda o: o.title)
 
 
-
-@unittest.skip('date-range is funky')
 class DateRangeFilterTests(TestCase):
 
     def setUp(self):
@@ -693,7 +691,6 @@ class DateRangeFilterTests(TestCase):
         f = F({'date': '3'})  # this month
         self.assertQuerysetEqual(f.qs, [1, 3, 4], lambda o: o.pk, False)
 
-    @unittest.expectedFailure
     def test_filtering_for_week(self):
         class F(FilterSet):
             date = DateRangeFilter()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -677,18 +677,18 @@ class DateRangeFilterTests(TestCase):
 
     def test_filtering_for_7_days(self):
         qs = mock.Mock(spec=['filter'])
-        with mock.patch('django_filters.filters.now'):
-            with mock.patch('django_filters.filters.timedelta') as mock_td:
-                with mock.patch(
-                        'django_filters.filters._truncate') as mock_truncate:
-                    mock_dt1, mock_dt2 = mock.MagicMock(), mock.MagicMock()
-                    mock_truncate.side_effect = [mock_dt1, mock_dt2]
-                    f = DateRangeFilter()
-                    f.filter(qs, '2')
-                    self.assertEqual(mock_td.call_args_list,
-                        [mock.call(days=7), mock.call(days=1)])
-                    qs.filter.assert_called_once_with(
-                        None__lt=mock_dt2, None__gte=mock_dt1)
+        with mock.patch('django_filters.filters.now'), \
+                mock.patch('django_filters.filters.timedelta') as mock_td, \
+                mock.patch('django_filters.filters._truncate') as mock_truncate:
+            mock_d1, mock_d2 = mock.MagicMock(), mock.MagicMock()
+            mock_truncate.side_effect = [mock_d1, mock_d2]
+            f = DateRangeFilter()
+            f.filter(qs, '2')
+            self.assertEqual(
+                mock_td.call_args_list,
+                [mock.call(days=7), mock.call(days=1)]
+            )
+            qs.filter.assert_called_once_with(None__lt=mock_d2, None__gte=mock_d1)
 
     def test_filtering_for_today(self):
         qs = mock.Mock(spec=['filter'])

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -644,14 +644,7 @@ class DateRangeFilterTests(TestCase):
         self.assertIsInstance(field, forms.ChoiceField)
 
     def test_filtering(self):
-        qs = mock.Mock(spec=['all'])
-        f = DateRangeFilter()
-        f.filter(qs, '')
-        qs.all.assert_called_once_with()
-
-    # the correct behavior fails right now
-    @unittest.expectedFailure
-    def test_filtering_skipped_with_blank_value(self):
+        # skip filtering, as it's an empty value
         qs = mock.Mock(spec=[])
         f = DateRangeFilter()
         result = f.filter(qs, '')

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -794,11 +794,11 @@ class DateTimeFromToRangeFilterTests(TestCase):
         result = f.filter(qs, None)
         self.assertEqual(qs, result)
 
-    def test_filtering_ignores_lookup_type(self):
+    def test_filtering_ignores_lookup_expr(self):
         qs = mock.Mock()
         value = mock.Mock(
             start=datetime(2015, 4, 7, 8, 30), stop=datetime(2015, 9, 6, 11, 45))
-        f = DateTimeFromToRangeFilter(lookup_type='gte')
+        f = DateTimeFromToRangeFilter(lookup_expr='gte')
         f.filter(qs, value)
         qs.filter.assert_called_once_with(
             None__range=(datetime(2015, 4, 7, 8, 30), datetime(2015, 9, 6, 11, 45)))

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -650,12 +650,12 @@ class DateRangeFilterTests(TestCase):
         result = f.filter(qs, '')
         self.assertEqual(qs, result)
 
-    @unittest.expectedFailure
     def test_filtering_skipped_with_out_of_range_value(self):
+        # Field validation should prevent this from occuring
         qs = mock.Mock(spec=[])
         f = DateRangeFilter()
-        result = f.filter(qs, 999)
-        self.assertEqual(qs, result)
+        with self.assertRaises(AssertionError):
+            f.filter(qs, 999)
 
     def test_filtering_for_this_year(self):
         qs = mock.Mock(spec=['filter'])

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -574,14 +574,6 @@ class NumericRangeFilterTests(TestCase):
         f.filter(qs, value)
         qs.filter.assert_called_once_with(None__overlap=(20, 30))
 
-    @unittest.expectedFailure
-    def test_filtering_lower_field_higher_than_upper_field(self):
-        qs = mock.Mock(spec=['filter'])
-        value = mock.Mock(start=35, stop=30)
-        f = NumericRangeFilter()
-        result = f.filter(qs, value)
-        self.assertEqual(qs, result)
-
     def test_zero_to_zero(self):
         qs = mock.Mock(spec=['filter'])
         value = mock.Mock(start=0, stop=0)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -283,7 +283,6 @@ class BooleanFilterTests(TestCase):
         qs.exclude.assert_called_once_with(somefield__exact=True)
         self.assertNotEqual(qs, result)
 
-    @unittest.expectedFailure
     def test_filtering_skipped_with_blank_value(self):
         qs = mock.Mock()
         f = BooleanFilter(name='somefield')
@@ -380,7 +379,6 @@ class MultipleChoiceFilterTests(TestCase):
         result = f.filter(qs, ['other', 'values', 'there'])
         self.assertEqual(qs, result)
 
-    @unittest.expectedFailure
     def test_filtering_skipped_with_empty_list_value_and_some_choices(self):
         qs = mock.Mock(spec=[])
         f = MultipleChoiceFilter(name='somefield')

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -482,7 +482,6 @@ class FilterSetClassCreationTests(TestCase):
 
         self.assertEqual(list(F.base_filters), list(ProxyF.base_filters))
 
-    @unittest.expectedFailure
     def test_filterset_for_mti_model(self):
         class F(FilterSet):
             class Meta:


### PR DESCRIPTION
Corrects a few expected failures. Some of these were already fixed in code (320), but the tests were not updated. Some actual fixes:
- `DateRangeFilter` tests contradicted each other on default behavior. One test expected a noop while another expected to call `qs.all()`. Made the default behavior a noop and removed contradictory test.
- `DateRangeFilter`s 'past week' handling was cutting off dates from 'today'. Datetime truncation was misbehaving.
- Removed a failing test from `NumericRangeFilter`. It should *not* expect to have its values automatically ordered. Not sure that it would be the correct behavior for all lookup types.
- Fixed `Meta.fields` handling for MTI models. If it is None, then the `parent_link` field is skipped.
- Other small fixes...