### PR TITLE
Test to show that templates from drf extensions can't be loaded

### DIFF
--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -280,6 +280,17 @@ class IntegrationTestFiltering(CommonFilteringTestCase):
         response = view(request).render()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    @override_settings(INSTALLED_APPS=['rest_framework', 'django_filters'])
+    def test_html_rendering(self):
+        """
+        Make sure templates can be loaded.
+        """
+        view = FilterFieldsRootView.as_view()
+        request = factory.get('/')
+        request.META['HTTP_ACCEPT'] = 'text/html'
+        response = view(request).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
 
 @override_settings(ROOT_URLCONF='tests.rest_framework.test_backends')
 class IntegrationTestDetailFiltering(CommonFilteringTestCase):


### PR DESCRIPTION
I'm not sure there is a bug, but I can't find a way to load templates from `django_filters/rest_framework/templates/...`

Maybe it is solvable through settings but I didn't find it yet.

The test is to show what I'm talking about.