### PR TITLE
Rework form labels 

### DIFF
--- a/django_filters/conf.py
+++ b/django_filters/conf.py
@@ -7,6 +7,7 @@ from .utils import deprecate
 
 
 DEFAULTS = {
+    'DISABLE_HELP_TEXT': False,
     'HELP_TEXT_FILTER': True,
     'HELP_TEXT_EXCLUDE': True,
     'VERBOSE_LOOKUPS': {

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -19,7 +19,7 @@ from .fields import (
     Lookup, LookupTypeField, BaseCSVField, BaseRangeField, RangeField,
     DateRangeField, DateTimeRangeField, TimeRangeField, IsoDateTimeField
 )
-from .utils import deprecate, pretty_name
+from .utils import deprecate, label_for_filter, pretty_name
 
 
 __all__ = [
@@ -127,18 +127,24 @@ class Filter(object):
         return locals()
     lookup_type = property(**lookup_type())
 
+    def label():
+        def fget(self):
+            if self._label is None and hasattr(self, 'parent'):
+                model = self.parent._meta.model
+                self._label = label_for_filter(
+                    model, self.name, self.lookup_expr, self.exclude
+                )
+            return self._label
+
+        def fset(self, value):
+            self._label = value
+
+        return locals()
+    label = property(**label())
+
     @property
     def field(self):
         if not hasattr(self, '_field'):
-            help_text = self.extra.pop('help_text', None)
-            if help_text is None:
-                if self.exclude and settings.HELP_TEXT_EXCLUDE:
-                    help_text = _('This is an exclusion filter')
-                elif not self.exclude and settings.HELP_TEXT_FILTER:
-                    help_text = _('Filter')
-                else:
-                    help_text = ''
-
             if (self.lookup_expr is None or
                     isinstance(self.lookup_expr, (list, tuple))):
 
@@ -162,11 +168,11 @@ class Filter(object):
 
                 self._field = LookupTypeField(self.field_class(
                     required=self.required, widget=self.widget, **self.extra),
-                    lookup, required=self.required, label=self.label, help_text=help_text)
+                    lookup, required=self.required, label=self.label)
             else:
                 self._field = self.field_class(required=self.required,
                                                label=self.label, widget=self.widget,
-                                               help_text=help_text, **self.extra)
+                                               **self.extra)
         return self._field
 
     def filter(self, qs, value):
@@ -440,6 +446,7 @@ class BaseCSVFilter(Filter):
     base_field_class = BaseCSVField
 
     def __init__(self, *args, **kwargs):
+        kwargs.setdefault('help_text', _('Multiple values may be separated by commas.'))
         super(BaseCSVFilter, self).__init__(*args, **kwargs)
 
         class ConcreteCSVField(self.base_field_class, self.field_class):

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -145,6 +145,11 @@ class Filter(object):
     @property
     def field(self):
         if not hasattr(self, '_field'):
+            field_kwargs = self.extra.copy()
+
+            if settings.DISABLE_HELP_TEXT:
+                field_kwargs.pop('help_text', None)
+
             if (self.lookup_expr is None or
                     isinstance(self.lookup_expr, (list, tuple))):
 
@@ -167,12 +172,12 @@ class Filter(object):
                                 lookup.append(choice)
 
                 self._field = LookupTypeField(self.field_class(
-                    required=self.required, widget=self.widget, **self.extra),
+                    required=self.required, widget=self.widget, **field_kwargs),
                     lookup, required=self.required, label=self.label)
             else:
                 self._field = self.field_class(required=self.required,
                                                label=self.label, widget=self.widget,
-                                               **self.extra)
+                                               **field_kwargs)
         return self._field
 
     def filter(self, qs, value):

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -433,8 +433,7 @@ class BaseFilterSet(object):
 
         default = {
             'name': name,
-            'label': capfirst(f.verbose_name),
-            'lookup_expr': lookup_expr
+            'lookup_expr': lookup_expr,
         }
 
         filter_class, params = cls.filter_for_lookup(f, lookup_type)
@@ -454,7 +453,6 @@ class BaseFilterSet(object):
         queryset = f.field.model._default_manager.all()
         default = {
             'name': name,
-            'label': capfirst(rel.related_name),
             'queryset': queryset,
         }
         if rel.multiple:

--- a/django_filters/utils.py
+++ b/django_filters/utils.py
@@ -8,6 +8,8 @@ from django.db.models.expressions import Expression
 from django.db.models.fields import FieldDoesNotExist
 from django.db.models.fields.related import RelatedField, ForeignObjectRel
 from django.utils import six, timezone
+from django.utils.encoding import force_text
+from django.utils.translation import ugettext as _
 
 try:
     from django.forms.utils import pretty_name
@@ -155,3 +157,82 @@ def handle_timezone(value):
     elif not settings.USE_TZ and timezone.is_aware(value):
         return timezone.make_naive(value, timezone.UTC())
     return value
+
+
+def verbose_field_name(model, field_name):
+    """
+    Get the verbose name for a given ``field_name``. The ``field_name``
+    will be traversed across relationships. Returns '[invalid name]' for
+    any field name that cannot be traversed.
+
+    ex::
+
+        >>> verbose_field_name(Article, 'author__name')
+        'author name'
+
+    """
+    if field_name is None:
+        return '[invalid name]'
+
+    parts = get_field_parts(model, field_name)
+    if not parts:
+        return '[invalid name]'
+
+    names = []
+    for part in parts:
+        if isinstance(part, ForeignObjectRel):
+            names.append(part.related_name)
+        else:
+            names.append(part.verbose_name)
+
+    return ' '.join(names)
+
+
+def verbose_lookup_expr(lookup_expr):
+    """
+    Get a verbose, more humanized expression for a given ``lookup_expr``.
+    Each part in the expression is looked up in the ``FILTERS_VERBOSE_LOOKUPS``
+    dictionary. Missing keys will simply default to itself.
+
+    ex::
+
+        >>> verbose_lookup_expr('year__lt')
+        'year is less than'
+
+        # with `FILTERS_VERBOSE_LOOKUPS = {}`
+        >>> verbose_lookup_expr('year__lt')
+        'year lt'
+
+    """
+    from .conf import settings as app_settings
+
+    VERBOSE_LOOKUPS = app_settings.VERBOSE_LOOKUPS or {}
+    lookups = [
+        force_text(VERBOSE_LOOKUPS.get(lookup, _(lookup)))
+        for lookup in lookup_expr.split(LOOKUP_SEP)
+    ]
+
+    return ' '.join(lookups)
+
+
+def label_for_filter(model, field_name, lookup_expr, exclude=False):
+    """
+    Create a generic label suitable for a filter.
+
+    ex::
+
+        >>> label_for_filter(Article, 'author__name', 'in')
+        'auther name is in'
+
+    """
+    name = verbose_field_name(model, field_name)
+    verbose_expression = [_('exclude'), name] if exclude else [name]
+
+    # iterable lookups indicate a LookupTypeField, which should not be verbose
+    if isinstance(lookup_expr, six.string_types):
+        verbose_expression += [verbose_lookup_expr(lookup_expr)]
+
+    verbose_expression = [force_text(part) for part in verbose_expression if part]
+    verbose_expression = pretty_name(' '.join(verbose_expression))
+
+    return verbose_expression

--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -22,7 +22,9 @@ fields on a related model. eg, ``manufacturer__name``.
 ~~~~~~~~~
 
 The label as it will apear in the HTML, analogous to a form field's label
-argument.
+argument. If a label is not provided, a verbose label will be generated based
+on the field ``name`` and the parts of the ``lookup_expr``.
+(See: :ref:`verbose-lookups-setting`).
 
 ``widget``
 ~~~~~~~~~~

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -9,20 +9,59 @@ default values. All settings are prefixed with ``FILTERS_``, although this
 is a bit verbose it helps to make it easy to identify these settings.
 
 
-FILTERS_HELP_TEXT_EXCLUDE
+FILTERS_DISABLE_HELP_TEXT
 -------------------------
 
-Default: ``True``
+Default: ``False``
 
-Enable / disable the default field ``help_text`` on filters where ``exclude=True`` (:doc:`/ref/filters`). This does not affect fields which explicitly define ``help_text``.
+Some filters provide informational ``help_text``. For example, csv-based
+filters (``filters.BaseCSVFilter``) inform users that "Multiple values may
+be separated by commas".
 
-.. note:: This setting is pending deprecation.
+You may set this to ``True`` to disable the ``help_text`` for **all**
+filters, removing the text from the rendered form's output.
 
-FILTERS_HELP_TEXT_FILTER
-------------------------
 
-Default: ``True``
+.. _verbose-lookups-setting:
 
-Enable / disable the default field ``help_text`` on filters where ``exclude=False`` (:doc:`/ref/filters`). This does not affect fields which explicitly define ``help_text``.
+FILTERS_VERBOSE_LOOKUPS
+-----------------------
 
-.. note:: This setting is pending deprecation.
+.. note::
+
+    This is considered an advanced setting and is subject to change.
+
+Default:
+
+.. code-block:: python
+
+    # refer to 'django_filters.conf.DEFAULTS'
+    'VERBOSE_LOOKUPS': {
+        'exact': _(''),
+        'iexact': _(''),
+        'contains': _('contains'),
+        'icontains': _('contains'),
+        ...
+    }
+
+This setting controls the verbose output for generated filter labels. Instead
+of getting expression parts such as "lt" and "contained_by", the verbose label
+would contain "is less than" and "is contained by". Verbose output may be
+disabled by setting this to a falsy value.
+
+This setting also accepts callables. The callable should not require arguments
+and should return a dictionary. This is useful for extending or overriding the
+default terms without having to copy the entire set of terms to your settings.
+For example, you could add verbose output for "exact" lookups.
+
+.. code-block:: python
+
+    # settings.py
+    def FILTERS_VERBOSE_LOOKUPS():
+        from django_filters.conf import DEFAULTS
+
+        verbose_lookups = DEFAULTS['VERBOSE_LOOKUPS'].copy()
+        verbose_lookups.update({
+            'exact': 'is equal to',
+        })
+        return verbose_lookups

--- a/tests/models.py
+++ b/tests/models.py
@@ -95,6 +95,7 @@ class Comment(models.Model):
 
 
 class Article(models.Model):
+    name = models.CharField(verbose_name='title', max_length=200, blank=True)
     published = models.DateTimeField()
     author = models.ForeignKey(User, null=True, on_delete=models.CASCADE)
 

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -336,12 +336,10 @@ class IntegrationTestFiltering(CommonFilteringTestCase):
             <p>
                 <label for="id_decimal">Decimal:</label>
                 <input id="id_decimal" name="decimal" step="any" type="number" />
-                <span class="helptext">Filter</span>
             </p>
             <p>
                 <label for="id_date">Date:</label>
                 <input id="id_date" name="date" type="text" />
-                <span class="helptext">Filter</span>
             </p>
             <button type="submit" class="btn btn-primary">Submit</button>
         </form>

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -10,6 +10,9 @@ class DefaultSettingsTests(TestCase):
         self.assertIsInstance(settings.VERBOSE_LOOKUPS, dict)
         self.assertIn('exact', settings.VERBOSE_LOOKUPS)
 
+    def test_disable_help_text(self):
+        self.assertFalse(settings.DISABLE_HELP_TEXT)
+
     def test_help_text_filter(self):
         self.assertTrue(settings.HELP_TEXT_FILTER)
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -7,7 +7,7 @@ import mock
 import warnings
 
 from django import forms
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from django_filters import filters, widgets
 from django_filters.fields import (
@@ -64,27 +64,6 @@ class FilterTests(TestCase):
         f = Filter()
         field = f.field
         self.assertIsInstance(field, forms.Field)
-        self.assertEqual(field.help_text, 'Filter')
-
-    def test_field_with_exclusion(self):
-        f = Filter(exclude=True)
-        field = f.field
-        self.assertIsInstance(field, forms.Field)
-        self.assertEqual(field.help_text, 'This is an exclusion filter')
-
-    @override_settings(FILTERS_HELP_TEXT_FILTER=False)
-    def test_default_field_settings(self):
-        f = Filter()
-        field = f.field
-        self.assertIsInstance(field, forms.Field)
-        self.assertEqual(field.help_text, '')
-
-    @override_settings(FILTERS_HELP_TEXT_EXCLUDE=False)
-    def test_field_with_exclusion_settings(self):
-        f = Filter(exclude=True)
-        field = f.field
-        self.assertIsInstance(field, forms.Field)
-        self.assertEqual(field.help_text, '')
 
     def test_field_with_single_lookup_expr(self):
         f = Filter(lookup_expr='iexact')
@@ -102,7 +81,6 @@ class FilterTests(TestCase):
         f = Filter(lookup_expr=None, exclude=True)
         field = f.field
         self.assertIsInstance(field, LookupTypeField)
-        self.assertEqual(field.help_text, 'This is an exclusion filter')
 
     def test_field_with_list_lookup_expr(self):
         f = Filter(lookup_expr=('istartswith', 'iendswith'))
@@ -119,8 +97,7 @@ class FilterTests(TestCase):
             f.field
             mocked.assert_called_once_with(required=False,
                                            label='somelabel',
-                                           widget='somewidget',
-                                           help_text=mock.ANY)
+                                           widget='somewidget')
 
     def test_field_extra_params(self):
         with mock.patch.object(Filter, 'field_class',
@@ -128,8 +105,8 @@ class FilterTests(TestCase):
             f = Filter(someattr='someattr')
             f.field
             mocked.assert_called_once_with(required=mock.ANY,
-                                           label=mock.ANY, widget=mock.ANY,
-                                           help_text=mock.ANY,
+                                           label=mock.ANY,
+                                           widget=mock.ANY,
                                            someattr='someattr')
 
     def test_field_with_required_filter(self):
@@ -137,8 +114,9 @@ class FilterTests(TestCase):
                                spec=['__call__']) as mocked:
             f = Filter(required=True)
             f.field
-            mocked.assert_called_once_with(required=True, label=mock.ANY,
-                                           widget=mock.ANY, help_text=mock.ANY)
+            mocked.assert_called_once_with(required=True,
+                                           label=mock.ANY,
+                                           widget=mock.ANY)
 
     def test_filtering(self):
         qs = mock.Mock(spec=['filter'])

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -78,7 +78,30 @@ class FilterSetFormTests(TestCase):
                 fields = ('title',)
 
         f = F().form
-        self.assertEqual(f.fields['title'].help_text, "This is an exclusion filter")
+        self.assertEqual(f.fields['title'].label, "Exclude title")
+
+    def test_complex_form_fields(self):
+        class F(FilterSet):
+            username = CharFilter(label='Filter for users with username')
+            exclude_username = CharFilter(name='username', lookup_expr='iexact', exclude=True)
+
+            class Meta:
+                model = User
+                fields = {
+                    'status': ['exact', 'lt', 'gt'],
+                    'favorite_books__title': ['iexact', 'in'],
+                    'manager_of__users__username': ['exact'],
+                }
+
+        fields = F().form.fields
+        self.assertEqual(fields['username'].label, 'Filter for users with username')
+        self.assertEqual(fields['exclude_username'].label, 'Exclude username')
+        self.assertEqual(fields['status'].label, 'Status')
+        self.assertEqual(fields['status__lt'].label, 'Status is less than')
+        self.assertEqual(fields['status__gt'].label, 'Status is greater than')
+        self.assertEqual(fields['favorite_books__title__iexact'].label, 'Favorite books title')
+        self.assertEqual(fields['favorite_books__title__in'].label, 'Favorite books title is in')
+        self.assertEqual(fields['manager_of__users__username'].label, 'Manager of users username')
 
     def test_form_fields_using_widget(self):
         class F(FilterSet):
@@ -118,8 +141,8 @@ class FilterSetFormTests(TestCase):
                 fields = ('book_title',)
 
         f = F().form
-        self.assertEqual(f.fields['book_title'].label, None)
-        self.assertEqual(f['book_title'].label, 'Book title')
+        self.assertEqual(f.fields['book_title'].label, "Title")
+        self.assertEqual(f['book_title'].label, "Title")
 
     def test_form_field_with_manual_name_and_label(self):
         class F(FilterSet):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from django import forms
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from django_filters.filterset import FilterSet
 from django_filters.filters import CharFilter
@@ -203,3 +203,24 @@ class FilterSetFormTests(TestCase):
         self.assertEqual(
             list(f.fields['manager'].choices), [('', '---------'), (3, 'manager')]
         )
+
+    def test_disabled_help_text(self):
+        class F(FilterSet):
+            class Meta:
+                model = Book
+                fields = {
+                    # 'in' lookups are CSV-based, which have a `help_text`.
+                    'title': ['in']
+                }
+
+        self.assertEqual(
+            F().form.fields['title__in'].help_text,
+            'Multiple values may be separated by commas.'
+        )
+
+        with override_settings(FILTERS_DISABLE_HELP_TEXT=True):
+
+            self.assertEqual(
+                F().form.fields['title__in'].help_text,
+                ''
+            )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,8 +5,9 @@ import django
 from django.test import TestCase
 from django.db import models
 from django.db.models.constants import LOOKUP_SEP
+from django.db.models.fields.related import ForeignObjectRel
 
-from django_filters.utils import get_model_field, resolve_field
+from django_filters.utils import get_field_parts, get_model_field, resolve_field
 from django_filters.exceptions import FieldLookupError
 
 from .models import User
@@ -14,6 +15,34 @@ from .models import Article
 from .models import Book
 from .models import HiredWorker
 from .models import Business
+
+
+class GetFieldPartsTests(TestCase):
+
+    def test_field(self):
+        parts = get_field_parts(User, 'username')
+
+        self.assertEqual(len(parts), 1)
+        self.assertIsInstance(parts[0], models.CharField)
+
+    def test_non_existent_field(self):
+        result = get_model_field(User, 'unknown__name')
+        self.assertIsNone(result)
+
+    def test_forwards_related_field(self):
+        parts = get_field_parts(User, 'favorite_books__title')
+
+        self.assertEqual(len(parts), 2)
+        self.assertIsInstance(parts[0], models.ManyToManyField)
+        self.assertIsInstance(parts[1], models.CharField)
+
+    def test_reverse_related_field(self):
+        parts = get_field_parts(User, 'manager_of__users__username')
+
+        self.assertEqual(len(parts), 3)
+        self.assertIsInstance(parts[0], ForeignObjectRel)
+        self.assertIsInstance(parts[1], models.ManyToManyField)
+        self.assertIsInstance(parts[2], models.CharField)
 
 
 class GetModelFieldTests(TestCase):


### PR DESCRIPTION
Hey @carltongibson - wanted to take a stab at improving the form output. In brief, the PR allows filters to automatically generate more verbose, human friendly labels to use in forms. Given the following... 

``` py
class ArticleFilter(FilterSet):
    exclude_author = CharFilter(name='author__name', lookup_expr='istartswith', exclude=True)

    class Meta:
        model = Article
        fields = {
            'author__name': ['exact'],
            'published': ['exact', 'date__lt', 'date__gt', ],
        }
```

This would generate default filter labels such as "Exclude author name starts with" and "Published date is less than". It's not perfect, but it should convey enough information and be suitable for DRF's filter integration.
---

**Context:**
The current form implementation works well for the `Meta.fields` list syntax, but kind of falls apart when it comes to the dict syntax. From the above example, there are a few issues:
- Field name translation does not traverse relationships for `Meta.fields`. Instead of 'author first name', we just get 'first name', which doesn't make sense as it is not an attribute on the book model. This is even worse for shared fields, such as 'id' - no way to differentiate between the book 'id' and author 'id' labels.
- Lookup expressions are not taken into account. This doesn't matter for the list syntax, since there is just the one 'exact' lookup, but this doesn't work with multiple lookups per field. All of the published filter labels just read 'published'.
- Oddly enough, these issues also affect the ordering field for both with the `Meta.fields` dict syntax and with declarative filters. Ordering is kind of borked - only really works with the `Meta.fields` list syntax.
- Additionally, not a fan with the current `help_text` for filters. 
  - The 'Filter' `help_text` doesn't add any meaningful context. See #422 and DRF's default FilterSet, which comments them out.
  - The 'This is an exclusion filter' is useful, but could instead be handled in the label, as seen above.
  - `help_text` should provide additional context about usage. eg, CSV filters indicating that the expected input should be comma-separated.

**Change list:**
- Add default label generation to the `Filter` class.
- FilterSet no longer generates labels for filters.
- Existing 'Filter'/'Exclude' `help_text` has been removed. 
- Added settings conf. Based on DRF's app settings, but a little simpler.
- `FILTERS_VERBOSE_LABELS` is a dict (or callable that resolves to a dict) of lookup expressions mapped to verbose expressions. eg, {'exact': 'is equal to'}. 
- `FILTERS_HELP_TEXT_FILTER` and `FILTERS_HELP_TEXT_EXCLUDE` have been removed. 
- Added 'Values should be comma-separated' `help_text` to the base CSV filter.

**Misc notes:**
- The 'exact' lookup has an empty verbose text. This was to maintain better consistency with the existing labels you'd see with the `Meta.fields` list syntax. eg, 'Author name' instead of 'Author name is equal to'. 
- Case-insensitive lookups have the same verbose text as their case-sensitive counterparts. 
  - I couldn't think of a terse way of differentiating the former. 
  - Does it matter? Would you typically expose both lookups? If a user needs to differentiate, they can always override `FILTERS_VERBOSE_LOOKUPS`. 

**Questions:**
At this point, the PR is 'feature complete' and tested, but there are a couple of issues/questions.
- [x] ~~The ordering field is somewhat borked (more details in #438), and the label changes exacerbate this. Currently, one test is failing. Should the PR temporarily mark the test as an expected failure (to be fixed in a separate PR), or should this PR grow in scope and fix ordering field?~~ Separate PR merged.
- [x] ~~Should there be a usage warning that `FILTERS_HELP_TEXT_FILTER` and `FILTERS_HELP_TEXT_EXCLUDE` no longer have effect?~~ Separate PR merged.
- [ ] Should `LookupTypeField` be integrated with the `FILTERS_VERBOSE_LOOKUPS` setting? (Probably could be handled as a separate PR).
- [ ] Are the verbose labels satisfactory for the current lookups?
  - [ ] Is the lack of differentiating text for case-insensitive lookups okay? 

**TODO:**
- [x] fix ordering field test
- [x] remove DRF filterset `help_text` removal
- [x] document settings deprecations / new settings (callable or dict-like).
