### PR TITLE
AllValuesMultipleFilter for Multiple Selection of AllValues

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -368,6 +368,13 @@ class AllValuesFilter(ChoiceFilter):
         self.extra['choices'] = [(o, o) for o in qs]
         return super(AllValuesFilter, self).field
 
+class AllValuesMultipleFilter(MultipleChoiceFilter):
+    @property
+    def field(self):
+        qs = self.model._default_manager.distinct()
+        qs = qs.order_by(self.name).values_list(self.name, flat=True)
+        self.extra['choices'] = [(o, o) for o in qs]
+        return super(AllValuesMultipleFilter, self).field
 
 class BaseCSVFilter(Filter):
     """

--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -460,6 +460,14 @@ database.  So if in the DB for the given field you have values of 5, 7, and 9
 each of those is present as an option.  This is similar to the default behavior
 of the admin.
 
+``AllValuesMultipleFilter``
+~~~~~~~~~~~~~~~~~~~
+
+This is a ``MultipleChoiceFilter`` whose choices are the current values in the
+database.  So if in the DB for the given field you have values of 5, 7, and 9
+each of those is present as an option.  This is similar to the default behavior
+of the admin.
+
 .. _base-in-filter:
 
 ``BaseInFilter``


### PR DESCRIPTION
The `AllValuesFilter` is great for selecting a single instance of only objects that exist in the database, but there isn't a built-in equivalent for selecting multiple fields. This is a simple (most copy+paste) extension that I am using in one of my projects to achieve the desired result (multiple selection of items that are generated based on what exists in the database)