### PR TITLE
Fix django_filters importability in Django settings

### DIFF
--- a/django_filters/compat.py
+++ b/django_filters/compat.py
@@ -11,7 +11,9 @@ try:
 except ImportError:
     crispy_forms = None
 
-is_crispy = 'crispy_forms' in settings.INSTALLED_APPS and crispy_forms
+
+def is_crispy():
+    return 'crispy_forms' in settings.INSTALLED_APPS and crispy_forms
 
 
 # coreapi is optional (Note that uritemplate is a dependency of coreapi)

--- a/django_filters/conf.py
+++ b/django_filters/conf.py
@@ -1,4 +1,6 @@
 
+from __future__ import absolute_import
+
 from django.conf import settings as dj_settings
 from django.core.signals import setting_changed
 from django.utils.translation import ugettext_lazy as _
@@ -63,8 +65,13 @@ DEFAULTS = {
 
 DEPRECATED_SETTINGS = [
     'HELP_TEXT_FILTER',
-    'HELP_TEXT_EXCLUDE'
+    'HELP_TEXT_EXCLUDE',
 ]
+
+
+def is_callable(value):
+    # check for callables, except types
+    return callable(value) and not isinstance(value, type)
 
 
 class Settings(object):

--- a/django_filters/constants.py
+++ b/django_filters/constants.py
@@ -2,14 +2,14 @@
 ALL_FIELDS = '__all__'
 
 
-class STRICTNESS:
-    class IGNORE:
+class STRICTNESS(object):
+    class IGNORE(object):
         pass
 
-    class RETURN_NO_RESULTS:
+    class RETURN_NO_RESULTS(object):
         pass
 
-    class RAISE_VALIDATION_ERROR:
+    class RAISE_VALIDATION_ERROR(object):
         pass
 
     # Values of False & True chosen for backward compatability reasons.

--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -29,18 +29,20 @@ FILTER_TEMPLATE = """
 """
 
 
-if compat.is_crispy:
-    template_path = 'django_filters/rest_framework/crispy_form.html'
-    template_default = CRISPY_TEMPLATE
-
-else:
-    template_path = 'django_filters/rest_framework/form.html'
-    template_default = FILTER_TEMPLATE
-
-
 class DjangoFilterBackend(BaseFilterBackend):
     default_filter_set = filterset.FilterSet
-    template = template_path
+
+    @property
+    def template(self):
+        if compat.is_crispy():
+            return 'django_filters/rest_framework/crispy_form.html'
+        return 'django_filters/rest_framework/form.html'
+
+    @property
+    def template_default(self):
+        if compat.is_crispy():
+            return CRISPY_TEMPLATE
+        return FILTER_TEMPLATE
 
     def get_filter_class(self, view, queryset=None):
         """
@@ -85,7 +87,7 @@ class DjangoFilterBackend(BaseFilterBackend):
         try:
             template = loader.get_template(self.template)
         except TemplateDoesNotExist:
-            template = Template(template_default)
+            template = Template(self.template_default)
 
         return template_render(template, context={
             'filter': filter_instance

--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 
 from django.template import RequestContext, Template, TemplateDoesNotExist, loader
 from django.utils import six
-from rest_framework.filters import BaseFilterBackend
 
 from .. import compat
 from . import filterset
@@ -28,7 +27,7 @@ FILTER_TEMPLATE = """
 """
 
 
-class DjangoFilterBackend(BaseFilterBackend):
+class DjangoFilterBackend(object):
     default_filter_set = filterset.FilterSet
 
     @property

--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -1,9 +1,8 @@
 
 from __future__ import absolute_import
 
-from django.template import Template, TemplateDoesNotExist, loader
+from django.template import RequestContext, Template, TemplateDoesNotExist, loader
 from django.utils import six
-from rest_framework.compat import template_render
 from rest_framework.filters import BaseFilterBackend
 
 from .. import compat
@@ -89,9 +88,11 @@ class DjangoFilterBackend(BaseFilterBackend):
         except TemplateDoesNotExist:
             template = Template(self.template_default)
 
-        return template_render(template, context={
+        context = RequestContext(request, {
             'filter': filter_instance
         })
+
+        return template.render(context)
 
     def get_schema_fields(self, view):
         # This is not compatible with widgets where the query param differs from the

--- a/django_filters/rest_framework/filterset.py
+++ b/django_filters/rest_framework/filterset.py
@@ -9,10 +9,6 @@ from django_filters import filterset
 from .filters import BooleanFilter, IsoDateTimeFilter
 from .. import compat
 
-if compat.is_crispy:
-    from crispy_forms.helper import FormHelper
-    from crispy_forms.layout import Layout, Submit
-
 
 FILTER_FOR_DBFIELD_DEFAULTS = deepcopy(filterset.FILTER_FOR_DBFIELD_DEFAULTS)
 FILTER_FOR_DBFIELD_DEFAULTS.update({
@@ -27,7 +23,10 @@ class FilterSet(filterset.FilterSet):
     def __init__(self, *args, **kwargs):
         super(FilterSet, self).__init__(*args, **kwargs)
 
-        if compat.is_crispy:
+        if compat.is_crispy():
+            from crispy_forms.helper import FormHelper
+            from crispy_forms.layout import Layout, Submit
+
             layout_components = list(self.form.fields.keys()) + [
                 Submit('', _('Submit'), css_class='btn-default'),
             ]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,3 +1,9 @@
+
+# ensure package/conf is importable
+from django_filters import STRICTNESS
+from django_filters.conf import DEFAULTS
+
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
@@ -34,5 +40,7 @@ STATIC_URL = '/static/'
 
 # help verify that DEFAULTS is importable from conf.
 def FILTERS_VERBOSE_LOOKUPS():
-    from django_filters.conf import DEFAULTS
     return DEFAULTS['VERBOSE_LOOKUPS']
+
+
+FILTERS_STRICTNESS = STRICTNESS.RETURN_NO_RESULTS

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -127,7 +127,7 @@ class IsCallableTests(TestCase):
         def func():
             pass
 
-        class Class():
+        class Class(object):
             def __call__(self):
                 pass
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,7 +1,7 @@
 
 from django.test import TestCase, override_settings
 
-from django_filters.conf import settings
+from django_filters.conf import settings, is_callable
 from django_filters import FilterSet, STRICTNESS
 
 from tests.models import User
@@ -119,3 +119,24 @@ class OverrideSettingsTests(TestCase):
 
         self.assertFalse(hasattr(settings, 'FILTERS_FOOBAR'))
         self.assertFalse(hasattr(settings, 'FOOBAR'))
+
+
+class IsCallableTests(TestCase):
+
+    def test_behavior(self):
+        def func():
+            pass
+
+        class Class():
+            def __call__(self):
+                pass
+
+            def method(self):
+                pass
+
+        c = Class()
+
+        self.assertTrue(is_callable(func))
+        self.assertFalse(is_callable(Class))
+        self.assertTrue(is_callable(c))
+        self.assertTrue(is_callable(c.method))


### PR DESCRIPTION
This aims to fix #575, and makes `django_filters` safe to import inside of Django's settings. 

- Settings are lazily resolved with `__getattr__` instead of being initialized in the `__init__`.
  - `VERBOSE_LOOKUPS` no longer has special callable handling - this was generalized to apply to all settings. 
- `is_crispy` is now a function and invoked from the backend's methods. This defers the `INSTALLED_APPS` check to not occur during module import. 

Side note:
In order for this to work, the backend can no longer inherit from DRF's `BaseFilterBackend`.  `rest_framework.filters` imports `rest_framework.compat` which in turn accesses django's settings. Looking through DRF's code, it's not actually necessary to inherit from `BaseFilterBackend`. Inheriting from `object` *should* be safe?