### PR TITLE
Add QuerySetRequestMixin

### DIFF
--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -323,6 +323,22 @@ Example::
             model = Book
             fields = ['author']
 
+The ``queryset`` argument also supports callable behavior. If a callable is
+passed, it will be invoked with ``Filterset.request`` as its only argument.
+This allows you to easily filter by properties on the request object without
+having to override the ``FilterSet.__init__``.
+
+.. code-block:: python
+
+    def departments(request):
+        company = request.user.company
+        return company.department_set.all()
+
+    class EmployeeFilter(filters.FilterSet):
+        department = filters.ModelChoiceFilter(queryset=departments)
+        ...
+
+
 ``ModelMultipleChoiceFilter``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -332,6 +348,7 @@ for ``ManyToManyField`` by default.
 As with ``ModelChoiceFilter``, if automatically instantiated,
 ``ModelMultipleChoiceFilter`` will use the default ``QuerySet`` for the related
 field. If manually instantiated you **must** provide the ``queryset`` kwarg.
+Like ``ModelChoiceFilter``, the ``queryset`` argument has callable behavior.
 
 To use a custom field name for the lookup, you can use ``to_field_name``::
 

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -236,11 +236,63 @@ default filters for all the models fields of the same kind using
             }
 
 
+Request-based filtering
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``FilterSet`` may be initialized with an optional ``request`` argument. If
+a request object is passed, then you may access the request during filtering.
+This allows you to filter by properties on the request, such as the currently
+logged-in user or the ``Accepts-Languages`` header.
+
+
+Filtering the primary ``.qs``
+"""""""""""""""""""""""""""""
+
+To filter the primary queryset by the ``request`` object, simply override the
+``FilterSet.qs`` property. For example, you could filter blog articles to only
+those that are published and those that are owned by the logged-in user
+(presumably the author's draft articles).
+
+.. code-block:: python
+
+    class ArticleFilter(django_filters.FilterSet):
+
+        class Meta:
+            model = Article
+            fields = [...]
+
+        @property
+        def qs(self):
+            parent = super(ArticleFilter, self).qs
+            return parent.filter(is_published=True) \
+                | parent.filter(author=request.user)
+
+
+Filtering the related queryset for ``ModelChoiceFilter``
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+The ``queryset`` argument for ``ModelChoiceFilter`` and ``ModelMultipleChoiceFilter``
+supports callable behavior. If a callable is passed, it will be invoked with the
+``request`` as its only argument. This allows you to perform the same kinds of
+request-based filtering without resorting to overriding ``FilterSet.__init__``.
+
+.. code-block:: python
+
+    def departments(request):
+        company = request.user.company
+        return company.department_set.all()
+
+    class EmployeeFilter(filters.FilterSet):
+        department = filters.ModelChoiceFilter(queryset=departments)
+        ...
+
+
 Customize filtering with ``Filter.method``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can control the behavior of a filter by specifying a ``method`` to perform
 filtering. View more information in the :ref:`method reference <filter-method>`.
+Note that you may access the filterset's properties, such as the ``request``.
 
 .. code-block:: python
 

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1644,7 +1644,7 @@ class MiscFilterSetTests(TestCase):
                 model = User
                 fields = ['account']
 
-        qs = mock.MagicMock()
+        qs = mock.NonCallableMagicMock()
         f = F({'account': 'jdoe'}, queryset=qs)
         result = f.qs
         self.assertNotEqual(qs, result)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -500,6 +500,33 @@ class ModelChoiceFilterTests(TestCase):
         self.assertIsInstance(field, forms.ModelChoiceField)
         self.assertEqual(field.queryset, qs)
 
+    def test_callable_queryset(self):
+        request = mock.NonCallableMock(spec=[])
+        qs = mock.NonCallableMock(spec=[])
+
+        qs_callable = mock.Mock(return_value=qs)
+
+        f = ModelChoiceFilter(queryset=qs_callable)
+        f.parent = mock.Mock(request=request)
+        field = f.field
+
+        qs_callable.assert_called_with(request)
+        self.assertEqual(field.queryset, qs)
+
+    def test_get_queryset_override(self):
+        request = mock.NonCallableMock(spec=[])
+        qs = mock.NonCallableMock(spec=[])
+
+        class F(ModelChoiceFilter):
+            get_queryset = mock.create_autospec(ModelChoiceFilter.get_queryset, return_value=qs)
+
+        f = F()
+        f.parent = mock.Mock(request=request)
+        field = f.field
+
+        f.get_queryset.assert_called_with(f, request)
+        self.assertEqual(field.queryset, qs)
+
 
 class ModelMultipleChoiceFilterTests(TestCase):
 
@@ -529,6 +556,19 @@ class ModelMultipleChoiceFilterTests(TestCase):
 
         self.assertEqual(list(f.filter(qs, ['Firstname'])), [user])
         self.assertEqual(list(f.filter(qs, [user])), [user])
+
+    def test_callable_queryset(self):
+        request = mock.NonCallableMock(spec=[])
+        qs = mock.NonCallableMock(spec=[])
+
+        qs_callable = mock.Mock(return_value=qs)
+
+        f = ModelMultipleChoiceFilter(queryset=qs_callable)
+        f.parent = mock.Mock(request=request)
+        field = f.field
+
+        qs_callable.assert_called_with(request)
+        self.assertEqual(field.queryset, qs)
 
 
 class NumberFilterTests(TestCase):

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -688,6 +688,20 @@ class FilterMethodTests(TestCase):
         self.assertIn('parent', str(w.exception))
         self.assertIn('filter_f', str(w.exception))
 
+    def test_method_self_is_parent(self):
+        # Ensure the method isn't 're-parented' on the `FilterMethod` helper class.
+        # Filter methods should have access to the filterset's properties.
+        request = mock.Mock()
+
+        class F(FilterSet):
+            f = CharFilter(method='filter_f')
+
+            def filter_f(inner_self, qs, name, value):
+                self.assertIsInstance(inner_self, F)
+                self.assertIs(inner_self.request, request)
+
+        F({'f': 'foo'}, request=request, queryset=User.objects.all()).qs
+
     def test_method_unresolvable(self):
         class F(FilterSet):
             f = Filter(method='filter_f')


### PR DESCRIPTION
Exposes the request to be used during filtering. See DRF [#3766](/tomchristie/django-rest-framework/issues/3766), [#3905](/tomchristie/django-rest-framework/issues/3905), [#3977](/tomchristie/django-rest-framework/issues/3977).
- Add `FilterSet.request`, which is generally accessible through the `Filter.parent`.
- Add queryset callable handling to `ModelChoiceFilter` and `ModelMultipleChoiceFilter` through `QuerySetRequestMixin`. 

``` py
def departments(request):
    company = request.user.company
    return company.department_set.all()

class EmployeeFilter(filters.FilterSet):
    department = filters.ModelChoiceFilter(queryset=departments)
    ...
```

``` py
class Filter(filters.FilterSet):
    relation = django_filters.CharFilter(method='filter_relation')

    def filter_relation(self, queryset, name, value):
        return queryset.filter(id__in=some_search_involving(self.user, value))
```

**TODO:**
- [x] docs
- [x] tests
