### PR TITLE
Import coreapi directly instead of from DRF

### DIFF
--- a/django_filters/compat.py
+++ b/django_filters/compat.py
@@ -14,9 +14,11 @@ except ImportError:
 is_crispy = 'crispy_forms' in settings.INSTALLED_APPS and crispy_forms
 
 
-# coreapi only compatible with DRF 3.4+
+# coreapi is optional (Note that uritemplate is a dependency of coreapi)
+# Fixes #525 - cannot simply import from rest_framework.compat, due to
+# import issues w/ django-guardian.
 try:
-    from rest_framework.compat import coreapi
+    import coreapi
 except ImportError:
     coreapi = None
 


### PR DESCRIPTION
Fixes #525. 

This is ultimately an interaction between `DRF`+`django-filter`+`django-guardian`, which results in the following:

```py
  File "lib/python2.7/site-packages/django_filters/compat.py", line 19, in <module>
    from rest_framework.compat import coreapi
  File "lib/python2.7/site-packages/rest_framework/compat.py", line 210, in <module>
    import guardian.shortcuts  # Fixes #1624
  File "lib/python2.7/site-packages/guardian/shortcuts.py", line 6, in <module>
    from django.contrib.auth.models import Group, Permission
```

Importing coreapi directly, instead of through DRF prevents the import to django-guardian. 