### PR TITLE
Add filters_for_model as a class method

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -160,9 +160,7 @@ class FilterSetMetaclass(type):
         opts = new_class._meta = FilterSetOptions(
             getattr(new_class, 'Meta', None))
         if opts.model:
-            filters = filters_for_model(opts.model, opts.fields, opts.exclude,
-                                        new_class.filter_for_field,
-                                        new_class.filter_for_reverse_field)
+            filters = new_class.filters_for_model(opts.model, opts)
             filters.update(declared_filters)
         else:
             filters = declared_filters
@@ -423,6 +421,14 @@ class BaseFilterSet(object):
         if _filter and filter_api_name != _filter.name:
             return [inverted + _filter.name]
         return [order_choice]
+
+    @classmethod
+    def filters_for_model(cls, model, opts):
+        return filters_for_model(
+            model, opts.fields, opts.exclude,
+            cls.filter_for_field,
+            cls.filter_for_reverse_field
+        )
 
     @classmethod
     def filter_for_field(cls, f, name, lookup_expr='exact'):


### PR DESCRIPTION
It seems oddly inconsistent that filters_for_model is not a class method. Thoughts:

- previous implementation prevents extensibility as there's nowhere to hook into this process (relevant to drf-filters and other custom filterset implementations)
- The new class method simply proxies the original.
- The signature of the class method is different.
  - It doesn't seem necessary to pass the `cls.filter_for_field`/`cls.filter_for_reverse_field` here. 
  - `opts` feels more appropriate to pass to the class method than just `filters` and `exclude`. A custom implementation might have different relevant `opts` attributes to process.
- didn't write any tests since there isn't any real functionality change (could test `@classmethod` overriding, but that seems redundant to python just working as intended).