### PR TITLE
Fixed 'UTC' object is not callable in Django > 1.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 docs/_build
 .python-version
 .tox
+.coverage

--- a/django_filters/utils.py
+++ b/django_filters/utils.py
@@ -146,7 +146,7 @@ def handle_timezone(value):
     if settings.USE_TZ and timezone.is_naive(value):
         return timezone.make_aware(value, timezone.get_default_timezone())
     elif not settings.USE_TZ and timezone.is_aware(value):
-        return timezone.make_naive(value, timezone.UTC())
+        return timezone.make_naive(value, timezone.utc)
     return value
 
 


### PR DESCRIPTION
Fixed `UTC` object is not callable in Django > 1.10.
Added `.coverage` to `.gitignore `.