### PR TITLE
setup.py - add PyPI trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,10 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
+        'Framework :: Django',
+        'Framework :: Django :: 1.8',
+        'Framework :: Django :: 1.9',
+        'Framework :: Django :: 1.10',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',


### PR DESCRIPTION
They're [[ https://pypi.python.org/pypi?%3Aaction=list_classifiers | official classifiers ]] and can be used to help users to upgrade their Django version. Just have to remember to keep them up to date!