### PR TITLE
Simplify .qs property, fix minor correctness issue

### DIFF
--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1623,6 +1623,8 @@ class MiscFilterSetTests(TestCase):
         self.assertQuerysetEqual(f.qs, [], lambda o: o.pk)
 
     def test_filter_with_initial(self):
+        # Initial values are a form presentation option - the FilterSet should
+        # not use an initial value as a default value to filter by.
         class F(FilterSet):
             status = ChoiceFilter(choices=STATUS_CHOICES, initial=1)
 
@@ -1631,8 +1633,10 @@ class MiscFilterSetTests(TestCase):
                 fields = ['status']
 
         qs = User.objects.all()
+        users = ['alex', 'jacob', 'aaron', 'carl']
+
         f = F(queryset=qs)
-        self.assertQuerysetEqual(f.qs, ['alex'], lambda o: o.username)
+        self.assertQuerysetEqual(f.qs.order_by('pk'), users, lambda o: o.username)
 
         f = F({'status': 0}, queryset=qs)
         self.assertQuerysetEqual(f.qs, ['carl'], lambda o: o.username)


### PR DESCRIPTION
I can provide a more detailed breakdown, but the else block (lines 333-346) is much more difficult to reason about than expected - it only executes in two different sets of conditions:
- The `FilterSet` is unbound.
- The `Filterset` is bound, the form is invalid, and the strictness option is set to `IGNORE`.

Ironically the else block is largely a no-op, except that it has the side-effect of using a field's initial values as a default value to filter with. This isn't the correct behavior, as initial values should only be used during form rendering. 
