### PR TITLE
Fix OrderingFilter label translation

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -656,7 +656,7 @@ class OrderingFilter(BaseCSVFilter, ChoiceFilter):
 
     def build_choices(self, fields, labels):
         ascending = [
-            (param, labels.get(field, pretty_name(param)))
+            (param, labels.get(field, _(pretty_name(param))))
             for field, param in fields.items()
         ]
         descending = [

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -660,8 +660,8 @@ class OrderingFilter(BaseCSVFilter, ChoiceFilter):
             for field, param in fields.items()
         ]
         descending = [
-            ('-%s' % pair[0], self.descending_fmt % pair[1])
-            for pair in ascending
+            ('-%s' % param, labels.get('-%s' % param, self.descending_fmt % label))
+            for param, label in ascending
         ]
 
         # interleave the ascending and descending choices

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -10,6 +10,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'django.contrib.auth',
     'rest_framework',
+    'django_filters',
     'tests.rest_framework',
     'tests',
 )


### PR DESCRIPTION
Supersedes and resolves #543.

This also adds descending options to `OrderingFilter.field_labels`. 