### PR TITLE
Update Django and Python versions in testing matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache: pip
 
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
@@ -29,10 +28,6 @@ notifications:
 
 matrix:
   exclude:
-    - python: "3.2"
-      env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
-    - python: "3.2"
-      env: DJANGO='django>=1.9.0,<1.10.0'
     - python: "3.3"
       env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
     - python: "3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ python:
 
 env:
   - DJANGO='https://github.com/django/django/archive/master.tar.gz'
+  - DJANGO='django>=1.10.0,<1.11.0'
   - DJANGO='django>=1.9.0,<1.10.0'
   - DJANGO='django>=1.8.0,<1.9.0'
 
@@ -30,6 +31,8 @@ matrix:
   exclude:
     - python: "3.3"
       env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
+    - python: "3.3"
+      env: DJANGO='django>=1.10.0,<1.11.0'
     - python: "3.3"
       env: DJANGO='django>=1.9.0,<1.10.0'
   allow_failures:

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Requirements
 ------------
 
 * Python 2.7, 3.3, 3.4, 3.5
-* Django 1.8, 1.9
+* Django 1.8, 1.9, 1.10
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Full documentation on `read the docs`_.
 Requirements
 ------------
 
-* Python 2.7, 3.2, 3.3, 3.4, 3.5
+* Python 2.7, 3.3, 3.4, 3.5
 * Django 1.8, 1.9
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
        {py27,py33,py34,py35}-django18,
-       {py27,py34,py35}-django19,
+       {py27,py34,py35}-django{19,110},
        {py27,py34,py35}-django-latest
 
 
@@ -19,5 +19,6 @@ setenv =
 deps =
     django18: django>=1.8.0,<1.9.0
     django19: django>=1.9.0,<1.10.0
+    django110: django>=1.10.0,<1.11.0
     django-latest: https://github.com/django/django/archive/master.tar.gz
     -rrequirements/test.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-       {py27,py32,py33,py34}-django{17,18},
+       {py27,py33,py34}-django{17,18},
        {py27,py34,py35}-django19,
        {py27,py34,py35}-django-latest
 
@@ -8,7 +8,6 @@ envlist =
 [testenv]
 basepython =
              py27: python2.7
-             py32: python3.2
              py33: python3.3
              py34: python3.4
              py35: python3.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-       {py27,py33,py34}-django{17,18},
+       {py27,py33,py34}-django18,
        {py27,py34,py35}-django19,
        {py27,py34,py35}-django-latest
 
@@ -17,7 +17,6 @@ commands = ./runtests.py
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
-    django17: django>=1.7.0,<1.8.0
     django18: django>=1.8.0,<1.9.0
     django19: django>=1.9.0,<1.10.0
     django-latest: https://github.com/django/django/archive/master.tar.gz

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-       {py27,py33,py34}-django18,
+       {py27,py33,py34,py35}-django18,
        {py27,py34,py35}-django19,
        {py27,py34,py35}-django-latest
 


### PR DESCRIPTION
* Stop testing on Python 3.2 (since it's [no longer supported](https://docs.python.org/devguide/#status-of-python-branches) as of 2016-02-20)
* Remove Django 1.7 remnants (these were left behind when Django 1.7 was removed from Travis testing)
* Add a Django 1.8+Python 3.5 combo to the Tox config (this was already being tested on Travis)
* Test on Django 1.10