### PR TITLE
Revert #59, deprecate proxied queryset methods

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -304,6 +304,10 @@ class BaseFilterSet(object):
         warnings.warn('FilterSet no longer emulates a container. Perform lookups on .qs instead.', DeprecationWarning, stacklevel=2)
         return self.qs[key]
 
+    def count(self):
+        warnings.warn('FilterSet no longer emulates a container. Call .qs.count() instead.', DeprecationWarning, stacklevel=2)
+        return self.qs.count()
+
     @property
     def qs(self):
         if not hasattr(self, '_qs'):
@@ -358,9 +362,6 @@ class BaseFilterSet(object):
             self._qs = qs
 
         return self._qs
-
-    def count(self):
-        return self.qs.count()
 
     @property
     def form(self):

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import copy
 import re
+import warnings
 from collections import OrderedDict
 
 from django import forms
@@ -291,13 +292,16 @@ class BaseFilterSet(object):
             filter_.parent = self
 
     def __iter__(self):
+        warnings.warn('FilterSet no longer emulates a container. Iterate over .qs instead.', DeprecationWarning, stacklevel=2)
         for obj in self.qs:
             yield obj
 
     def __len__(self):
+        warnings.warn('FilterSet no longer emulates a container. Get the length of .qs instead.', DeprecationWarning, stacklevel=2)
         return self.qs.count()
 
     def __getitem__(self, key):
+        warnings.warn('FilterSet no longer emulates a container. Perform lookups on .qs instead.', DeprecationWarning, stacklevel=2)
         return self.qs[key]
 
     @property

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -27,6 +27,12 @@ from .utils import try_dbfield, get_model_field, resolve_field
 ORDER_BY_FIELD = 'o'
 
 
+def deprecate(msg):
+    warnings.warn(
+        "%s See: https://django-filter.readthedocs.io/en/latest/migration.html" % msg,
+        DeprecationWarning, stacklevel=3)
+
+
 class STRICTNESS(object):
     """
     Values of False & True chosen for backward compatability reasons.
@@ -292,20 +298,20 @@ class BaseFilterSet(object):
             filter_.parent = self
 
     def __iter__(self):
-        warnings.warn('FilterSet no longer emulates a container. Iterate over .qs instead.', DeprecationWarning, stacklevel=2)
+        deprecate('QuerySet methods are no longer proxied.')
         for obj in self.qs:
             yield obj
 
     def __len__(self):
-        warnings.warn('FilterSet no longer emulates a container. Get the length of .qs instead.', DeprecationWarning, stacklevel=2)
+        deprecate('QuerySet methods are no longer proxied.')
         return self.qs.count()
 
     def __getitem__(self, key):
-        warnings.warn('FilterSet no longer emulates a container. Perform lookups on .qs instead.', DeprecationWarning, stacklevel=2)
+        deprecate('QuerySet methods are no longer proxied.')
         return self.qs[key]
 
     def count(self):
-        warnings.warn('FilterSet no longer emulates a container. Call .qs.count() instead.', DeprecationWarning, stacklevel=2)
+        deprecate('QuerySet methods are no longer proxied.')
         return self.qs.count()
 
     @property

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -19,4 +19,5 @@ Contents:
     ref/fields
     ref/widgets
     ref/settings
+    migration
     tests

--- a/docs/migration.txt
+++ b/docs/migration.txt
@@ -1,0 +1,29 @@
+Migrating to 1.0
+================
+
+The 1.0 release of django-filter introduces several API changes and refinements
+that break forwards compatibility. Below is a list of deprecations and
+instructions on how to migrate to the 1.0 release. A forwards-compatible 0.15
+release has also been created to help with migration. It is compatible with
+both the existing and new APIs and will raise warnings for deprecated behavior.
+
+
+QuerySet methods are no longer proxied
+--------------------------------------
+Details: https://github.com/carltongibson/django-filter/pull/440
+
+The ``__iter__()``, ``__len__()``, ``__getitem__()``, ``count()`` methods are
+no longer proxied from the queryset. To fix this, call the methods on the
+``.qs`` property itself.
+
+.. code-block:: python
+
+    f = UserFilter(request.GET, queryset=User.objects.all())
+
+    # 0.x
+    for obj in f:
+        ...
+
+    # 1.0
+    for obj in f.qs:
+        ...

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -339,13 +339,13 @@ And lastly we need a template::
             {{ filter.form.as_p }}
             <input type="submit" />
         </form>
-        {% for obj in filter %}
+        {% for obj in filter.qs %}
             {{ obj.name }} - ${{ obj.price }}<br />
         {% endfor %}
     {% endblock %}
 
 And that's all there is to it!  The ``form`` attribute contains a normal
-Django form, and when we iterate over the ``FilterSet`` we get the objects in
+Django form, and when we iterate over the ``FilterSet.qs`` we get the objects in
 the resulting queryset.
 
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -58,18 +58,6 @@ class User(models.Model):
     def __str__(self):
         return self.username
 
-@python_2_unicode_compatible
-class UsersOfManager(models.Model):
-    users = models.ManyToManyField(User,
-                                   limit_choices_to={'is_active': True},
-                                   related_name='users_of_manager')
-    manager = models.ForeignKey(User,
-                                limit_choices_to=lambda: {'status': 1},
-                                related_name='his_users')
-
-    def __str__(self):
-        return self.manager.name + '_group'
-
 
 @python_2_unicode_compatible
 class ManagerGroup(models.Model):

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,0 +1,41 @@
+
+import warnings
+from django.test import TestCase
+
+from django_filters import FilterSet
+from .models import User
+
+
+class UserFilter(FilterSet):
+    class Meta:
+        model = User
+
+
+class FilterSetContainerDeprecationTests(TestCase):
+
+    def test__iter__notification(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            [obj for obj in UserFilter()]
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+    def test__getitem__notification(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            with self.assertRaises(IndexError):
+                UserFilter()[0]
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+    def test__len__notification(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            len(UserFilter())
+
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -39,3 +39,11 @@ class FilterSetContainerDeprecationTests(TestCase):
             len(UserFilter())
 
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+    def test__count__notification(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            UserFilter().count()
+
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1524,27 +1524,27 @@ class CSVFilterTests(TestCase):
         qs = User.objects.all()
         f = F(queryset=qs)
         self.assertEqual(len(f.qs), 4)
-        self.assertEqual(f.count(), 4)
+        self.assertEqual(f.qs.count(), 4)
 
         f = F({'status__in': ''}, queryset=qs)
         self.assertEqual(len(f.qs), 0)
-        self.assertEqual(f.count(), 0)
+        self.assertEqual(f.qs.count(), 0)
 
         f = F({'status__in': '0'}, queryset=qs)
         self.assertEqual(len(f.qs), 1)
-        self.assertEqual(f.count(), 1)
+        self.assertEqual(f.qs.count(), 1)
 
         f = F({'status__in': '0,2'}, queryset=qs)
         self.assertEqual(len(f.qs), 3)
-        self.assertEqual(f.count(), 3)
+        self.assertEqual(f.qs.count(), 3)
 
         f = F({'status__in': '0,,1'}, queryset=qs)
         self.assertEqual(len(f.qs), 2)
-        self.assertEqual(f.count(), 2)
+        self.assertEqual(f.qs.count(), 2)
 
         f = F({'status__in': '2'}, queryset=qs)
         self.assertEqual(len(f.qs), 2)
-        self.assertEqual(f.count(), 2)
+        self.assertEqual(f.qs.count(), 2)
 
     def test_string_filtering(self):
         F = self.user_filter
@@ -1552,27 +1552,27 @@ class CSVFilterTests(TestCase):
         qs = User.objects.all()
         f = F(queryset=qs)
         self.assertEqual(len(f.qs), 4)
-        self.assertEqual(f.count(), 4)
+        self.assertEqual(f.qs.count(), 4)
 
         f = F({'username__in': ''}, queryset=qs)
         self.assertEqual(len(f.qs), 0)
-        self.assertEqual(f.count(), 0)
+        self.assertEqual(f.qs.count(), 0)
 
         f = F({'username__in': 'alex'}, queryset=qs)
         self.assertEqual(len(f.qs), 1)
-        self.assertEqual(f.count(), 1)
+        self.assertEqual(f.qs.count(), 1)
 
         f = F({'username__in': 'alex,aaron'}, queryset=qs)
         self.assertEqual(len(f.qs), 2)
-        self.assertEqual(f.count(), 2)
+        self.assertEqual(f.qs.count(), 2)
 
         f = F({'username__in': 'alex,,aaron'}, queryset=qs)
         self.assertEqual(len(f.qs), 2)
-        self.assertEqual(f.count(), 2)
+        self.assertEqual(f.qs.count(), 2)
 
         f = F({'username__in': 'alex,'}, queryset=qs)
         self.assertEqual(len(f.qs), 1)
-        self.assertEqual(f.count(), 1)
+        self.assertEqual(f.qs.count(), 1)
 
     def test_datetime_filtering(self):
         F = self.article_filter
@@ -1582,27 +1582,27 @@ class CSVFilterTests(TestCase):
         qs = Article.objects.all()
         f = F(queryset=qs)
         self.assertEqual(len(f.qs), 4)
-        self.assertEqual(f.count(), 4)
+        self.assertEqual(f.qs.count(), 4)
 
         f = F({'published__in': ''}, queryset=qs)
         self.assertEqual(len(f.qs), 0)
-        self.assertEqual(f.count(), 0)
+        self.assertEqual(f.qs.count(), 0)
 
         f = F({'published__in': '%s' % (after, )}, queryset=qs)
         self.assertEqual(len(f.qs), 2)
-        self.assertEqual(f.count(), 2)
+        self.assertEqual(f.qs.count(), 2)
 
         f = F({'published__in': '%s,%s' % (after, before, )}, queryset=qs)
         self.assertEqual(len(f.qs), 4)
-        self.assertEqual(f.count(), 4)
+        self.assertEqual(f.qs.count(), 4)
 
         f = F({'published__in': '%s,,%s' % (after, before, )}, queryset=qs)
         self.assertEqual(len(f.qs), 4)
-        self.assertEqual(f.count(), 4)
+        self.assertEqual(f.qs.count(), 4)
 
         f = F({'published__in': '%s,' % (after, )}, queryset=qs)
         self.assertEqual(len(f.qs), 2)
-        self.assertEqual(f.count(), 2)
+        self.assertEqual(f.qs.count(), 2)
 
     def test_related_filtering(self):
         F = self.article_filter
@@ -1610,27 +1610,27 @@ class CSVFilterTests(TestCase):
         qs = Article.objects.all()
         f = F(queryset=qs)
         self.assertEqual(len(f.qs), 4)
-        self.assertEqual(f.count(), 4)
+        self.assertEqual(f.qs.count(), 4)
 
         f = F({'author__in': ''}, queryset=qs)
         self.assertEqual(len(f.qs), 0)
-        self.assertEqual(f.count(), 0)
+        self.assertEqual(f.qs.count(), 0)
 
         f = F({'author__in': '1'}, queryset=qs)
         self.assertEqual(len(f.qs), 2)
-        self.assertEqual(f.count(), 2)
+        self.assertEqual(f.qs.count(), 2)
 
         f = F({'author__in': '1,2'}, queryset=qs)
         self.assertEqual(len(f.qs), 4)
-        self.assertEqual(f.count(), 4)
+        self.assertEqual(f.qs.count(), 4)
 
         f = F({'author__in': '1,,2'}, queryset=qs)
         self.assertEqual(len(f.qs), 4)
-        self.assertEqual(f.count(), 4)
+        self.assertEqual(f.qs.count(), 4)
 
         f = F({'author__in': '1,'}, queryset=qs)
         self.assertEqual(len(f.qs), 2)
-        self.assertEqual(f.count(), 2)
+        self.assertEqual(f.qs.count(), 2)
 
 
 class MiscFilterSetTests(TestCase):
@@ -1706,19 +1706,19 @@ class MiscFilterSetTests(TestCase):
         qs = User.objects.all()
         f = F(queryset=qs)
         self.assertEqual(len(f.qs), 4)
-        self.assertEqual(f.count(), 4)
+        self.assertEqual(f.qs.count(), 4)
 
         f = F({'status': '0'}, queryset=qs)
         self.assertEqual(len(f.qs), 1)
-        self.assertEqual(f.count(), 1)
+        self.assertEqual(f.qs.count(), 1)
 
         f = F({'status': '1'}, queryset=qs)
         self.assertEqual(len(f.qs), 1)
-        self.assertEqual(f.count(), 1)
+        self.assertEqual(f.qs.count(), 1)
 
         f = F({'status': '2'}, queryset=qs)
         self.assertEqual(len(f.qs), 2)
-        self.assertEqual(f.count(), 2)
+        self.assertEqual(f.qs.count(), 2)
 
     def test_invalid_field_lookup(self):
         # We want to ensure that non existent lookups (or just simple misspellings)

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -844,9 +844,9 @@ class AllValuesFilterTests(TestCase):
                 fields = ['username']
 
         self.assertEqual(list(F().qs), list(User.objects.all()))
-        self.assertEqual(list(F({'username': 'alex'})),
+        self.assertEqual(list(F({'username': 'alex'}).qs),
                          [User.objects.get(username='alex')])
-        self.assertEqual(list(F({'username': 'jose'})),
+        self.assertEqual(list(F({'username': 'jose'}).qs),
                          list())
 
     def test_filtering_without_strict(self):
@@ -863,9 +863,9 @@ class AllValuesFilterTests(TestCase):
                 fields = ['username']
 
         self.assertEqual(list(F().qs), list(User.objects.all()))
-        self.assertEqual(list(F({'username': 'alex'})),
+        self.assertEqual(list(F({'username': 'alex'}).qs),
                          [User.objects.get(username='alex')])
-        self.assertEqual(list(F({'username': 'jose'})),
+        self.assertEqual(list(F({'username': 'jose'}).qs),
                          list(User.objects.all()))
 
 
@@ -889,9 +889,9 @@ class MethodFilterTests(TestCase):
                 )
 
         self.assertEqual(list(F().qs), list(User.objects.all()))
-        self.assertEqual(list(F({'username': 'alex'})),
+        self.assertEqual(list(F({'username': 'alex'}).qs),
                          [User.objects.get(username='alex')])
-        self.assertEqual(list(F({'username': 'jose'})),
+        self.assertEqual(list(F({'username': 'jose'}).qs),
                          list())
 
     def test_filtering_external(self):
@@ -912,9 +912,9 @@ class MethodFilterTests(TestCase):
                 fields = ['username']
 
         self.assertEqual(list(F().qs), list(User.objects.all()))
-        self.assertEqual(list(F({'username': 'alex'})),
+        self.assertEqual(list(F({'username': 'alex'}).qs),
                          [User.objects.get(username='alex')])
-        self.assertEqual(list(F({'username': 'jose'})),
+        self.assertEqual(list(F({'username': 'jose'}).qs),
                          list())
 
 
@@ -936,13 +936,13 @@ class MethodFilterTests(TestCase):
                 )
 
         self.assertEqual(list(F().qs), list(User.objects.all()))
-        self.assertEqual(list(F({'username': 'mike'})),
+        self.assertEqual(list(F({'username': 'mike'}).qs),
                          [User.objects.get(username='mike'),
                           User.objects.get(username='jake')],)
-        self.assertEqual(list(F({'username': 'jake'})),
+        self.assertEqual(list(F({'username': 'jake'}).qs),
                          [User.objects.get(username='mike'),
                           User.objects.get(username='jake')])
-        self.assertEqual(list(F({'username': 'aaron'})),
+        self.assertEqual(list(F({'username': 'aaron'}).qs),
                          [User.objects.get(username='mike'),
                           User.objects.get(username='jake')])
 
@@ -961,11 +961,11 @@ class MethodFilterTests(TestCase):
                 fields = ['username']
 
         self.assertEqual(list(F().qs), list(User.objects.all()))
-        self.assertEqual(list(F({'username': 'mike'})),
+        self.assertEqual(list(F({'username': 'mike'}).qs),
                          list(User.objects.all()))
-        self.assertEqual(list(F({'username': 'jake'})),
+        self.assertEqual(list(F({'username': 'jake'}).qs),
                          list(User.objects.all()))
-        self.assertEqual(list(F({'username': 'aaron'})),
+        self.assertEqual(list(F({'username': 'aaron'}).qs),
                          list(User.objects.all()))
 
 

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -719,7 +719,6 @@ class FilterSetOrderingTests(TestCase):
             f.qs, ['carl', 'alex', 'aaron', 'jacob'], lambda o: o.username)
 
 
-
 class FilterSetTogetherTests(TestCase):
 
     def setUp(self):
@@ -759,3 +758,20 @@ class FilterSetTogetherTests(TestCase):
         f = F({'username': 'alex', 'status': 1}, queryset=self.qs)
         self.assertEqual(f.qs.count(), 1)
         self.assertQuerysetEqual(f.qs, [self.alex.pk], lambda o: o.pk)
+
+
+@unittest.skip('remove when relevant deprecations have been completed')
+class MiscFilterSetTests(TestCase):
+
+    def test_no__getitem__(self):
+        # The DTL processes variable lookups by the following rules:
+        # https://docs.djangoproject.com/en/1.9/ref/templates/language/#variables
+        # A __getitem__ implementation precedes normal attribute access, and in
+        # the case of #58, will force the queryset to evaluate when it should
+        # not (eg, when rendering a blank form).
+        self.assertFalse(hasattr(FilterSet, '__getitem__'))
+
+    def test_no_qs_proxying(self):
+        # The FilterSet should not proxy .qs methods - just access .qs directly
+        self.assertFalse(hasattr(FilterSet, '__len__'))
+        self.assertFalse(hasattr(FilterSet, '__iter__'))


### PR DESCRIPTION
This originally aimed at just fixing #439, but includes deprecating the container-like methods on FilterSet,  `__iter__`, `__len__`, and `__getitem__`, which are proxied from the queryset.

While it may be a convenience to iterate directly over a FilterSet instance, as seen with `__getitem__` in #439, you can run into weird interactions. I'd argue that the FilterSet should not be container-like. Instead, users should directly access `.qs`.

Side note:
`__getitem__` was originally added in #59 to add django-pagination integration, but the project seems to be defunct (last updated in 2010). No relevant tests or docs on the integration.
