### PR TITLE
Add UUIDFilter to filters.__all__

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -29,6 +29,7 @@ __all__ = [
     'DateRangeFilter',
     'DateTimeFilter',
     'DateTimeFromToRangeFilter',
+    'DurationFilter',
     'Filter',
     'IsoDateTimeFilter',
     'MethodFilter',

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -20,13 +20,28 @@ from .fields import (
 
 
 __all__ = [
-    'Filter', 'CharFilter', 'BooleanFilter', 'ChoiceFilter',
-    'TypedChoiceFilter', 'MultipleChoiceFilter', 'DateFilter',
-    'DateTimeFilter', 'IsoDateTimeFilter', 'TimeFilter', 'ModelChoiceFilter',
-    'ModelMultipleChoiceFilter', 'NumberFilter', 'NumericRangeFilter', 'RangeFilter',
-    'DateRangeFilter', 'DateFromToRangeFilter', 'DateTimeFromToRangeFilter',
-    'TimeRangeFilter', 'AllValuesFilter', 'MethodFilter', 'UUIDFilter',
-    'DurationFilter',
+    'AllValuesFilter',
+    'BooleanFilter',
+    'CharFilter',
+    'ChoiceFilter',
+    'DateFilter',
+    'DateFromToRangeFilter',
+    'DateRangeFilter',
+    'DateTimeFilter',
+    'DateTimeFromToRangeFilter',
+    'Filter',
+    'IsoDateTimeFilter',
+    'MethodFilter',
+    'ModelChoiceFilter',
+    'ModelMultipleChoiceFilter',
+    'MultipleChoiceFilter',
+    'NumberFilter',
+    'NumericRangeFilter',
+    'RangeFilter',
+    'TimeFilter',
+    'TimeRangeFilter',
+    'TypedChoiceFilter',
+    'UUIDFilter',
 ]
 
 


### PR DESCRIPTION
It's currently not possible to import UUIDFilter, because it's not included in `filters.__all__`.

I've added it and alphabetised the list to make it easier to pick these problems up in the future.