### PR TITLE
Updated readthedocs url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,5 +69,5 @@ Support
 If you have questions about usage or development you can join the
 `mailing list`_.
 
-.. _`read the docs`: https://django-filter.readthedocs.org/en/latest/
+.. _`read the docs`: https://django-filter.readthedocs.io/en/latest/
 .. _`mailing list`: http://groups.google.com/group/django-filter


### PR DESCRIPTION
Read the docs have moved projects to the readthedocs.io subdomain.

http://blog.readthedocs.com/securing-subdomains/

As well as the README, the website on the GitHub homepage could be updated as well.