### PR TITLE
Default to only creating ChoiceFilter for exact lookups

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -471,6 +471,9 @@ class BaseFilterSet(object):
             return None, {}
 
         # perform lookup specific checks
+        if lookup_type == 'exact' and f.choices:
+            return ChoiceFilter, {'choices': f.choices}
+
         if lookup_type == 'isnull':
             data = try_dbfield(DEFAULTS.get, models.BooleanField)
 
@@ -495,10 +498,6 @@ class BaseFilterSet(object):
             )
 
             return ConcreteRangeFilter, params
-
-        # Default behavior
-        if f.choices:
-            return ChoiceFilter, {'choices': f.choices}
 
         return filter_class, params
 


### PR DESCRIPTION
`ChoiceFilter`s are currently generated for fields with choices, regardless of the lookup type. https://github.com/carltongibson/django-filter/blob/v0.13/django_filters/filterset.py#L490-L491

This makes sense for `exact` lookups, but does not work for `icontains` or `startswith` as the filter value will (probably) not be in the field's choices.

More context [here](https://github.com/philipn/django-rest-framework-filters/issues/88#issuecomment-234622226)