### PR TITLE
Changelog - Add when Django 1.10 support note

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,8 @@ __ https://github.com/carltongibson/django-filter/blob/develop/docs/migration.tx
 Version 0.14.0 (2016-08-14)
 ---------------------------
 
+* Confirmed support for Django 1.10.
+
 * Add support for filtering on DurationField (new in Django 1.8).
 
 * Fix UUIDFilter import issue


### PR DESCRIPTION
I was upgrading my packages in preparation for Django 1.10 and couldn't find a note in the changelog for `django-filter` about it, though there is one for Django 1.9. At first I thought that it wasn't tested on Django 1.10 yet, but looking at `tox.ini` it is, since f2e85cdd3aeec58beff5aee18d95a58dd8c2088e. Since `0.14.0` was the first release after that commit, I've added a note there that it's the first version with confirmed 1.10 support.
