### PR TITLE
Move filter options to Meta class

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -154,6 +154,7 @@ class FilterSetOptions(object):
         self.filter_overrides = getattr(options, 'filter_overrides', {})
 
         self.order_by = getattr(options, 'order_by', False)
+        self.order_by_field = getattr(options, 'order_by_field', ORDER_BY_FIELD)
 
         self.strict = getattr(options, 'strict', STRICTNESS.RETURN_NO_RESULTS)
 
@@ -199,6 +200,10 @@ class FilterSetMetaclass(type):
         if hasattr(new_class, 'strict'):
             deprecate('strict has been deprecated. Use Meta.strict instead.')
             new_class._meta.strict = new_class.strict
+
+        if hasattr(new_class, 'order_by_field'):
+            deprecate('order_by_field has been moved to the Meta class.')
+            new_class._meta.order_by_field = new_class.order_by_field
 
         new_class.declared_filters = declared_filters
         new_class.base_filters = filters
@@ -296,8 +301,6 @@ FILTER_FOR_DBFIELD_DEFAULTS = {
 
 
 class BaseFilterSet(object):
-    order_by_field = ORDER_BY_FIELD
-
     def __init__(self, data=None, queryset=None, prefix=None, strict=None):
         self.is_bound = data is not None
         self.data = data or {}
@@ -370,8 +373,8 @@ class BaseFilterSet(object):
                     qs = filter_.filter(qs, value)
 
             if self._meta.order_by:
-                order_field = self.form.fields[self.order_by_field]
-                data = self.form[self.order_by_field].data
+                order_field = self.form.fields[self._meta.order_by_field]
+                data = self.form[self._meta.order_by_field].data
                 ordered_value = None
                 try:
                     ordered_value = order_field.clean(data)
@@ -381,7 +384,7 @@ class BaseFilterSet(object):
                 # With a None-queryset, ordering must be enforced (#84).
                 if (ordered_value in EMPTY_VALUES and
                         self.strict == STRICTNESS.RETURN_NO_RESULTS):
-                    ordered_value = self.form.fields[self.order_by_field].choices[0][0]
+                    ordered_value = self.form.fields[self._meta.order_by_field].choices[0][0]
 
                 if ordered_value:
                     qs = qs.order_by(*self.get_order_by(ordered_value))
@@ -396,7 +399,7 @@ class BaseFilterSet(object):
             fields = OrderedDict([
                 (name, filter_.field)
                 for name, filter_ in six.iteritems(self.filters)])
-            fields[self.order_by_field] = self.ordering_field
+            fields[self._meta.order_by_field] = self.ordering_field
             Form = type(str('%sForm' % self.__class__.__name__),
                         (self._meta.form,), fields)
             if self._meta.together:

--- a/docs/migration.txt
+++ b/docs/migration.txt
@@ -52,3 +52,33 @@ the ``Meta.exclude`` attribute.
         class Meta:
             model = User
             exclude = ['password']
+
+
+Move FilterSet options to Meta class
+------------------------------------
+Details: https://github.com/carltongibson/django-filter/issues/430
+
+Several ``FilterSet`` options have been moved to the ``Meta`` class to prevent
+potential conflicts with declared filter names. This includes:
+
+* ``filter_overrides``
+* ``strict``
+* ``order_by_field``
+
+.. code-block:: python
+
+    # 0.x
+    class UserFilter(FilterSet):
+        filter_overrides = {}
+        strict = STRICTNESS.RAISE_VALIDATION_ERROR
+        order_by_field = 'order'
+        ...
+
+    # 1.0
+    class UserFilter(FilterSet):
+        ...
+
+        class Meta:
+            filter_overrides = {}
+            strict = STRICTNESS.RAISE_VALIDATION_ERROR
+            order_by_field = 'order'

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -106,3 +106,25 @@ class FilterSetMetaDeprecationTests(TestCase):
             self.assertIn("Not setting Meta.fields with Meta.model is undocumented behavior", str(w[-1].message))
 
         self.assertEqual(list(F.base_filters.keys()), ['ip', 'mask'])
+
+
+class StrictnessDeprecationTests(TestCase):
+    def test_notification(self):
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                strict = False
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+    def test_passthrough(self):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                strict = False
+
+            self.assertEqual(F._meta.strict, False)

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -161,3 +161,25 @@ class FilterOverridesDeprecationTests(TestCase):
         })
 
         self.assertEqual(list(F.base_filters.keys()), ['ip', 'mask'])
+
+
+class OrderByFieldDeprecationTests(TestCase):
+    def test_notification(self):
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                order_by_field = 'field'
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+    def test_passthrough(self):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                order_by_field = 'field'
+
+            self.assertEqual(F._meta.order_by_field, 'field')

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -857,11 +857,11 @@ class AllValuesFilterTests(TestCase):
 
         class F(FilterSet):
             username = AllValuesFilter()
-            strict = False
 
             class Meta:
                 model = User
                 fields = ['username']
+                strict = False
 
         self.assertEqual(list(F().qs), list(User.objects.all()))
         self.assertEqual(list(F({'username': 'alex'}).qs),

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -227,14 +227,15 @@ class FilterSetFilterForLookupTests(TestCase):
 
     def test_isnull_with_filter_overrides(self):
         class OFilterSet(FilterSet):
-            filter_overrides = {
-                models.BooleanField: {
-                    'filter_class': BooleanFilter,
-                    'extra': lambda f: {
-                        'widget': BooleanWidget,
+            class Meta:
+                filter_overrides = {
+                    models.BooleanField: {
+                        'filter_class': BooleanFilter,
+                        'extra': lambda f: {
+                            'widget': BooleanWidget,
+                        },
                     },
-                },
-            }
+                }
 
         f = Article._meta.get_field('author')
         result, params = OFilterSet.filter_for_lookup(f, 'isnull')
@@ -483,12 +484,13 @@ class FilterSetClassCreationTests(TestCase):
 
     def test_custom_field_gets_filter_from_override(self):
         class F(FilterSet):
-            filter_overrides = {
-                SubnetMaskField: {'filter_class': CharFilter}}
-
             class Meta:
                 model = NetworkSetting
                 fields = '__all__'
+
+                filter_overrides = {
+                    SubnetMaskField: {'filter_class': CharFilter}
+                }
 
         self.assertEqual(list(F.base_filters.keys()), ['ip', 'mask'])
 

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -609,26 +609,24 @@ class FilterSetOrderingTests(TestCase):
 
     def test_ordering_on_unknown_value_results_in_default_ordering_without_strict(self):
         class F(FilterSet):
-            strict = STRICTNESS.IGNORE
-
             class Meta:
                 model = User
                 fields = ['username', 'status']
                 order_by = ['status']
+                strict = STRICTNESS.IGNORE
 
-        self.assertFalse(F.strict)
+        self.assertFalse(F._meta.strict)
         f = F({'o': 'username'}, queryset=self.qs)
         self.assertQuerysetEqual(
             f.qs, ['alex', 'jacob', 'aaron', 'carl'], lambda o: o.username)
 
     def test_ordering_on_unknown_value_results_in_default_ordering_with_strict_raise(self):
         class F(FilterSet):
-            strict = STRICTNESS.RAISE_VALIDATION_ERROR
-
             class Meta:
                 model = User
                 fields = ['username', 'status']
                 order_by = ['status']
+                strict = STRICTNESS.RAISE_VALIDATION_ERROR
 
         f = F({'o': 'username'}, queryset=self.qs)
         with self.assertRaises(ValidationError) as excinfo:

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -683,16 +683,15 @@ class FilterSetOrderingTests(TestCase):
 
     def test_ordering_with_overridden_field_name(self):
         """
-        Set the `order_by_field` on the queryset and ensure that the
+        Set the `order_by_field` on the filterset and ensure that the
         field name is respected.
         """
         class F(FilterSet):
-            order_by_field = 'order'
-
             class Meta:
                 model = User
                 fields = ['username', 'status']
                 order_by = ['status']
+                order_by_field = 'order'
 
         f = F({'order': 'status'}, queryset=self.qs)
         self.assertQuerysetEqual(

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -215,16 +215,15 @@ class FilterSetFormTests(TestCase):
 
     def test_ordering_with_overridden_field_name(self):
         """
-        Set the `order_by_field` on the queryset and ensure that the
+        Set the `order_by_field` on the filterset and ensure that the
         field name is respected.
         """
         class F(FilterSet):
-            order_by_field = 'order'
-
             class Meta:
                 model = User
                 fields = ['username', 'status']
                 order_by = ['status']
+                order_by_field = 'order'
 
         f = F().form
         self.assertNotIn('o', f.fields)
@@ -233,16 +232,15 @@ class FilterSetFormTests(TestCase):
 
     def test_ordering_with_overridden_field_name_and_descending(self):
         """
-        Set the `order_by_field` on the queryset and ensure that the
+        Set the `order_by_field` on the filterset and ensure that the
         field name is respected.
         """
         class F(FilterSet):
-            order_by_field = 'order'
-
             class Meta:
                 model = User
                 fields = ['username', 'status']
                 order_by = ['status', '-status']
+                order_by_field = 'order'
 
         f = F().form
         self.assertNotIn('o', f.fields)
@@ -251,12 +249,11 @@ class FilterSetFormTests(TestCase):
 
     def test_ordering_with_overridden_field_name_and_using_all_fields(self):
         class F(FilterSet):
-            order_by_field = 'order'
-
             class Meta:
                 model = User
                 fields = ['username', 'status']
                 order_by = True
+                order_by_field = 'order'
 
         f = F().form
         self.assertIn('order', f.fields)


### PR DESCRIPTION
Extracted the `strict`, `filter_overrides`, and `order_by_field` moves to `Meta` from the other PRs. This resolves #430. 