### PR TITLE
Expose request to filters

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -277,7 +277,7 @@ FILTER_FOR_DBFIELD_DEFAULTS = {
 class BaseFilterSet(object):
     FILTER_DEFAULTS = FILTER_FOR_DBFIELD_DEFAULTS
 
-    def __init__(self, data=None, queryset=None, prefix=None, strict=None):
+    def __init__(self, data=None, queryset=None, prefix=None, strict=None, request=None):
         self.is_bound = data is not None
         self.data = data or {}
         if queryset is None:
@@ -287,6 +287,8 @@ class BaseFilterSet(object):
 
         # What to do on on validation errors
         self.strict = self._meta.strict if strict is None else strict
+
+        self.request = request
 
         self.filters = copy.deepcopy(self.base_filters)
         # propagate the model being used through the filters

--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -71,7 +71,7 @@ class DjangoFilterBackend(BaseFilterBackend):
         filter_class = self.get_filter_class(view, queryset)
 
         if filter_class:
-            return filter_class(request.query_params, queryset=queryset).qs
+            return filter_class(request.query_params, queryset=queryset, request=request).qs
 
         return queryset
 
@@ -79,7 +79,7 @@ class DjangoFilterBackend(BaseFilterBackend):
         filter_class = self.get_filter_class(view, queryset)
         if not filter_class:
             return None
-        filter_instance = filter_class(request.query_params, queryset=queryset)
+        filter_instance = filter_class(request.query_params, queryset=queryset, request=request)
 
         try:
             template = loader.get_template(self.template)

--- a/django_filters/views.py
+++ b/django_filters/views.py
@@ -36,7 +36,10 @@ class FilterMixin(object):
         """
         Returns the keyword arguments for instanciating the filterset.
         """
-        kwargs = {'data': self.request.GET or None}
+        kwargs = {
+            'data': self.request.GET or None,
+            'request': self.request,
+        }
         try:
             kwargs.update({
                 'queryset': self.get_queryset(),


### PR DESCRIPTION
This is lightweight version of #494 where I don't try to change `ModelChoiceFilter`. It can still be done later.
This pull request focuses on bringing request object available to filters.