### PR TITLE
Move FilterSet options to Meta class

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import copy
 import re
+import warnings
 from collections import OrderedDict
 
 from django import forms
@@ -23,7 +24,7 @@ from .filters import (Filter, CharFilter, BooleanFilter, BaseInFilter, BaseRange
 from .utils import try_dbfield, get_model_field, resolve_field
 
 
-ORDER_BY_FIELD = 'o'
+ORDERING_PARAM = 'o'
 
 
 class STRICTNESS(object):
@@ -137,6 +138,7 @@ class FilterSetOptions(object):
         self.exclude = getattr(options, 'exclude', None)
 
         self.order_by = getattr(options, 'order_by', False)
+        self.ordering_param = getattr(options, 'ordering_param', ORDERING_PARAM)
 
         self.form = getattr(options, 'form', forms.Form)
 
@@ -169,6 +171,10 @@ class FilterSetMetaclass(type):
         if not_defined:
             raise TypeError("Meta.fields contains a field that isn't defined "
                             "on this FilterSet: {}".format(not_defined))
+
+        if hasattr(new_class, 'order_by_field'):
+            warnings.warn('order_by_field has been deprecated. Use Meta.ordering_param instead.', DeprecationWarning, stacklevel=2)
+            new_class._meta.ordering_param = new_class.order_by_field
 
         new_class.declared_filters = declared_filters
         new_class.base_filters = filters
@@ -267,7 +273,6 @@ FILTER_FOR_DBFIELD_DEFAULTS = {
 
 class BaseFilterSet(object):
     filter_overrides = {}
-    order_by_field = ORDER_BY_FIELD
     # What to do on on validation errors
     strict = STRICTNESS.RETURN_NO_RESULTS
 
@@ -335,8 +340,8 @@ class BaseFilterSet(object):
                     qs = filter_.filter(qs, value)
 
             if self._meta.order_by:
-                order_field = self.form.fields[self.order_by_field]
-                data = self.form[self.order_by_field].data
+                order_field = self.form.fields[self._meta.ordering_param]
+                data = self.form[self._meta.ordering_param].data
                 ordered_value = None
                 try:
                     ordered_value = order_field.clean(data)
@@ -346,7 +351,7 @@ class BaseFilterSet(object):
                 # With a None-queryset, ordering must be enforced (#84).
                 if (ordered_value in EMPTY_VALUES and
                         self.strict == STRICTNESS.RETURN_NO_RESULTS):
-                    ordered_value = self.form.fields[self.order_by_field].choices[0][0]
+                    ordered_value = self.form.fields[self._meta.ordering_param].choices[0][0]
 
                 if ordered_value:
                     qs = qs.order_by(*self.get_order_by(ordered_value))
@@ -364,7 +369,7 @@ class BaseFilterSet(object):
             fields = OrderedDict([
                 (name, filter_.field)
                 for name, filter_ in six.iteritems(self.filters)])
-            fields[self.order_by_field] = self.ordering_field
+            fields[self._meta.ordering_param] = self.ordering_field
             Form = type(str('%sForm' % self.__class__.__name__),
                         (self._meta.form,), fields)
             if self._meta.together:

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -5,6 +5,28 @@ from django.test import TestCase
 from django_filters import FilterSet
 
 
+class StrictnessDeprecationTests(TestCase):
+    def test_notification(self):
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                strict = False
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+    def test_passthrough(self):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                strict = False
+
+            self.assertEqual(F._meta.strict, False)
+
+
 class OrderByFieldDeprecationTests(TestCase):
     def test_notification(self):
 

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,0 +1,27 @@
+
+import warnings
+from django.test import TestCase
+
+from django_filters import FilterSet
+
+
+class OrderByFieldDeprecationTests(TestCase):
+    def test_notification(self):
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                order_by_field = 'field'
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+    def test_passthrough(self):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                order_by_field = 'field'
+
+            self.assertEqual(F._meta.ordering_param, 'field')

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -856,11 +856,11 @@ class AllValuesFilterTests(TestCase):
 
         class F(FilterSet):
             username = AllValuesFilter()
-            strict = False
 
             class Meta:
                 model = User
                 fields = ['username']
+                strict = False
 
         self.assertEqual(list(F().qs), list(User.objects.all()))
         self.assertEqual(list(F({'username': 'alex'})),

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -584,26 +584,24 @@ class FilterSetOrderingTests(TestCase):
 
     def test_ordering_on_unknown_value_results_in_default_ordering_without_strict(self):
         class F(FilterSet):
-            strict = STRICTNESS.IGNORE
-
             class Meta:
                 model = User
                 fields = ['username', 'status']
                 order_by = ['status']
+                strict = STRICTNESS.IGNORE
 
-        self.assertFalse(F.strict)
+        self.assertFalse(F._meta.strict)
         f = F({'o': 'username'}, queryset=self.qs)
         self.assertQuerysetEqual(
             f.qs, ['alex', 'jacob', 'aaron', 'carl'], lambda o: o.username)
 
     def test_ordering_on_unknown_value_results_in_default_ordering_with_strict_raise(self):
         class F(FilterSet):
-            strict = STRICTNESS.RAISE_VALIDATION_ERROR
-
             class Meta:
                 model = User
                 fields = ['username', 'status']
                 order_by = ['status']
+                strict = STRICTNESS.RAISE_VALIDATION_ERROR
 
         f = F({'o': 'username'}, queryset=self.qs)
         with self.assertRaises(ValidationError) as excinfo:

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -658,16 +658,15 @@ class FilterSetOrderingTests(TestCase):
 
     def test_ordering_with_overridden_field_name(self):
         """
-        Set the `order_by_field` on the queryset and ensure that the
+        Set the `ordering_param` on the queryset and ensure that the
         field name is respected.
         """
         class F(FilterSet):
-            order_by_field = 'order'
-
             class Meta:
                 model = User
                 fields = ['username', 'status']
                 order_by = ['status']
+                ordering_param = 'order'
 
         f = F({'order': 'status'}, queryset=self.qs)
         self.assertQuerysetEqual(

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -214,16 +214,15 @@ class FilterSetFormTests(TestCase):
 
     def test_ordering_with_overridden_field_name(self):
         """
-        Set the `order_by_field` on the queryset and ensure that the
+        Set the `ordering_param` on the queryset and ensure that the
         field name is respected.
         """
         class F(FilterSet):
-            order_by_field = 'order'
-
             class Meta:
                 model = User
                 fields = ['username', 'status']
                 order_by = ['status']
+                ordering_param = 'order'
 
         f = F().form
         self.assertNotIn('o', f.fields)
@@ -232,16 +231,15 @@ class FilterSetFormTests(TestCase):
 
     def test_ordering_with_overridden_field_name_and_descending(self):
         """
-        Set the `order_by_field` on the queryset and ensure that the
+        Set the `ordering_param` on the queryset and ensure that the
         field name is respected.
         """
         class F(FilterSet):
-            order_by_field = 'order'
-
             class Meta:
                 model = User
                 fields = ['username', 'status']
                 order_by = ['status', '-status']
+                ordering_param = 'order'
 
         f = F().form
         self.assertNotIn('o', f.fields)
@@ -250,12 +248,11 @@ class FilterSetFormTests(TestCase):
 
     def test_ordering_with_overridden_field_name_and_using_all_fields(self):
         class F(FilterSet):
-            order_by_field = 'order'
-
             class Meta:
                 model = User
                 fields = ['username', 'status']
                 order_by = True
+                ordering_param = 'order'
 
         f = F().form
         self.assertIn('order', f.fields)


### PR DESCRIPTION
Resolves #430 and #431.

**Notes:**
- `strict` is still accessed as an instance attribute on the FilterSet instead of through the meta class. This is because `strict` is an argument in the initializer, although undocumented and untested.

**TODO:**
- [ ] docs