### PR TITLE
Add DRF BooleanFilter

### DIFF
--- a/django_filters/rest_framework/__init__.py
+++ b/django_filters/rest_framework/__init__.py
@@ -2,4 +2,4 @@
 from __future__ import absolute_import
 from .backends import DjangoFilterBackend
 from .filterset import FilterSet
-from ..filters import *
+from .filters import *

--- a/django_filters/rest_framework/filters.py
+++ b/django_filters/rest_framework/filters.py
@@ -1,0 +1,10 @@
+
+from ..filters import *
+from ..widgets import BooleanWidget
+
+
+class BooleanFilter(BooleanFilter):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('widget', BooleanWidget)
+
+        super(BooleanFilter, self).__init__(*args, **kwargs)

--- a/django_filters/rest_framework/filterset.py
+++ b/django_filters/rest_framework/filterset.py
@@ -6,8 +6,7 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
 from django_filters import filterset
-from ..filters import BooleanFilter, IsoDateTimeFilter
-from ..widgets import BooleanWidget
+from .filters import BooleanFilter, IsoDateTimeFilter
 from .. import compat
 
 if compat.is_crispy:
@@ -18,12 +17,7 @@ if compat.is_crispy:
 FILTER_FOR_DBFIELD_DEFAULTS = deepcopy(filterset.FILTER_FOR_DBFIELD_DEFAULTS)
 FILTER_FOR_DBFIELD_DEFAULTS.update({
     models.DateTimeField: {'filter_class': IsoDateTimeFilter},
-    models.BooleanField: {
-        'filter_class': BooleanFilter,
-        'extra': lambda f: {
-            'widget': BooleanWidget,
-        },
-    },
+    models.BooleanField: {'filter_class': BooleanFilter},
 })
 
 

--- a/tests/rest_framework/test_filters.py
+++ b/tests/rest_framework/test_filters.py
@@ -1,0 +1,15 @@
+
+from django.test import TestCase
+
+from django_filters.rest_framework import filters
+from django_filters.widgets import BooleanWidget
+
+
+class BooleanFilterTests(TestCase):
+
+    def test_widget(self):
+        # Ensure that `BooleanFilter` uses the correct widget when importing
+        # from `rest_framework.filters`.
+        f = filters.BooleanFilter()
+
+        self.assertEqual(f.widget, BooleanWidget)

--- a/tests/rest_framework/test_filterset.py
+++ b/tests/rest_framework/test_filterset.py
@@ -1,8 +1,7 @@
 
 from django.test import TestCase
 
-from django_filters.rest_framework import FilterSet
-from django_filters.filters import BooleanFilter, IsoDateTimeFilter
+from django_filters.rest_framework import FilterSet, filters
 from django_filters.widgets import BooleanWidget
 
 from ..models import User, Article
@@ -13,11 +12,11 @@ class FilterSetFilterForFieldTests(TestCase):
     def test_isodatetimefilter(self):
         field = Article._meta.get_field('published')
         result = FilterSet.filter_for_field(field, 'published')
-        self.assertIsInstance(result, IsoDateTimeFilter)
+        self.assertIsInstance(result, filters.IsoDateTimeFilter)
         self.assertEqual(result.name, 'published')
 
     def test_booleanfilter_widget(self):
         field = User._meta.get_field('is_active')
         result = FilterSet.filter_for_field(field, 'is_active')
-        self.assertIsInstance(result, BooleanFilter)
+        self.assertIsInstance(result, filters.BooleanFilter)
         self.assertEqual(result.widget, BooleanWidget)


### PR DESCRIPTION
This fixes a small usage issue. The DRF FilterSet is generating `BooleanFilter`s with the API-friendly `BooleanWidget`, however if you were to import from `rest_framework` and instantiate the boolean filter manually, you would get the incorrect widget.

```py
from django_filters import rest_framework

class MyFilterSet(rest_framework.FilterSet):
    field = rest_framework.BooleanFilter()
```