### PR TITLE
Fix ordering select widget

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -3,14 +3,12 @@ from __future__ import unicode_literals
 
 from datetime import datetime, time, timedelta, tzinfo
 import decimal
-import unittest
 
-import django
 from django import forms
 from django.test import TestCase, override_settings
 from django.utils.timezone import make_aware, get_default_timezone
 
-from django_filters.widgets import RangeWidget
+from django_filters.widgets import BaseCSVWidget, CSVWidget, RangeWidget
 from django_filters.fields import (
     Lookup, LookupTypeField, BaseCSVField, BaseRangeField, RangeField,
     DateRangeField, DateTimeRangeField, TimeRangeField, IsoDateTimeField
@@ -195,6 +193,25 @@ class BaseCSVFieldTests(TestCase):
 
         with self.assertRaises(forms.ValidationError):
             self.field.clean(['a', 'b', 'c'])
+
+    def test_derived_widget(self):
+        with self.assertRaises(AssertionError) as excinfo:
+            BaseCSVField(widget=RangeWidget())
+
+        msg = str(excinfo.exception)
+        self.assertIn("'BaseCSVField.widget' must be a widget class", msg)
+        self.assertIn("RangeWidget", msg)
+
+        widget = CSVWidget()
+        field = BaseCSVField(widget=widget)
+        self.assertIs(field.widget, widget)
+
+        field = BaseCSVField(widget=CSVWidget)
+        self.assertIsInstance(field.widget, CSVWidget)
+
+        field = BaseCSVField(widget=forms.Select)
+        self.assertIsInstance(field.widget, forms.Select)
+        self.assertIsInstance(field.widget, BaseCSVWidget)
 
 
 class BaseRangeFieldTests(TestCase):

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -6,6 +6,7 @@ import mock
 import unittest
 
 import django
+from django import forms
 from django.test import TestCase, override_settings
 from django.utils import six
 from django.utils.timezone import now
@@ -24,6 +25,7 @@ from django_filters.filters import DurationFilter
 from django_filters.filters import MultipleChoiceFilter
 from django_filters.filters import ModelMultipleChoiceFilter
 from django_filters.filters import NumberFilter
+from django_filters.filters import OrderingFilter
 from django_filters.filters import RangeFilter
 from django_filters.filters import TimeRangeFilter
 # from django_filters.widgets import LinkWidget
@@ -1584,6 +1586,46 @@ class CSVFilterTests(TestCase):
 
         f = F({'author__in': '1,'}, queryset=qs)
         self.assertEqual(f.qs.count(), 2)
+
+
+class OrderingFilterTests(TestCase):
+
+    def setUp(self):
+        User.objects.create(username='alex', status=1)
+        User.objects.create(username='jacob', status=2)
+        User.objects.create(username='aaron', status=2)
+        User.objects.create(username='carl', status=0)
+
+    def test_ordering(self):
+        class F(FilterSet):
+            o = OrderingFilter(
+                fields=('username', )
+            )
+
+            class Meta:
+                model = User
+                fields = ['username']
+
+        qs = User.objects.all()
+        f = F({'o': 'username'}, queryset=qs)
+        names = f.qs.values_list('username', flat=True)
+        self.assertEqual(list(names), ['aaron', 'alex', 'carl', 'jacob'])
+
+    def test_ordering_with_select_widget(self):
+        class F(FilterSet):
+            o = OrderingFilter(
+                widget=forms.Select,
+                fields=('username', )
+            )
+
+            class Meta:
+                model = User
+                fields = ['username']
+
+        qs = User.objects.all()
+        f = F({'o': 'username'}, queryset=qs)
+        names = f.qs.values_list('username', flat=True)
+        self.assertEqual(list(names), ['aaron', 'alex', 'carl', 'jacob'])
 
 
 class MiscFilterSetTests(TestCase):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -9,7 +9,7 @@ import warnings
 from django import forms
 from django.test import TestCase, override_settings
 
-from django_filters import filters
+from django_filters import filters, widgets
 from django_filters.fields import (
     Lookup,
     RangeField,
@@ -1097,3 +1097,10 @@ class OrderingFilterTests(TestCase):
         with self.assertRaises(AssertionError) as ctx:
             f([0, 1, 2])
         self.assertEqual(str(ctx.exception), "'fields' must contain strings or (field name, param name) pairs.")
+
+    def test_widget(self):
+        f = OrderingFilter()
+        widget = f.field.widget
+
+        self.assertIsInstance(widget, widgets.BaseCSVWidget)
+        self.assertIsInstance(widget, forms.Select)

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 from django.forms import TextInput, Select
 
 from django_filters.widgets import BooleanWidget
+from django_filters.widgets import BaseCSVWidget
 from django_filters.widgets import CSVWidget
 from django_filters.widgets import RangeWidget
 from django_filters.widgets import LinkWidget
@@ -182,6 +183,9 @@ class CSVWidgetTests(TestCase):
         self.assertHTMLEqual(w.render('price', ''), """
             <input type="text" name="price" />""")
 
+        self.assertHTMLEqual(w.render('price', '1'), """
+            <input type="text" name="price" value="1" />""")
+
         self.assertHTMLEqual(w.render('price', '1,2'), """
             <input type="text" name="price" value="1,2" />""")
 
@@ -224,3 +228,54 @@ class CSVWidgetTests(TestCase):
 
         result = w.value_from_datadict({}, {}, 'price')
         self.assertEqual(result, None)
+
+
+class CSVSelectTests(TestCase):
+    class CSVSelect(BaseCSVWidget, Select):
+        pass
+
+    def test_widget(self):
+        w = self.CSVSelect(choices=((1, 'a'), (2, 'b')))
+        self.assertHTMLEqual(
+            w.render('price', None),
+            """
+            <select name="price">
+                <option value="1">a</option>
+                <option value="2">b</option>
+            </select>
+            """
+        )
+
+        self.assertHTMLEqual(
+            w.render('price', ''),
+            """
+            <select name="price">
+                <option value="1">a</option>
+                <option value="2">b</option>
+            </select>
+            """)
+
+        self.assertHTMLEqual(
+            w.render('price', '1'),
+            """
+            <select name="price">
+                <option selected="selected" value="1">a</option>
+                <option value="2">b</option>
+            </select>
+            """)
+
+        self.assertHTMLEqual(
+            w.render('price', '1,2'),
+            """
+            <select name="price">
+                <option value="1">a</option>
+                <option value="2">b</option>
+            </select>
+            """
+        )
+
+        self.assertHTMLEqual(w.render('price', ['1', '2']), """
+            <input type="text" name="price" value="1,2" />""")
+
+        self.assertHTMLEqual(w.render('price', [1, 2]), """
+            <input type="text" name="price" value="1,2" />""")


### PR DESCRIPTION
Fixes #496. Supersedes and closes #499.

- Changed `CSVWidget` => `BaseCSVWidget`
  - The rendering behavior only forces a text input when there are multiple values to render (ie, you directly modify the url query params to have multiple values). 
  - If there are one or zero values, the mixed-in widget is used to render (such as select, date input, etc...),  making the widget suitable to use in forms.
  - Form usage will generally only for allow one input (e.g, a select/date input can only provide one value).
  - API usage allows for comma-separated values.
- Re-added `CSVWidget` class that is the base widget pre-mixed w/ `TextInput`. This mimics the previous behavior and is used by the `CSVRangeField`, as range *only* accept two values via comma separation. 
- `BaseCSVField` will now mix the main widget class w/ `BaseCSVWidget` (making `CSVSelect`s, `CSVDateInput`s, etc...). This the same way a mixed-in csv filter will make it's derivative mixed-in csv field.
