### PR TITLE
Bugfix/496 ordering filter select widget

### DIFF
--- a/django_filters/fields.py
+++ b/django_filters/fields.py
@@ -2,13 +2,14 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from datetime import datetime, time
-from collections import namedtuple
+from collections import namedtuple, Iterable
 
 from django import forms
 from django.utils.dateparse import parse_datetime
 
 from django.utils.encoding import force_str
 from django.utils.translation import ugettext_lazy as _
+from django.utils.six import string_types
 
 from .utils import handle_timezone
 from .widgets import RangeWidget, LookupTypeWidget, CSVWidget
@@ -134,6 +135,10 @@ class BaseCSVField(forms.Field):
     def clean(self, value):
         if value is None:
             return None
+
+        if isinstance(value, string_types) and value != '':
+            value = [value]
+
         return [super(BaseCSVField, self).clean(v) for v in value]
 
 

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -6,12 +6,13 @@ import mock
 import unittest
 
 import django
+from django import forms
 from django.test import TestCase, override_settings
 from django.utils import six
 from django.utils.timezone import now
 from django.utils import timezone
 
-from django_filters.filterset import FilterSet
+from django_filters.filterset import FilterSet, STRICTNESS
 from django_filters.filters import AllValuesFilter
 from django_filters.filters import AllValuesMultipleFilter
 from django_filters.filters import CharFilter
@@ -24,6 +25,7 @@ from django_filters.filters import DurationFilter
 from django_filters.filters import MultipleChoiceFilter
 from django_filters.filters import ModelMultipleChoiceFilter
 from django_filters.filters import NumberFilter
+from django_filters.filters import OrderingFilter
 from django_filters.filters import RangeFilter
 from django_filters.filters import TimeRangeFilter
 # from django_filters.widgets import LinkWidget
@@ -1584,6 +1586,50 @@ class CSVFilterTests(TestCase):
 
         f = F({'author__in': '1,'}, queryset=qs)
         self.assertEqual(f.qs.count(), 2)
+
+
+class OrderingFilterTests(TestCase):
+
+    def setUp(self):
+        User.objects.create(username='alex', status=1)
+        User.objects.create(username='jacob', status=2)
+        User.objects.create(username='aaron', status=2)
+        User.objects.create(username='carl', status=0)
+
+    def test_ordering(self):
+        class F(FilterSet):
+            o = OrderingFilter(
+                fields=('username',)
+            )
+
+            class Meta:
+                model = User
+                fields = ['username',]
+                strict = STRICTNESS.RAISE_VALIDATION_ERROR
+
+
+        qs = User.objects.all()
+        f = F({'o': 'username'}, queryset=qs)
+        names = f.qs.values_list("username", flat=True)
+        self.assertEqual(list(names), ['aaron', 'alex', 'carl', 'jacob',])
+
+    def test_ordering_with_select_widget(self):
+        class F(FilterSet):
+            o = OrderingFilter(
+                widget=forms.Select(),
+                fields=('username',)
+            )
+
+            class Meta:
+                model = User
+                fields = ['username',]
+                strict = STRICTNESS.RAISE_VALIDATION_ERROR
+
+
+        qs = User.objects.all()
+        f = F({'o': 'username'}, queryset=qs)
+        names = f.qs.values_list("username", flat=True)
+        self.assertEqual(list(names), ['aaron', 'alex', 'carl', 'jacob',])
 
 
 class MiscFilterSetTests(TestCase):


### PR DESCRIPTION
Ref #496 

Not to merge. Just showing the issue. 

We require: 

1. a Field using a CSVSelect widget. 
2. Docs saying use "either the default of CSVWidget" for this filter. 