### PR TITLE
Fix empty value for csv filter

### DIFF
--- a/django_filters/widgets.py
+++ b/django_filters/widgets.py
@@ -144,6 +144,8 @@ class CSVWidget(forms.TextInput):
         value = super(CSVWidget, self).value_from_datadict(data, files, name)
 
         if value is not None:
+            if value == '':  # empty value should parse as an empty list
+                return []
             return value.split(',')
         return None
 

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1526,6 +1526,9 @@ class CSVFilterTests(TestCase):
         self.assertEqual(f.qs.count(), 4)
 
         f = F({'status__in': ''}, queryset=qs)
+        self.assertEqual(f.qs.count(), 4)
+
+        f = F({'status__in': ','}, queryset=qs)
         self.assertEqual(f.qs.count(), 0)
 
         f = F({'status__in': '0'}, queryset=qs)
@@ -1548,6 +1551,9 @@ class CSVFilterTests(TestCase):
         self.assertEqual(f.qs.count(), 4)
 
         f = F({'username__in': ''}, queryset=qs)
+        self.assertEqual(f.qs.count(), 4)
+
+        f = F({'username__in': ','}, queryset=qs)
         self.assertEqual(f.qs.count(), 0)
 
         f = F({'username__in': 'alex'}, queryset=qs)
@@ -1573,6 +1579,9 @@ class CSVFilterTests(TestCase):
         self.assertEqual(f.qs.count(), 4)
 
         f = F({'published__in': ''}, queryset=qs)
+        self.assertEqual(f.qs.count(), 4)
+
+        f = F({'published__in': ','}, queryset=qs)
         self.assertEqual(f.qs.count(), 0)
 
         f = F({'published__in': '%s' % (after, )}, queryset=qs)
@@ -1595,6 +1604,9 @@ class CSVFilterTests(TestCase):
         self.assertEqual(f.qs.count(), 4)
 
         f = F({'author__in': ''}, queryset=qs)
+        self.assertEqual(f.qs.count(), 4)
+
+        f = F({'author__in': ','}, queryset=qs)
         self.assertEqual(f.qs.count(), 0)
 
         f = F({'author__in': '1'}, queryset=qs)

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1523,27 +1523,21 @@ class CSVFilterTests(TestCase):
 
         qs = User.objects.all()
         f = F(queryset=qs)
-        self.assertEqual(len(f.qs), 4)
         self.assertEqual(f.qs.count(), 4)
 
         f = F({'status__in': ''}, queryset=qs)
-        self.assertEqual(len(f.qs), 0)
         self.assertEqual(f.qs.count(), 0)
 
         f = F({'status__in': '0'}, queryset=qs)
-        self.assertEqual(len(f.qs), 1)
         self.assertEqual(f.qs.count(), 1)
 
         f = F({'status__in': '0,2'}, queryset=qs)
-        self.assertEqual(len(f.qs), 3)
         self.assertEqual(f.qs.count(), 3)
 
         f = F({'status__in': '0,,1'}, queryset=qs)
-        self.assertEqual(len(f.qs), 2)
         self.assertEqual(f.qs.count(), 2)
 
         f = F({'status__in': '2'}, queryset=qs)
-        self.assertEqual(len(f.qs), 2)
         self.assertEqual(f.qs.count(), 2)
 
     def test_string_filtering(self):
@@ -1551,27 +1545,21 @@ class CSVFilterTests(TestCase):
 
         qs = User.objects.all()
         f = F(queryset=qs)
-        self.assertEqual(len(f.qs), 4)
         self.assertEqual(f.qs.count(), 4)
 
         f = F({'username__in': ''}, queryset=qs)
-        self.assertEqual(len(f.qs), 0)
         self.assertEqual(f.qs.count(), 0)
 
         f = F({'username__in': 'alex'}, queryset=qs)
-        self.assertEqual(len(f.qs), 1)
         self.assertEqual(f.qs.count(), 1)
 
         f = F({'username__in': 'alex,aaron'}, queryset=qs)
-        self.assertEqual(len(f.qs), 2)
         self.assertEqual(f.qs.count(), 2)
 
         f = F({'username__in': 'alex,,aaron'}, queryset=qs)
-        self.assertEqual(len(f.qs), 2)
         self.assertEqual(f.qs.count(), 2)
 
         f = F({'username__in': 'alex,'}, queryset=qs)
-        self.assertEqual(len(f.qs), 1)
         self.assertEqual(f.qs.count(), 1)
 
     def test_datetime_filtering(self):
@@ -1585,23 +1573,18 @@ class CSVFilterTests(TestCase):
         self.assertEqual(f.qs.count(), 4)
 
         f = F({'published__in': ''}, queryset=qs)
-        self.assertEqual(len(f.qs), 0)
         self.assertEqual(f.qs.count(), 0)
 
         f = F({'published__in': '%s' % (after, )}, queryset=qs)
-        self.assertEqual(len(f.qs), 2)
         self.assertEqual(f.qs.count(), 2)
 
         f = F({'published__in': '%s,%s' % (after, before, )}, queryset=qs)
-        self.assertEqual(len(f.qs), 4)
         self.assertEqual(f.qs.count(), 4)
 
         f = F({'published__in': '%s,,%s' % (after, before, )}, queryset=qs)
-        self.assertEqual(len(f.qs), 4)
         self.assertEqual(f.qs.count(), 4)
 
         f = F({'published__in': '%s,' % (after, )}, queryset=qs)
-        self.assertEqual(len(f.qs), 2)
         self.assertEqual(f.qs.count(), 2)
 
     def test_related_filtering(self):
@@ -1609,27 +1592,21 @@ class CSVFilterTests(TestCase):
 
         qs = Article.objects.all()
         f = F(queryset=qs)
-        self.assertEqual(len(f.qs), 4)
         self.assertEqual(f.qs.count(), 4)
 
         f = F({'author__in': ''}, queryset=qs)
-        self.assertEqual(len(f.qs), 0)
         self.assertEqual(f.qs.count(), 0)
 
         f = F({'author__in': '1'}, queryset=qs)
-        self.assertEqual(len(f.qs), 2)
         self.assertEqual(f.qs.count(), 2)
 
         f = F({'author__in': '1,2'}, queryset=qs)
-        self.assertEqual(len(f.qs), 4)
         self.assertEqual(f.qs.count(), 4)
 
         f = F({'author__in': '1,,2'}, queryset=qs)
-        self.assertEqual(len(f.qs), 4)
         self.assertEqual(f.qs.count(), 4)
 
         f = F({'author__in': '1,'}, queryset=qs)
-        self.assertEqual(len(f.qs), 2)
         self.assertEqual(f.qs.count(), 2)
 
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -212,9 +212,17 @@ class CSVWidgetTests(TestCase):
         result = w.value_from_datadict(data, {}, 'price')
         self.assertEqual(result, ['1', '', '2'])
 
+        data = {'price': '1,'}
+        result = w.value_from_datadict(data, {}, 'price')
+        self.assertEqual(result, ['1', ''])
+
+        data = {'price': ','}
+        result = w.value_from_datadict(data, {}, 'price')
+        self.assertEqual(result, ['', ''])
+
         data = {'price': ''}
         result = w.value_from_datadict(data, {}, 'price')
-        self.assertEqual(result, [''])
+        self.assertEqual(result, [])
 
         result = w.value_from_datadict({}, {}, 'price')
         self.assertEqual(result, None)


### PR DESCRIPTION
More context at https://stackoverflow.com/questions/38645495

Filtering on `param=` is usually skipped via empty value checking. The CSV widget is incorrectly parsing blank values as `['']`, which then bypasses the empty check on the filter and results in filtering against the empty value. 