### PR TITLE
Try importing `rest_framework` module

### DIFF
--- a/django_filters/__init__.py
+++ b/django_filters/__init__.py
@@ -4,6 +4,13 @@ from .constants import STRICTNESS
 from .filterset import FilterSet
 from .filters import *
 
+# We make the `rest_framework` module available without an additional import.
+#   If DRF is not installed we simply set None.
+try:
+    from . import rest_framework
+except ImportError:
+    rest_frameork = None
+
 __version__ = '1.0.0'
 
 

--- a/django_filters/__init__.py
+++ b/django_filters/__init__.py
@@ -9,7 +9,7 @@ from .filters import *
 try:
     from . import rest_framework
 except ImportError:
-    rest_frameork = None
+    rest_framework = None
 
 __version__ = '1.0.0'
 


### PR DESCRIPTION
Fixes #567 

Tries to import the `rest_framework` module — making it available from the `django_filters` namespace. 

Sets `rest_framework=None` if DRF is not installed. (I'm thinking that's enough of a fallback.)