### PR TITLE
MultipleChoiceFilter: allow to override get_filter_predicate

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -211,6 +211,11 @@ class MultipleChoiceFilter(Filter):
     filtering may be a no-operation. In this case you may wish to avoid the
     filtering overhead, particularly if using a `distinct` call.
 
+    You can override `get_filter_predicate` to use a custom filter.
+    By default it will use the filter's name for the key, and the value will
+    be the model object - or in case of passing in `to_field_name` the
+    value of that attribute on the model.
+
     Set `always_filter` to `False` after instantiation to enable the default
     `is_noop` test. You can override `is_noop` if you need a different test
     for your application.

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -264,7 +264,10 @@ class MultipleChoiceFilter(Filter):
         return qs.distinct() if self.distinct else qs
 
     def get_filter_predicate(self, v):
-        return {self.name: v}
+        try:
+            return {self.name: getattr(v, self.field.to_field_name)}
+        except (AttributeError, TypeError):
+            return {self.name: v}
 
 
 class DateFilter(Filter):

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -252,7 +252,7 @@ class MultipleChoiceFilter(Filter):
         if not self.conjoined:
             q = Q()
         for v in set(value):
-            predicate = {self.name: v}
+            predicate = self.get_filter_predicate(v)
             if self.conjoined:
                 qs = self.get_method(qs)(**predicate)
             else:
@@ -262,6 +262,9 @@ class MultipleChoiceFilter(Filter):
             qs = self.get_method(qs)(q)
 
         return qs.distinct() if self.distinct else qs
+
+    def get_filter_predicate(self, v):
+        return {self.name: v}
 
 
 class DateFilter(Filter):

--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -158,7 +158,15 @@ ModelMultipleChoiceFilter only.
 ``queryset``
 ~~~~~~~~~~~~
 
-``ModelChoiceFilter`` and ``ModelMultipleChoiceFilter`` require a queryset to operate on which must be passed as a kwarg.
+``ModelChoiceFilter`` and ``ModelMultipleChoiceFilter`` require a queryset to
+operate on which must be passed as a kwarg.
+
+``to_field_name``
+~~~~~~~~~~~~~~~~~
+
+If you pass in ``to_field_name`` (which gets forwarded to the Django field),
+it will be used also in the default ``get_filter_predicate`` implementation
+as the model's attribute.
 
 
 Filters
@@ -324,6 +332,33 @@ for ``ManyToManyField`` by default.
 As with ``ModelChoiceFilter``, if automatically instantiated,
 ``ModelMultipleChoiceFilter`` will use the default ``QuerySet`` for the related
 field. If manually instantiated you **must** provide the ``queryset`` kwarg.
+
+To use a custom field name for the lookup, you can use ``to_field_name``::
+
+    class FooFilter(BaseFilterSet):
+        foo = django_filters.filters.ModelMultipleChoiceFilter(
+            name='attr__uuid',
+            to_field_name='uuid',
+            queryset=Foo.objects.all(),
+        )
+
+If you want to use a custom queryset, e.g. to add annotated fields, this can be
+done as follows::
+
+    class MyMultipleChoiceFilter(django_filters.ModelMultipleChoiceFilter):
+        def get_filter_predicate(self, v):
+            return {'annotated_field': v.annotated_field}
+
+        def filter(self, qs, value):
+            if value:
+                qs = qs.qs_with_annotated_field()
+                qs = super().filter(qs, value)
+            return qs
+
+    foo = MyMultipleChoiceFilter(
+        to_field_name='annotated_field',
+        queryset=Model.objects.qs_with_annotated_field(),
+    )
 
 ``NumberFilter``
 ~~~~~~~~~~~~~~~~

--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -351,14 +351,33 @@ done as follows::
 
         def filter(self, qs, value):
             if value:
-                qs = qs.qs_with_annotated_field()
+                qs = qs.annotate_with_custom_field()
                 qs = super().filter(qs, value)
             return qs
 
     foo = MyMultipleChoiceFilter(
         to_field_name='annotated_field',
-        queryset=Model.objects.qs_with_annotated_field(),
+        queryset=Model.objects.annotate_with_custom_field(),
     )
+
+The ``annotate_with_custom_field`` method would be defined through a custom
+QuerySet, which then gets used as the model's manager::
+
+    class CustomQuerySet(models.QuerySet):
+        def annotate_with_custom_field(self):
+            return self.annotate(
+                custom_field=Case(
+                    When(foo__isnull=False,
+                         then=F('foo__uuid')),
+                    When(bar__isnull=False,
+                         then=F('bar__uuid')),
+                    default=None,
+                ),
+            )
+
+    class MyModel(models.Model):
+        objects = CustomQuerySet.as_manager()
+
 
 ``NumberFilter``
 ~~~~~~~~~~~~~~~~

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -513,6 +513,21 @@ class ModelMultipleChoiceFilterTests(TestCase):
         self.assertIsInstance(field, forms.ModelMultipleChoiceField)
         self.assertEqual(field.queryset, qs)
 
+    def test_filtering_to_field_name(self):
+        qs = User.objects.all()
+        f = ModelMultipleChoiceFilter(name='first_name',
+                                      to_field_name='first_name',
+                                      queryset=qs)
+        user = User.objects.create(first_name='Firstname')
+
+        self.assertEqual(f.get_filter_predicate(user),
+                         {'first_name': 'Firstname'})
+        self.assertEqual(f.get_filter_predicate('FilterValue'),
+                         {'first_name': 'FilterValue'})
+
+        self.assertEqual(list(f.filter(qs, ['Firstname'])), [user])
+        self.assertEqual(list(f.filter(qs, [user])), [user])
+
 
 class NumberFilterTests(TestCase):
 


### PR DESCRIPTION
This allows to use an annotated field easily, without overriding
`filter` altogether:

    class MyMultipleChoiceFilter(django_filters.ModelMultipleChoiceFilter):
        def get_filter_predicate(self, v):
            return {'annotated_field': v.annotated_field}

    foo = MyMultipleChoiceFilter(
        to_field_name='annotated_field',
        queryset=Model.objects.qs_with_annotated_field(),
    )