### PR TITLE
DRF FilterBackend & FilterSet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,13 @@ python:
   - "3.5"
 
 env:
-  - DJANGO='https://github.com/django/django/archive/master.tar.gz'
-  - DJANGO='django>=1.9.0,<1.10.0'
-  - DJANGO='django>=1.8.0,<1.9.0'
+  - DJANGO='https://github.com/django/django/archive/master.tar.gz' REST_FRAMEWORK='djangorestframework>=3.3,<3.4'
+  - DJANGO='django>=1.9.0,<1.10.0' REST_FRAMEWORK='djangorestframework>=3.3,<3.4'
+  - DJANGO='django>=1.8.0,<1.9.0' REST_FRAMEWORK='djangorestframework>=3.3,<3.4'
+  - DJANGO='django>=1.8.0,<1.9.0' REST_FRAMEWORK='djangorestframework>=3.2,<3.3'
 
 install:
-  - travis_retry pip install $DJANGO
+  - travis_retry pip install $DJANGO $REST_FRAMEWORK
   - travis_retry pip install -r requirements/travis-ci.txt
 
 script:
@@ -30,13 +31,13 @@ notifications:
 matrix:
   exclude:
     - python: "3.2"
-      env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
+      env: DJANGO='https://github.com/django/django/archive/master.tar.gz' REST_FRAMEWORK='djangorestframework>=3.3,<3.4'
     - python: "3.2"
-      env: DJANGO='django>=1.9.0,<1.10.0'
+      env: DJANGO='django>=1.9.0,<1.10.0' REST_FRAMEWORK='djangorestframework>=3.3,<3.4'
     - python: "3.3"
-      env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
+      env: DJANGO='https://github.com/django/django/archive/master.tar.gz' REST_FRAMEWORK='djangorestframework>=3.3,<3.4'
     - python: "3.3"
-      env: DJANGO='django>=1.9.0,<1.10.0'
+      env: DJANGO='django>=1.9.0,<1.10.0' REST_FRAMEWORK='djangorestframework>=3.3,<3.4'
   allow_failures:
-    - env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
+    - env: DJANGO='https://github.com/django/django/archive/master.tar.gz' REST_FRAMEWORK='djangorestframework>=3.3,<3.4'
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,11 @@ python:
   - "3.5"
 
 env:
-  - DJANGO='https://github.com/django/django/archive/master.tar.gz' REST_FRAMEWORK='djangorestframework>=3.3,<3.4'
+  - DJANGO='https://github.com/django/django/archive/master.tar.gz' REST_FRAMEWORK='djangorestframework>=3.4,<3.5'
+  - DJANGO='django>=1.10.0,<1.11.0' REST_FRAMEWORK='djangorestframework>=3.4,<3.5'
+  - DJANGO='django>=1.9.0,<1.10.0' REST_FRAMEWORK='djangorestframework>=3.4,<3.5'
   - DJANGO='django>=1.9.0,<1.10.0' REST_FRAMEWORK='djangorestframework>=3.3,<3.4'
+  - DJANGO='django>=1.8.0,<1.9.0' REST_FRAMEWORK='djangorestframework>=3.4,<3.5'
   - DJANGO='django>=1.8.0,<1.9.0' REST_FRAMEWORK='djangorestframework>=3.3,<3.4'
   - DJANGO='django>=1.8.0,<1.9.0' REST_FRAMEWORK='djangorestframework>=3.2,<3.3'
 
@@ -30,14 +33,24 @@ notifications:
 
 matrix:
   exclude:
+    - python: "3.3"
+      env: DJANGO='https://github.com/django/django/archive/master.tar.gz' REST_FRAMEWORK='djangorestframework>=3.4,<3.5'
+    - python: "3.3"
+      env: DJANGO='django>=1.10.0,<1.11.0' REST_FRAMEWORK='djangorestframework>=3.4,<3.5'
+    - python: "3.3"
+      env: DJANGO='django>=1.9.0,<1.10.0' REST_FRAMEWORK='djangorestframework>=3.4,<3.5'
+    - python: "3.3"
+      env: DJANGO='django>=1.9.0,<1.10.0' REST_FRAMEWORK='djangorestframework>=3.3,<3.4'
+
     - python: "3.2"
-      env: DJANGO='https://github.com/django/django/archive/master.tar.gz' REST_FRAMEWORK='djangorestframework>=3.3,<3.4'
+      env: DJANGO='https://github.com/django/django/archive/master.tar.gz' REST_FRAMEWORK='djangorestframework>=3.4,<3.5'
+    - python: "3.2"
+      env: DJANGO='django>=1.10.0,<1.11.0' REST_FRAMEWORK='djangorestframework>=3.4,<3.5'
+    - python: "3.2"
+      env: DJANGO='django>=1.9.0,<1.10.0' REST_FRAMEWORK='djangorestframework>=3.4,<3.5'
     - python: "3.2"
       env: DJANGO='django>=1.9.0,<1.10.0' REST_FRAMEWORK='djangorestframework>=3.3,<3.4'
-    - python: "3.3"
-      env: DJANGO='https://github.com/django/django/archive/master.tar.gz' REST_FRAMEWORK='djangorestframework>=3.3,<3.4'
-    - python: "3.3"
-      env: DJANGO='django>=1.9.0,<1.10.0' REST_FRAMEWORK='djangorestframework>=3.3,<3.4'
+
   allow_failures:
-    - env: DJANGO='https://github.com/django/django/archive/master.tar.gz' REST_FRAMEWORK='djangorestframework>=3.3,<3.4'
+    - env: DJANGO='https://github.com/django/django/archive/master.tar.gz' REST_FRAMEWORK='djangorestframework>=3.4,<3.5'
   fast_finish: true

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,7 @@ Requirements
 
 * Python 2.7, 3.2, 3.3, 3.4, 3.5
 * Django 1.8, 1.9
+* DRF 3.2, 3.3
 
 Installation
 ------------

--- a/django_filters/compat.py
+++ b/django_filters/compat.py
@@ -2,6 +2,13 @@
 import django
 
 
+# django-crispy-forms is optional
+try:
+    import crispy_forms
+except ImportError:
+    crispy_forms = None
+
+
 def remote_field(field):
     """
     https://docs.djangoproject.com/en/1.9/releases/1.9/#field-rel-changes

--- a/django_filters/rest_framework/__init__.py
+++ b/django_filters/rest_framework/__init__.py
@@ -1,0 +1,4 @@
+# flake8: noqa
+from __future__ import absolute_import
+from .filterset import FilterSet
+from ..filters import *

--- a/django_filters/rest_framework/__init__.py
+++ b/django_filters/rest_framework/__init__.py
@@ -1,4 +1,5 @@
 # flake8: noqa
 from __future__ import absolute_import
+from .backends import FilterBackend
 from .filterset import FilterSet
 from ..filters import *

--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -1,0 +1,95 @@
+
+from __future__ import absolute_import
+
+from django.conf import settings
+from django.template import loader
+from django.utils.translation import ugettext_lazy as _
+
+from rest_framework import compat
+from rest_framework.filters import BaseFilterBackend
+
+from ..compat import crispy_forms
+from . import filterset
+
+
+if 'crispy_forms' in settings.INSTALLED_APPS and crispy_forms:
+    from crispy_forms.helper import FormHelper
+    from crispy_forms.layout import Layout, Submit
+
+    class FilterSet(filterset.FilterSet):
+        def __init__(self, *args, **kwargs):
+            super(FilterSet, self).__init__(*args, **kwargs)
+            for field in self.form.fields.values():
+                field.help_text = None
+
+            layout_components = list(self.form.fields.keys()) + [
+                Submit('', _('Submit'), css_class='btn-default'),
+            ]
+
+            helper = FormHelper()
+            helper.form_method = 'GET'
+            helper.template_pack = 'bootstrap3'
+            helper.layout = Layout(*layout_components)
+
+            self.form.helper = helper
+
+    filter_template = 'django_filters/rest_framework/crispy_form.html'
+
+else:
+    class FilterSet(filterset.FilterSet):
+        def __init__(self, *args, **kwargs):
+            super(FilterSet, self).__init__(*args, **kwargs)
+            for field in self.form.fields.values():
+                field.help_text = None
+
+    filter_template = 'django_filters/rest_framework/form.html'
+
+
+class FilterBackend(BaseFilterBackend):
+    default_filter_set = FilterSet
+    template = filter_template
+
+    def get_filter_class(self, view, queryset=None):
+        """
+        Return the django-filters `FilterSet` used to filter the queryset.
+        """
+        filter_class = getattr(view, 'filter_class', None)
+        filter_fields = getattr(view, 'filter_fields', None)
+
+        if filter_class:
+            filter_model = filter_class.Meta.model
+
+            assert issubclass(queryset.model, filter_model), \
+                'FilterSet model %s does not match queryset model %s' % \
+                (filter_model, queryset.model)
+
+            return filter_class
+
+        if filter_fields:
+            class AutoFilterSet(self.default_filter_set):
+                class Meta:
+                    model = queryset.model
+                    fields = filter_fields
+
+            return AutoFilterSet
+
+        return None
+
+    def filter_queryset(self, request, queryset, view):
+        filter_class = self.get_filter_class(view, queryset)
+
+        if filter_class:
+            return filter_class(request.query_params, queryset=queryset).qs
+
+        return queryset
+
+    def to_html(self, request, queryset, view):
+        filter_class = self.get_filter_class(view, queryset)
+        if not filter_class:
+            return None
+        filter_instance = filter_class(request.query_params, queryset=queryset)
+        context = {
+            'filter': filter_instance
+        }
+        template = loader.get_template(self.template)
+        return compat.template_render(template, context)

--- a/django_filters/rest_framework/filterset.py
+++ b/django_filters/rest_framework/filterset.py
@@ -1,0 +1,25 @@
+
+from __future__ import absolute_import
+from copy import deepcopy
+
+from django.db import models
+
+from django_filters import filterset
+from ..filters import BooleanFilter, IsoDateTimeFilter
+from ..widgets import BooleanWidget
+
+
+FILTER_FOR_DBFIELD_DEFAULTS = deepcopy(filterset.FILTER_FOR_DBFIELD_DEFAULTS)
+FILTER_FOR_DBFIELD_DEFAULTS.update({
+    models.DateTimeField: {'filter_class': IsoDateTimeFilter},
+    models.BooleanField: {
+        'filter_class': BooleanFilter,
+        'extra': lambda f: {
+            'widget': BooleanWidget,
+        },
+    },
+})
+
+
+class FilterSet(filterset.FilterSet):
+    FILTER_DEFAULTS = FILTER_FOR_DBFIELD_DEFAULTS

--- a/django_filters/rest_framework/templates/django_filters/rest_framework/crispy_form.html
+++ b/django_filters/rest_framework/templates/django_filters/rest_framework/crispy_form.html
@@ -1,0 +1,5 @@
+{% load crispy_forms_tags %}
+{% load i18n %}
+
+<h2>{% trans "Field filters" %}</h2>
+{% crispy filter.form %}

--- a/django_filters/rest_framework/templates/django_filters/rest_framework/form.html
+++ b/django_filters/rest_framework/templates/django_filters/rest_framework/form.html
@@ -1,0 +1,6 @@
+{% load i18n %}
+<h2>{% trans "Field filters" %}</h2>
+<form class="form" action="" method="get">
+    {{ filter.form.as_p }}
+    <button type="submit" class="btn btn-primary">{% trans "Submit" %}</button>
+</form>

--- a/docs/migration.txt
+++ b/docs/migration.txt
@@ -27,3 +27,28 @@ no longer proxied from the queryset. To fix this, call the methods on the
     # 1.0
     for obj in f.qs:
         ...
+
+
+Move FilterSet options to Meta class
+------------------------------------
+Details: https://github.com/carltongibson/django-filter/issues/430
+
+Several ``FilterSet`` options have been moved to the ``Meta`` class to prevent
+potential conflicts with declared filter names. This includes:
+
+* ``filterset_class``
+* ``strict``
+
+.. code-block:: python
+
+    # 0.x
+    class UserFilter(FilterSet):
+        filter_overrides = {}
+        ...
+
+    # 1.0
+    class UserFilter(FilterSet):
+        ...
+
+        class Meta:
+            filter_overrides = {}

--- a/tests/rest_framework/models.py
+++ b/tests/rest_framework/models.py
@@ -1,0 +1,28 @@
+
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
+
+
+class BasicModel(models.Model):
+    text = models.CharField(
+        max_length=100,
+        verbose_name=_("Text comes here"),
+        help_text=_("Text description.")
+    )
+
+
+class BaseFilterableItem(models.Model):
+    text = models.CharField(max_length=100)
+
+
+class FilterableItem(BaseFilterableItem):
+    decimal = models.DecimalField(max_digits=4, decimal_places=2)
+    date = models.DateField()
+
+
+class DjangoFilterOrderingModel(models.Model):
+    date = models.DateField()
+    text = models.CharField(max_length=10)
+
+    class Meta:
+        ordering = ['-date']

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -1,0 +1,372 @@
+from __future__ import unicode_literals
+
+import datetime
+from decimal import Decimal
+
+from django.conf.urls import url
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.utils.dateparse import parse_date
+
+from rest_framework import generics, serializers, status
+from rest_framework.test import APIRequestFactory
+
+from django_filters import filters
+from django_filters.rest_framework import FilterBackend, FilterSet
+
+from .models import BaseFilterableItem, BasicModel, FilterableItem, DjangoFilterOrderingModel
+
+factory = APIRequestFactory()
+
+
+class FilterableItemSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = FilterableItem
+        fields = '__all__'
+
+
+# Basic filter on a list view.
+class FilterFieldsRootView(generics.ListCreateAPIView):
+    queryset = FilterableItem.objects.all()
+    serializer_class = FilterableItemSerializer
+    filter_fields = ['decimal', 'date']
+    filter_backends = (FilterBackend,)
+
+
+# These class are used to test a filter class.
+class SeveralFieldsFilter(FilterSet):
+    text = filters.CharFilter(lookup_type='icontains')
+    decimal = filters.NumberFilter(lookup_type='lt')
+    date = filters.DateFilter(lookup_type='gt')
+
+    class Meta:
+        model = FilterableItem
+        fields = ['text', 'decimal', 'date']
+
+
+class FilterClassRootView(generics.ListCreateAPIView):
+    queryset = FilterableItem.objects.all()
+    serializer_class = FilterableItemSerializer
+    filter_class = SeveralFieldsFilter
+    filter_backends = (FilterBackend,)
+
+
+# These classes are used to test a misconfigured filter class.
+class MisconfiguredFilter(FilterSet):
+    text = filters.CharFilter(lookup_type='icontains')
+
+    class Meta:
+        model = BasicModel
+        fields = ['text']
+
+
+class IncorrectlyConfiguredRootView(generics.ListCreateAPIView):
+    queryset = FilterableItem.objects.all()
+    serializer_class = FilterableItemSerializer
+    filter_class = MisconfiguredFilter
+    filter_backends = (FilterBackend,)
+
+
+class FilterClassDetailView(generics.RetrieveAPIView):
+    queryset = FilterableItem.objects.all()
+    serializer_class = FilterableItemSerializer
+    filter_class = SeveralFieldsFilter
+    filter_backends = (FilterBackend,)
+
+
+# These classes are used to test base model filter support
+class BaseFilterableItemFilter(FilterSet):
+    text = filters.CharFilter()
+
+    class Meta:
+        model = BaseFilterableItem
+
+
+class BaseFilterableItemFilterRootView(generics.ListCreateAPIView):
+    queryset = FilterableItem.objects.all()
+    serializer_class = FilterableItemSerializer
+    filter_class = BaseFilterableItemFilter
+    filter_backends = (FilterBackend,)
+
+
+# Regression test for #814
+class FilterFieldsQuerysetView(generics.ListCreateAPIView):
+    queryset = FilterableItem.objects.all()
+    serializer_class = FilterableItemSerializer
+    filter_fields = ['decimal', 'date']
+    filter_backends = (FilterBackend,)
+
+
+class GetQuerysetView(generics.ListCreateAPIView):
+    serializer_class = FilterableItemSerializer
+    filter_class = SeveralFieldsFilter
+    filter_backends = (FilterBackend,)
+
+    def get_queryset(self):
+        return FilterableItem.objects.all()
+
+
+urlpatterns = [
+    url(r'^(?P<pk>\d+)/$', FilterClassDetailView.as_view(), name='detail-view'),
+    url(r'^$', FilterClassRootView.as_view(), name='root-view'),
+    url(r'^get-queryset/$', GetQuerysetView.as_view(), name='get-queryset-view'),
+]
+
+
+class CommonFilteringTestCase(TestCase):
+    def _serialize_object(self, obj):
+        return {'id': obj.id, 'text': obj.text, 'decimal': str(obj.decimal), 'date': obj.date.isoformat()}
+
+    def setUp(self):
+        """
+        Create 10 FilterableItem instances.
+        """
+        base_data = ('a', Decimal('0.25'), datetime.date(2012, 10, 8))
+        for i in range(10):
+            text = chr(i + ord(base_data[0])) * 3  # Produces string 'aaa', 'bbb', etc.
+            decimal = base_data[1] + i
+            date = base_data[2] - datetime.timedelta(days=i * 2)
+            FilterableItem(text=text, decimal=decimal, date=date).save()
+
+        self.objects = FilterableItem.objects
+        self.data = [
+            self._serialize_object(obj)
+            for obj in self.objects.all()
+        ]
+
+
+class IntegrationTestFiltering(CommonFilteringTestCase):
+    """
+    Integration tests for filtered list views.
+    """
+
+    def test_get_filtered_fields_root_view(self):
+        """
+        GET requests to paginated ListCreateAPIView should return paginated results.
+        """
+        view = FilterFieldsRootView.as_view()
+
+        # Basic test with no filter.
+        request = factory.get('/')
+        response = view(request).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, self.data)
+
+        # Tests that the decimal filter works.
+        search_decimal = Decimal('2.25')
+        request = factory.get('/', {'decimal': '%s' % search_decimal})
+        response = view(request).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_data = [f for f in self.data if Decimal(f['decimal']) == search_decimal]
+        self.assertEqual(response.data, expected_data)
+
+        # Tests that the date filter works.
+        search_date = datetime.date(2012, 9, 22)
+        request = factory.get('/', {'date': '%s' % search_date})  # search_date str: '2012-09-22'
+        response = view(request).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_data = [f for f in self.data if parse_date(f['date']) == search_date]
+        self.assertEqual(response.data, expected_data)
+
+    def test_filter_with_queryset(self):
+        """
+        Regression test for #814.
+        """
+        view = FilterFieldsQuerysetView.as_view()
+
+        # Tests that the decimal filter works.
+        search_decimal = Decimal('2.25')
+        request = factory.get('/', {'decimal': '%s' % search_decimal})
+        response = view(request).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_data = [f for f in self.data if Decimal(f['decimal']) == search_decimal]
+        self.assertEqual(response.data, expected_data)
+
+    def test_filter_with_get_queryset_only(self):
+        """
+        Regression test for #834.
+        """
+        view = GetQuerysetView.as_view()
+        request = factory.get('/get-queryset/')
+        view(request).render()
+        # Used to raise "issubclass() arg 2 must be a class or tuple of classes"
+        # here when neither `model' nor `queryset' was specified.
+
+    def test_get_filtered_class_root_view(self):
+        """
+        GET requests to filtered ListCreateAPIView that have a filter_class set
+        should return filtered results.
+        """
+        view = FilterClassRootView.as_view()
+
+        # Basic test with no filter.
+        request = factory.get('/')
+        response = view(request).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, self.data)
+
+        # Tests that the decimal filter set with 'lt' in the filter class works.
+        search_decimal = Decimal('4.25')
+        request = factory.get('/', {'decimal': '%s' % search_decimal})
+        response = view(request).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_data = [f for f in self.data if Decimal(f['decimal']) < search_decimal]
+        self.assertEqual(response.data, expected_data)
+
+        # Tests that the date filter set with 'gt' in the filter class works.
+        search_date = datetime.date(2012, 10, 2)
+        request = factory.get('/', {'date': '%s' % search_date})  # search_date str: '2012-10-02'
+        response = view(request).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_data = [f for f in self.data if parse_date(f['date']) > search_date]
+        self.assertEqual(response.data, expected_data)
+
+        # Tests that the text filter set with 'icontains' in the filter class works.
+        search_text = 'ff'
+        request = factory.get('/', {'text': '%s' % search_text})
+        response = view(request).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_data = [f for f in self.data if search_text in f['text'].lower()]
+        self.assertEqual(response.data, expected_data)
+
+        # Tests that multiple filters works.
+        search_decimal = Decimal('5.25')
+        search_date = datetime.date(2012, 10, 2)
+        request = factory.get('/', {
+            'decimal': '%s' % (search_decimal,),
+            'date': '%s' % (search_date,)
+        })
+        response = view(request).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_data = [f for f in self.data if parse_date(f['date']) > search_date and
+                         Decimal(f['decimal']) < search_decimal]
+        self.assertEqual(response.data, expected_data)
+
+    def test_incorrectly_configured_filter(self):
+        """
+        An error should be displayed when the filter class is misconfigured.
+        """
+        view = IncorrectlyConfiguredRootView.as_view()
+
+        request = factory.get('/')
+        self.assertRaises(AssertionError, view, request)
+
+    def test_base_model_filter(self):
+        """
+        The `get_filter_class` model checks should allow base model filters.
+        """
+        view = BaseFilterableItemFilterRootView.as_view()
+
+        request = factory.get('/?text=aaa')
+        response = view(request).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+
+    def test_unknown_filter(self):
+        """
+        GET requests with filters that aren't configured should return 200.
+        """
+        view = FilterFieldsRootView.as_view()
+
+        search_integer = 10
+        request = factory.get('/', {'integer': '%s' % search_integer})
+        response = view(request).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+@override_settings(ROOT_URLCONF='tests.rest_framework.test_backends')
+class IntegrationTestDetailFiltering(CommonFilteringTestCase):
+    """
+    Integration tests for filtered detail views.
+    """
+    def _get_url(self, item):
+        return reverse('detail-view', kwargs=dict(pk=item.pk))
+
+    def test_get_filtered_detail_view(self):
+        """
+        GET requests to filtered RetrieveAPIView that have a filter_class set
+        should return filtered results.
+        """
+        item = self.objects.all()[0]
+        data = self._serialize_object(item)
+
+        # Basic test with no filter.
+        response = self.client.get(self._get_url(item))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, data)
+
+        # Tests that the decimal filter set that should fail.
+        search_decimal = Decimal('4.25')
+        high_item = self.objects.filter(decimal__gt=search_decimal)[0]
+        response = self.client.get(
+            '{url}'.format(url=self._get_url(high_item)),
+            {'decimal': '{param}'.format(param=search_decimal)})
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        # Tests that the decimal filter set that should succeed.
+        search_decimal = Decimal('4.25')
+        low_item = self.objects.filter(decimal__lt=search_decimal)[0]
+        low_item_data = self._serialize_object(low_item)
+        response = self.client.get(
+            '{url}'.format(url=self._get_url(low_item)),
+            {'decimal': '{param}'.format(param=search_decimal)})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, low_item_data)
+
+        # Tests that multiple filters works.
+        search_decimal = Decimal('5.25')
+        search_date = datetime.date(2012, 10, 2)
+        valid_item = self.objects.filter(decimal__lt=search_decimal, date__gt=search_date)[0]
+        valid_item_data = self._serialize_object(valid_item)
+        response = self.client.get(
+            '{url}'.format(url=self._get_url(valid_item)), {
+                'decimal': '{decimal}'.format(decimal=search_decimal),
+                'date': '{date}'.format(date=search_date)
+            })
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, valid_item_data)
+
+
+class DjangoFilterOrderingSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = DjangoFilterOrderingModel
+        fields = '__all__'
+
+
+class DjangoFilterOrderingTests(TestCase):
+    def setUp(self):
+        data = [{
+            'date': datetime.date(2012, 10, 8),
+            'text': 'abc'
+        }, {
+            'date': datetime.date(2013, 10, 8),
+            'text': 'bcd'
+        }, {
+            'date': datetime.date(2014, 10, 8),
+            'text': 'cde'
+        }]
+
+        for d in data:
+            DjangoFilterOrderingModel.objects.create(**d)
+
+    def test_default_ordering(self):
+        class DjangoFilterOrderingView(generics.ListAPIView):
+            serializer_class = DjangoFilterOrderingSerializer
+            queryset = DjangoFilterOrderingModel.objects.all()
+            filter_backends = (FilterBackend,)
+            filter_fields = ['text']
+            ordering = ('-date',)
+
+        view = DjangoFilterOrderingView.as_view()
+        request = factory.get('/')
+        response = view(request)
+
+        self.assertEqual(
+            response.data,
+            [
+                {'id': 3, 'date': '2014-10-08', 'text': 'cde'},
+                {'id': 2, 'date': '2013-10-08', 'text': 'bcd'},
+                {'id': 1, 'date': '2012-10-08', 'text': 'abc'}
+            ]
+        )

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -23,7 +23,7 @@ factory = APIRequestFactory()
 class FilterableItemSerializer(serializers.ModelSerializer):
     class Meta:
         model = FilterableItem
-        fields = '__all__'
+        fields = ['id', 'text', 'decimal', 'date']
 
 
 # Basic filter on a list view.
@@ -331,7 +331,7 @@ class IntegrationTestDetailFiltering(CommonFilteringTestCase):
 class DjangoFilterOrderingSerializer(serializers.ModelSerializer):
     class Meta:
         model = DjangoFilterOrderingModel
-        fields = '__all__'
+        fields = ['id', 'date', 'text']
 
 
 class DjangoFilterOrderingTests(TestCase):

--- a/tests/rest_framework/test_filterset.py
+++ b/tests/rest_framework/test_filterset.py
@@ -1,0 +1,23 @@
+
+from django.test import TestCase
+
+from django_filters.rest_framework import FilterSet
+from django_filters.filters import BooleanFilter, IsoDateTimeFilter
+from django_filters.widgets import BooleanWidget
+
+from ..models import User, Article
+
+
+class FilterSetFilterForFieldTests(TestCase):
+
+    def test_isodatetimefilter(self):
+        field = Article._meta.get_field('published')
+        result = FilterSet.filter_for_field(field, 'published')
+        self.assertIsInstance(result, IsoDateTimeFilter)
+        self.assertEqual(result.name, 'published')
+
+    def test_booleanfilter_widget(self):
+        field = User._meta.get_field('is_active')
+        result = FilterSet.filter_for_field(field, 'is_active')
+        self.assertIsInstance(result, BooleanFilter)
+        self.assertEqual(result.widget, BooleanWidget)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -10,6 +10,7 @@ INSTALLED_APPS = (
     'django.contrib.auth',
     'django_filters',
     'tests',
+    'tests.rest_framework',
 )
 
 ROOT_URLCONF = 'tests.urls'

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -47,3 +47,26 @@ class FilterSetContainerDeprecationTests(TestCase):
             UserFilter().count()
 
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+
+class FilterOverridesMovedTests(TestCase):
+
+    def test_notification(self):
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                filter_overrides = {}
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+    def test_passthrough(self):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                filter_overrides = {'foo': 'bar'}
+
+            self.assertDictEqual(F._meta.filter_overrides, {'foo': 'bar'})

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -216,14 +216,15 @@ class FilterSetFilterForLookupTests(TestCase):
 
     def test_isnull_with_filter_overrides(self):
         class OFilterSet(FilterSet):
-            filter_overrides = {
-                models.BooleanField: {
-                    'filter_class': BooleanFilter,
-                    'extra': lambda f: {
-                        'widget': BooleanWidget,
+            class Meta:
+                filter_overrides = {
+                    models.BooleanField: {
+                        'filter_class': BooleanFilter,
+                        'extra': lambda f: {
+                            'widget': BooleanWidget,
+                        },
                     },
-                },
-            }
+                }
 
         f = Article._meta.get_field('author')
         result, params = OFilterSet.filter_for_lookup(f, 'isnull')
@@ -463,11 +464,10 @@ class FilterSetClassCreationTests(TestCase):
 
     def test_custom_field_gets_filter_from_override(self):
         class F(FilterSet):
-            filter_overrides = {
-                SubnetMaskField: {'filter_class': CharFilter}}
-
             class Meta:
                 model = NetworkSetting
+                filter_overrides = {
+                    SubnetMaskField: {'filter_class': CharFilter}}
 
         self.assertEqual(list(F.base_filters.keys()), ['ip', 'mask'])
 


### PR DESCRIPTION
This is an attempt at #275.

#### Notes:
- Made `FILTER_DEFAULTS` a FilterSet class attribute. This allows the DRF FilterSet to modify the defaults without relying on `filter_overrides`. Using `filter_overrides` would complicate the API, as subclasses would have to copy the changes in addition to making their own.
- Made `filter_overrides` a meta option, providing a deprecation notice for the class attribute. This seems more correct? Behavior modifying options should exist in the class meta, not on the class itself (which should just be the declarative filters). Either way, can revert this and raise in a separate issue - I'd argue that `strict` and `order_by_field` should also be moved to meta.
- `django_filters.rest_framework` does not have a conditional dependency on DRF (as `rest_framework.filters` had on django-filter). It doesn't seem necessary, as you won't be loading the rest_framework sub-package unless DRF is installed.
- The crispy_forms conditional dependency was kept. I don't really have an opinion/preference, but it's a minimal amount of code so why not?
- Added DRF to the CI matrix. 
- The `FilterBackend` and tests are almost entirely a carbon copy of what exists on the current DRF master branch.

#### Questions:
- Should the `crispy_forms` conditional dependency be kept?
- Should we stop providing support for python 3.2 and 3.3?
  - Most likely, it will continue working even if not officially tested
  - It's complicating the build matrix and increasing test times
  - Still, they're technically supported until 1.8 EOL's in 2018 :\

#### TODO:
- [ ] Add DRF relevant docs.
- [x] Add migration docs.
- [x] Refactor.
- [ ] Wait for 453, simplify DRF requirement in testing matrix.
- [ ] Wait for 459, which contains the filter_overrides move