### PR TITLE
Rework filter generation

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -10,7 +10,6 @@ from django.db import models
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.fields.related import ForeignObjectRel
 from django.utils import six
-from django.utils.translation import ugettext as _
 
 from .conf import settings
 from .compat import remote_field, remote_queryset
@@ -235,12 +234,10 @@ class BaseFilterSet(object):
         self.request = request
 
         self.filters = copy.deepcopy(self.base_filters)
-        # propagate the model being used through the filters
-        for filter_ in self.filters.values():
-            filter_.model = self._meta.model
 
-        # Apply the parent to the filters, this will allow the filters to access the filterset
-        for filter_key, filter_ in six.iteritems(self.filters):
+        for filter_ in self.filters.values():
+            # propagate the model and filterset to the filters
+            filter_.model = self._meta.model
             filter_.parent = self
 
     @property

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -39,6 +39,7 @@ class StrictnessTests(TestCase):
     class F(FilterSet):
         class Meta:
             model = User
+            fields = []
 
     def test_settings_default(self):
         self.assertEqual(self.F().strict, STRICTNESS.RETURN_NO_RESULTS)

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -208,6 +208,7 @@ class ChoiceFilterTests(TestCase):
 
             class Meta:
                 model = Article
+                fields = ['author']
 
         # sanity check to make sure the filter is setup correctly
         f = F({'author': '1'})

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -322,20 +322,21 @@ class FilterSetClassCreationTests(TestCase):
                              ['title', 'price', 'average_rating'])
 
     def test_model_no_fields_or_exclude(self):
+        with self.assertRaises(AssertionError) as excinfo:
+            class F(FilterSet):
+                class Meta:
+                    model = Book
+
+        self.assertIn(
+            "Setting 'Meta.model' without either 'Meta.fields' or 'Meta.exclude'",
+            str(excinfo.exception)
+        )
+
+    def test_model_fields_empty(self):
         class F(FilterSet):
             class Meta:
                 model = Book
-
-        self.assertEqual(len(F.declared_filters), 0)
-        self.assertEqual(len(F.base_filters), 0)
-        self.assertListEqual(list(F.base_filters), [])
-
-    def test_model_exclude_is_none(self):
-        # equivalent to unset fields/exclude
-        class F(FilterSet):
-            class Meta:
-                model = Book
-                exclude = None
+                fields = []
 
         self.assertEqual(len(F.declared_filters), 0)
         self.assertEqual(len(F.base_filters), 0)
@@ -612,6 +613,7 @@ class FilterSetStrictnessTests(TestCase):
         class F(FilterSet):
             class Meta:
                 model = User
+                fields = []
 
         # Ensure default is not IGNORE
         self.assertEqual(F().strict, STRICTNESS.RETURN_NO_RESULTS)
@@ -624,6 +626,7 @@ class FilterSetStrictnessTests(TestCase):
         class F(FilterSet):
             class Meta:
                 model = User
+                fields = []
                 strict = STRICTNESS.IGNORE
 
         self.assertEqual(F().strict, STRICTNESS.IGNORE)
@@ -632,6 +635,7 @@ class FilterSetStrictnessTests(TestCase):
         class F(FilterSet):
             class Meta:
                 model = User
+                fields = []
                 strict = STRICTNESS.IGNORE
 
         strict = STRICTNESS.RAISE_VALIDATION_ERROR
@@ -641,6 +645,7 @@ class FilterSetStrictnessTests(TestCase):
         class F(FilterSet):
             class Meta:
                 model = User
+                fields = []
 
         self.assertEqual(F(strict=False).strict, STRICTNESS.IGNORE)
 
@@ -770,6 +775,7 @@ class FilterMethodTests(TestCase):
 
             class Meta:
                 model = User
+                fields = []
 
             def filter_f(inner_self, qs, name, value):
                 self.assertIsInstance(inner_self, F)

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -532,6 +532,16 @@ class FilterSetClassCreationTests(TestCase):
 
         self.assertEqual(list(F.base_filters.keys()), ['ip', 'mask'])
 
+    def test_custom_declared_field_no_warning(self):
+        class F(FilterSet):
+            mask = CharFilter()
+
+            class Meta:
+                model = NetworkSetting
+                fields = ['mask']
+
+        self.assertEqual(list(F.base_filters.keys()), ['mask'])
+
     def test_filterset_for_proxy_model(self):
         class F(FilterSet):
             class Meta:

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -428,9 +428,12 @@ class FilterSetClassCreationTests(TestCase):
                 class Meta:
                     model = Book
                     fields = ('username', 'price', 'other', 'another')
-        self.assertEqual(excinfo.exception.args, (
-            "Meta.fields contains a field that isn't defined "
-            "on this FilterSet: other",))
+
+        self.assertEqual(
+            str(excinfo.exception),
+            "'Meta.fields' contains fields that are not defined on this FilterSet: "
+            "other, another"
+        )
 
     def test_meta_fields_dictionary_containing_unknown(self):
         with self.assertRaises(TypeError):


### PR DESCRIPTION
This is a partial fix on #504 by asserting that `Meta.fields` or `Meta.exclude` is present when `Meta.model` is provided.

Additionally, refactored the filter generation such that it doesn't unnecessarily generate filters for already declared filters. This fixes #461 such that it is no longer necessary to have to specify `filter_overrides` for unrecognized, but declared filter fields. This is partially based on DRF's serializers.