### PR TITLE
Apply crispy layout to base DRF FilterSet

### DIFF
--- a/django_filters/compat.py
+++ b/django_filters/compat.py
@@ -1,5 +1,6 @@
 
 import django
+from django.conf import settings
 
 
 # django-crispy-forms is optional
@@ -7,6 +8,8 @@ try:
     import crispy_forms
 except ImportError:
     crispy_forms = None
+
+is_crispy = 'crispy_forms' in settings.INSTALLED_APPS and crispy_forms
 
 
 def remote_field(field):

--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -1,52 +1,21 @@
 
 from __future__ import absolute_import
 
-from django.conf import settings
 from django.template import loader
-from django.utils.translation import ugettext_lazy as _
-
-from rest_framework import compat
 from rest_framework.filters import BaseFilterBackend
 
-from ..compat import crispy_forms
+from .. import compat
 from . import filterset
 
 
-if 'crispy_forms' in settings.INSTALLED_APPS and crispy_forms:
-    from crispy_forms.helper import FormHelper
-    from crispy_forms.layout import Layout, Submit
-
-    class FilterSet(filterset.FilterSet):
-        def __init__(self, *args, **kwargs):
-            super(FilterSet, self).__init__(*args, **kwargs)
-            for field in self.form.fields.values():
-                field.help_text = None
-
-            layout_components = list(self.form.fields.keys()) + [
-                Submit('', _('Submit'), css_class='btn-default'),
-            ]
-
-            helper = FormHelper()
-            helper.form_method = 'GET'
-            helper.template_pack = 'bootstrap3'
-            helper.layout = Layout(*layout_components)
-
-            self.form.helper = helper
-
+if compat.is_crispy:
     filter_template = 'django_filters/rest_framework/crispy_form.html'
-
 else:
-    class FilterSet(filterset.FilterSet):
-        def __init__(self, *args, **kwargs):
-            super(FilterSet, self).__init__(*args, **kwargs)
-            for field in self.form.fields.values():
-                field.help_text = None
-
     filter_template = 'django_filters/rest_framework/form.html'
 
 
 class DjangoFilterBackend(BaseFilterBackend):
-    default_filter_set = FilterSet
+    default_filter_set = filterset.FilterSet
     template = filter_template
 
     def get_filter_class(self, view, queryset=None):

--- a/django_filters/rest_framework/filterset.py
+++ b/django_filters/rest_framework/filterset.py
@@ -3,10 +3,16 @@ from __future__ import absolute_import
 from copy import deepcopy
 
 from django.db import models
+from django.utils.translation import ugettext_lazy as _
 
 from django_filters import filterset
 from ..filters import BooleanFilter, IsoDateTimeFilter
 from ..widgets import BooleanWidget
+from .. import compat
+
+if compat.is_crispy:
+    from crispy_forms.helper import FormHelper
+    from crispy_forms.layout import Layout, Submit
 
 
 FILTER_FOR_DBFIELD_DEFAULTS = deepcopy(filterset.FILTER_FOR_DBFIELD_DEFAULTS)
@@ -23,3 +29,17 @@ FILTER_FOR_DBFIELD_DEFAULTS.update({
 
 class FilterSet(filterset.FilterSet):
     FILTER_DEFAULTS = FILTER_FOR_DBFIELD_DEFAULTS
+
+    def __init__(self, *args, **kwargs):
+        super(FilterSet, self).__init__(*args, **kwargs)
+
+        if compat.is_crispy:
+            layout_components = list(self.form.fields.keys()) + [
+                Submit('', _('Submit'), css_class='btn-default'),
+            ]
+            helper = FormHelper()
+            helper.form_method = 'GET'
+            helper.template_pack = 'bootstrap3'
+            helper.layout = Layout(*layout_components)
+
+            self.form.helper = helper


### PR DESCRIPTION
There is a slight bug in the handling of crispy_forms (which was ported from DRF).  
- If crispy forms were enabled, the crispy form template was always be used by the backend.
- If crispy forms were enabled, the crispy form helper *only* applied to the `AutoFilterSet` generated by the backend. Custom `FilterSet` classes did not have the helper classes applied.