### PR TITLE
Add widgets and labels options to FilterSet meta class a la Django Core's forms

### DIFF
--- a/docs/ref/filterset.txt
+++ b/docs/ref/filterset.txt
@@ -202,28 +202,20 @@ filters for a model field, you can override ``filter_for_lookup()``. Ex::
             # use default behavior otherwise
             return super(ProductFilter, cls).filter_for_lookup(f, lookup_type)
 
+Custom Widgets and Labels
+-------------------------
 
-``get_ordering_field()``
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you want to use a custom widget, or in any other way override the ordering
-field you can override the ``get_ordering_field()`` method on a ``FilterSet``.
-This method just needs to return a Form Field.
-
-Ordering on multiple fields, or other complex orderings can be achieved by
-overriding the ``FilterSet.get_order_by()`` method. This is passed the selected
-``order_by`` value, and is expected to return an iterable of values to pass to
-``QuerySet.order_by``. For example, to sort a ``User`` table by last name, then
-first name::
+If you want to use a custom widget or label for an auto-generated field, you can
+do so in the same way as in Django's form syntax, using the Meta class::
 
     class UserFilter(django_filters.FilterSet):
         class Meta:
-            order_by = (
-                ('username', 'Username'),
-                ('last_name', 'Last Name')
-            )
-
-        def get_order_by(self, order_value):
-            if order_value == 'last_name':
-                return ['last_name', 'first_name']
-            return super(UserFilter, self).get_order_by(order_value)
+            fields = ['username', 'last_name']
+            widgets = {
+                'username': forms.Textarea(),
+                'last_name': forms.TextField(attrs = {'class': 'someclass'})
+            }
+            labels = {
+                'username': 'User Name',
+                'last_name': 'Surname'
+            }

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -570,6 +570,23 @@ class FilterSetClassCreationTests(TestCase):
         self.assertEqual(django.forms.Textarea, type(F.base_filters['username'].widget))
         self.assertEqual(django.forms.RadioSelect, type(F.base_filters['is_active'].widget))
 
+    def test_meta_labels(self):
+        USER_NAME_LABEL = 'User Name'
+        FIRST_NAME_LABEL = 'Forename'
+        LAST_NAME_LABEL = 'Surname'
+
+        class F(FilterSet):
+            class Meta:
+                model = User
+                fields = '__all__'
+                labels = {
+                    'username': USER_NAME_LABEL,
+                    'first_name': FIRST_NAME_LABEL,
+                    'last_name': LAST_NAME_LABEL
+                }
+        self.assertEqual(USER_NAME_LABEL, F.base_filters['username'].label)
+        self.assertEqual(FIRST_NAME_LABEL, F.base_filters['first_name'].label)
+        self.assertEqual(LAST_NAME_LABEL, F.base_filters['last_name'].label)
 
 class FilterSetInstantiationTests(TestCase):
 

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -557,6 +557,19 @@ class FilterSetClassCreationTests(TestCase):
             list(F.base_filters) + ['amount_saved'],
             list(FtiF.base_filters))
 
+    def test_meta_widgets(self):
+        class F(FilterSet):
+            class Meta:
+                model = User
+                fields = '__all__'
+                widgets = {
+                    'username': django.forms.Textarea(),
+                    'is_active': django.forms.RadioSelect(choices=[(True, 'Yes'), (False, 'No')])
+                }
+
+        self.assertEqual(django.forms.Textarea, type(F.base_filters['username'].widget))
+        self.assertEqual(django.forms.RadioSelect, type(F.base_filters['is_active'].widget))
+
 
 class FilterSetInstantiationTests(TestCase):
 


### PR DESCRIPTION
Allow a 'widgets' and 'labels' option in the Meta class similar to django forms ([e.g.](https://docs.djangoproject.com/en/1.10/topics/forms/modelforms/#overriding-the-default-fields)) to allow easier customization of widgets and labels without having to redefine the field.

Also removed some deprecated documentation regarding "get_ordering_field()" and "get_order_by()" overrides that were tangentially related in the filterset reference.