### PR TITLE
Add empty value choice for `ChoiceFilter`

### DIFF
--- a/django_filters/conf.py
+++ b/django_filters/conf.py
@@ -10,6 +10,12 @@ DEFAULTS = {
     'DISABLE_HELP_TEXT': False,
     'HELP_TEXT_FILTER': True,
     'HELP_TEXT_EXCLUDE': True,
+
+    # empty/null choices
+    'EMPTY_CHOICE_LABEL': '---------',
+    'NULL_CHOICE_LABEL': None,
+    'NULL_CHOICE_VALUE': 'null',
+
     'VERBOSE_LOOKUPS': {
         # transforms don't need to be verbose, since their expressions are chained
         'date': _('date'),

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -384,7 +384,7 @@ class BaseFilterSet(object):
             if isinstance(opts.order_by[0], (list, tuple)):
                 choices = [(f[0], f[1]) for f in opts.order_by]
                 fields = {filters.get(f[0].lstrip('-')).name: f[0] for f in opts.order_by}
-                return OrderingFilter(choices=choices, fields=fields)
+                return OrderingFilter(choices=choices, fields=fields, empty_label=None)
 
             # e.g. ('field1', 'field2', ...)
             else:
@@ -394,14 +394,14 @@ class BaseFilterSet(object):
                 # preference filter label over attribute name
                 choices = [(f, display_text(f, fltr)) for f, fltr in order_by]
                 fields = {fltr.name: f for f, fltr in order_by}
-                return OrderingFilter(choices=choices, fields=fields)
+                return OrderingFilter(choices=choices, fields=fields, empty_label=None)
 
         # opts.order_by = True
         order_by = filters.items()
 
         fields = [(fltr.name, f) for f, fltr in order_by]
         labels = {f: display_text(f, fltr) for f, fltr in order_by}
-        return OrderingFilter(fields=fields, field_labels=labels)
+        return OrderingFilter(fields=fields, field_labels=labels, empty_label=None)
 
     @classmethod
     def filters_for_model(cls, model, opts):

--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -194,11 +194,10 @@ This filter matches a boolean, either ``True`` or ``False``, used with
 ``ChoiceFilter``
 ~~~~~~~~~~~~~~~~
 
-This filter matches an item of any type by choices, used with any field that
-has ``choices``.
+This filter matches values in its ``choices`` argument. The ``choices`` must be
+explicitly passed when the filter is declared on the ``FilterSet``. For example,
 
-
-Requires ``choices`` ``kwarg`` to be passed if explicitly declared on the ``FilterSet``. For example::
+.. code-block:: python
 
     class User(models.Model):
         username = models.CharField(max_length=255)
@@ -219,6 +218,20 @@ Requires ``choices`` ``kwarg`` to be passed if explicitly declared on the ``Filt
             model = User
             fields = ['status']
 
+
+``ChoiceFilter`` also has arguments that enable a choice for not filtering, as
+well as a choice for filtering by ``None`` values. Each of the arguments have a
+corresponding global setting (:doc:`/ref/settings`).
+
+* ``empty_label``: The display label to use for the select choice to not filter.
+  The choice may be disabled by setting this argument to ``None``. Defaults to
+  ``FILTERS_EMPTY_CHOICE_LABEL``.
+* ``null_label``: The display label to use for the choice to filter by ``None``
+  values. The choice may be disabled by setting this argument to ``None``.
+  Defaults to ``FILTERS_NULL_CHOICE_LABEL``.
+* ``null_value``: The special value to match to enable filtering by ``None``
+  values. This value defaults ``FILTERS_NULL_CHOICE_VALUE`` and needs to be
+  a non-empty value (``''``, ``None``, ``[]``, ``()``, ``{}``).
 
 
 ``TypedChoiceFilter``

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -9,6 +9,30 @@ default values. All settings are prefixed with ``FILTERS_``, although this
 is a bit verbose it helps to make it easy to identify these settings.
 
 
+FILTERS_EMPTY_CHOICE_LABEL
+--------------------------
+
+Default: ``'---------'``
+
+Set the default value for ``ChoiceFilter.empty_label``. You may disable the empty choice by setting this to ``None``.
+
+
+FILTERS_NULL_CHOICE_LABEL
+-------------------------
+
+Default: ``None``
+
+Set the default value for ``ChoiceFilter.null_label``. You may enable the null choice by setting a non-``None`` value.
+
+
+FILTERS_NULL_CHOICE_VALUE
+-------------------------
+
+Default: ``'null'``
+
+Set the default value for ``ChoiceFilter.null_value``. You may want to change this value if the default ``'null'`` string conflicts with an actual choice.
+
+
 FILTERS_DISABLE_HELP_TEXT
 -------------------------
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -19,6 +19,15 @@ class DefaultSettingsTests(TestCase):
     def test_help_text_exclude(self):
         self.assertTrue(settings.HELP_TEXT_EXCLUDE)
 
+    def test_empty_choice_label(self):
+        self.assertEqual(settings.EMPTY_CHOICE_LABEL, '---------')
+
+    def test_null_choice_label(self):
+        self.assertIsNone(settings.NULL_CHOICE_LABEL)
+
+    def test_null_choice_value(self):
+        self.assertEqual(settings.NULL_CHOICE_VALUE, 'null')
+
 
 class OverrideSettingsTests(TestCase):
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -8,7 +8,7 @@ import mock
 import warnings
 
 from django import forms
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from django_filters import filters, widgets
 from django_filters.fields import (

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1077,6 +1077,7 @@ class OrderingFilterTests(TestCase):
         )
 
         self.assertSequenceEqual(f.field.choices, (
+            ('', '---------'),
             ('a', 'A'),
             ('b', 'B'),
         ))
@@ -1087,6 +1088,7 @@ class OrderingFilterTests(TestCase):
         )
 
         self.assertSequenceEqual(f.field.choices, (
+            ('', '---------'),
             ('c', 'C'),
             ('-c', 'C (descending)'),
             ('d', 'D'),
@@ -1100,6 +1102,7 @@ class OrderingFilterTests(TestCase):
         )
 
         self.assertSequenceEqual(f.field.choices, (
+            ('', '---------'),
             ('c', 'foo'),
             ('-c', 'foo (descending)'),
             ('d', 'D'),

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -317,6 +317,82 @@ class ChoiceFilterTests(TestCase):
         field = f.field
         self.assertIsInstance(field, forms.ChoiceField)
 
+    def test_empty_choice(self):
+        # default value
+        f = ChoiceFilter(choices=[('a', 'a')])
+        self.assertEqual(f.field.choices, [
+            ('', '---------'),
+            ('a', 'a'),
+        ])
+
+        # set value, allow blank label
+        f = ChoiceFilter(choices=[('a', 'a')], empty_label='')
+        self.assertEqual(f.field.choices, [
+            ('', ''),
+            ('a', 'a'),
+        ])
+
+        # disable empty choice w/ None
+        f = ChoiceFilter(choices=[('a', 'a')], empty_label=None)
+        self.assertEqual(f.field.choices, [
+            ('a', 'a'),
+        ])
+
+    def test_null_choice(self):
+        # default is to be disabled
+        f = ChoiceFilter(choices=[('a', 'a')], )
+        self.assertEqual(f.field.choices, [
+            ('', '---------'),
+            ('a', 'a'),
+        ])
+
+        # set label, allow blank label
+        f = ChoiceFilter(choices=[('a', 'a')], null_label='')
+        self.assertEqual(f.field.choices, [
+            ('', '---------'),
+            ('null', ''),
+            ('a', 'a'),
+        ])
+
+        # set null value
+        f = ChoiceFilter(choices=[('a', 'a')], null_value='NULL', null_label='')
+        self.assertEqual(f.field.choices, [
+            ('', '---------'),
+            ('NULL', ''),
+            ('a', 'a'),
+        ])
+
+        # explicitly disable
+        f = ChoiceFilter(choices=[('a', 'a')], null_label=None)
+        self.assertEqual(f.field.choices, [
+            ('', '---------'),
+            ('a', 'a'),
+        ])
+
+    @override_settings(
+        FILTERS_EMPTY_CHOICE_LABEL='EMPTY LABEL',
+        FILTERS_NULL_CHOICE_LABEL='NULL LABEL',
+        FILTERS_NULL_CHOICE_VALUE='NULL VALUE', )
+    def test_settings_overrides(self):
+        f = ChoiceFilter(choices=[('a', 'a')], )
+        self.assertEqual(f.field.choices, [
+            ('', 'EMPTY LABEL'),
+            ('NULL VALUE', 'NULL LABEL'),
+            ('a', 'a'),
+        ])
+
+    def test_callable_choices(self):
+        def choices():
+            yield ('a', 'a')
+            yield ('b', 'b')
+
+        f = ChoiceFilter(choices=choices)
+        self.assertEqual(f.field.choices, [
+            ('', '---------'),
+            ('a', 'a'),
+            ('b', 'b'),
+        ])
+
 
 class MultipleChoiceFilterTests(TestCase):
 

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -696,6 +696,9 @@ class FilterMethodTests(TestCase):
         class F(FilterSet):
             f = CharFilter(method='filter_f')
 
+            class Meta:
+                model = User
+
             def filter_f(inner_self, qs, name, value):
                 self.assertIsInstance(inner_self, F)
                 self.assertIs(inner_self.request, request)

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -66,8 +66,10 @@ class FilterSetFormTests(TestCase):
         f = F().form
         self.assertEqual(len(f.fields), 1)
         self.assertIn('status', f.fields)
-        self.assertEqual(sorted(f.fields['status'].choices),
-                         sorted(STATUS_CHOICES))
+        self.assertSequenceEqual(
+            f.fields['status'].choices,
+            (('', '---------'), ) + STATUS_CHOICES
+        )
 
     def test_form_fields_exclusion(self):
         class F(FilterSet):
@@ -106,7 +108,8 @@ class FilterSetFormTests(TestCase):
     def test_form_fields_using_widget(self):
         class F(FilterSet):
             status = ChoiceFilter(widget=forms.RadioSelect,
-                                  choices=STATUS_CHOICES)
+                                  choices=STATUS_CHOICES,
+                                  empty_label=None)
 
             class Meta:
                 model = User
@@ -116,8 +119,10 @@ class FilterSetFormTests(TestCase):
         self.assertEqual(len(f.fields), 2)
         self.assertIn('status', f.fields)
         self.assertIn('username', f.fields)
-        self.assertEqual(sorted(f.fields['status'].choices),
-                         sorted(STATUS_CHOICES))
+        self.assertSequenceEqual(
+            f.fields['status'].choices,
+            STATUS_CHOICES
+        )
         self.assertIsInstance(f.fields['status'].widget, forms.RadioSelect)
 
     def test_form_field_with_custom_label(self):


### PR DESCRIPTION
Adds empty and null value handling for `ChoiceFilter`, which should fix #45 and resolve #261. 
- Adds `FILTERS_EMPTY_CHOICE_LABEL`, `FILTERS_NULL_CHOICE_LABEL`, and `FILTERS_NULL_CHOICE_VALUE` settings, which allow you to globally set the empty/null choice labels and the null choice value. 
  - Empty choice value is hardcoded as there shouldn't need to be a reason to override it. 
  - Null choice value defaults to `'null'`, which should be a JS-friendly magic value.
- Updated `ChoiceFilter`, which now takes corresponding `empty_label`, `null_label`, and `null_value` arguments. This is based on [`ModelChoiceField.empty_label`](https://github.com/django/django/blob/1.10/django/forms/models.py#L1136-L1139).
  - `empty_label` and `null_label` may be set to `None` to disable those choices.
  - `empty_label` defaults to `---------`, which maintains consistency w/ Django. This can be overridden globally or per filter.
  - `null_label` defaults to `None`, which means users must opt into using it.

**TODO:**
- [x] Add docs
- [x] Add tests
  - override `empty_label` value
  - test `empty_label` when None
  - ~~test w/ other widgets (`ChecboxSelectMultiple`)~~ There isn't anything to test here?
  - test w/ various filters (`OrderingFilter`, `AllValuesFilter`)
