### PR TITLE
filterset context support with drf view helper

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -214,8 +214,9 @@ FILTER_FOR_DBFIELD_DEFAULTS = {
 class BaseFilterSet(object):
     FILTER_DEFAULTS = FILTER_FOR_DBFIELD_DEFAULTS
 
-    def __init__(self, data=None, queryset=None, prefix=None, strict=None, request=None):
+    def __init__(self, data=None, queryset=None, prefix=None, strict=None, request=None, context=None):
         self.is_bound = data is not None
+        self.context = context or {}
         self.data = data or {}
         if queryset is None:
             queryset = self._meta.model._default_manager.all()

--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -51,13 +51,6 @@ class DjangoFilterBackend(BaseFilterBackend):
         filter_context = {}
         if hasattr(get_filter_context, '__call__'):
             filter_context = get_filter_context()
-            if not isinstance(filter_context, dict):
-                raise TypeError(
-                    "get_filter_context of {cls} expected to "
-                    "return dict, got {type} instead".format(
-                        cls=get_filter_context.im_class,
-                        type=filter_context)
-                )
 
         if filter_context:
             return filter_context

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -198,25 +198,11 @@ class ContextTests(TestCase):
             def get_filter_context(self):
                 return {'foo': 'bar'}
 
-        class BadFilterContextView(generics.ListCreateAPIView):
-            queryset = FilterableItem.objects.all()
-            serializer_class = FilterableItemSerializer
-            filter_class = SeveralFieldsFilter
-            filter_backends = (DjangoFilterBackend,)
-
-            def get_filter_context(self):
-                return 123
-
         request = factory.get('/')
         view = self.setup_view(FilterContextView, request)()
         backend = view.filter_backends[0]()
 
         self.assertDictEqual(backend.get_context(view, request), view.get_filter_context())
-
-        # Context supposed to be a dict
-        view = self.setup_view(BadFilterContextView, request)()
-        backend = view.filter_backends[0]()
-        self.assertRaises(TypeError, backend.get_context, view, request)
 
 
 class IntegrationTestFiltering(CommonFilteringTestCase):


### PR DESCRIPTION
This PR provides support for filterset context. The idea is borrowed from DRF serializer context feature. This is particularly useful when your filter methods needs access to some outside world.

It also provides helper for DRF apiviews so one can write:

```python
        class FilterContextView(generics.ListCreateAPIView):
            queryset = FilterableItem.objects.all()
            serializer_class = FilterableItemSerializer
            filter_class = SeveralFieldsFilter
            filter_backends = (DjangoFilterBackend,)

            def get_filter_context(self):
                return {'current_user': self.request.user}
```

and use this data inside filterset methods.