### PR TITLE
Lookup types

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 from django import forms
 from django.forms.forms import NON_FIELD_ERRORS
 from django.core.validators import EMPTY_VALUES
+from django.core.exceptions import FieldError
 from django.db import models
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.fields.related import ForeignObjectRel
@@ -426,7 +427,10 @@ class BaseFilterSet(object):
 
     @classmethod
     def filter_for_field(cls, f, name, lookup_expr='exact'):
-        f, lookup_type = resolve_field(f, lookup_expr)
+        try:
+            f, lookup_type = resolve_field(f, lookup_expr)
+        except FieldError:
+            return
 
         default = {
             'name': name,

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -20,6 +20,7 @@ from django_filters.filters import ModelMultipleChoiceFilter
 from django_filters.filters import UUIDFilter
 from django_filters.filters import BaseInFilter
 from django_filters.filters import BaseRangeFilter
+from django_filters.filters import LOOKUP_TYPES
 
 from django_filters.widgets import BooleanWidget
 
@@ -287,6 +288,18 @@ class FilterSetClassCreationTests(TestCase):
 
         self.assertEqual(len(F.declared_filters), 0)
         self.assertEqual(len(F.base_filters), 0)
+
+    def test_lookup_types(self):
+        class F(FilterSet):
+            class Meta:
+                model = Book
+                fields = {
+                    'title': LOOKUP_TYPES,
+                    'price': LOOKUP_TYPES,
+                }
+
+        self.assertEqual(len(F.declared_filters), 0)
+        self.assertEqual(len(F.base_filters), 36)
 
     def test_declaring_filter(self):
         class F(FilterSet):

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -299,7 +299,12 @@ class FilterSetClassCreationTests(TestCase):
                 }
 
         self.assertEqual(len(F.declared_filters), 0)
-        self.assertEqual(len(F.base_filters), 36)
+
+        if django.VERSION < (1, 9):
+            # django < 1.9 is a bit looser with lookups
+            self.assertEqual(len(F.base_filters), 50)
+        else:
+            self.assertEqual(len(F.base_filters), 36)
 
     def test_declaring_filter(self):
         class F(FilterSet):


### PR DESCRIPTION
It seems as though Django 1.9 has become more particular about query lookups because I was trying to implement a FilterSet such that it would enable all the lookup types for the field. Looking through the issue/pr tracker [using the `LOOKUP_TYPES` variable](https://github.com/carltongibson/django-filter/pull/301) was suggested. I tried to do that and got some errors.

I ended up adding a test that implements the example code @carltongibson has in that PR to verify that it wasn't caused by some crazy DRF wrapping (it wasn't). Then I figured I'd make the test pass.

I don't know if my fix is the best, but I think the test should be okay and it should pass in any case.