### PR TITLE
Fixed direct assignment to the forward side m2m set is deprecated.

### DIFF
--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -528,8 +528,8 @@ class ModelMultipleChoiceFilterTests(TestCase):
                                  average_rating=3.0)
         Book.objects.create(title="Stranger in a Strage Land", price='1.00',
                             average_rating=3.0)
-        alex.favorite_books = [b1, b2]
-        aaron.favorite_books = [b1, b3]
+        alex.favorite_books.add(b1, b2)
+        aaron.favorite_books.add(b1, b3)
 
         self.alex = alex
 
@@ -1290,8 +1290,8 @@ class M2MRelationshipTests(TestCase):
                                  average_rating=4.0)
         Book.objects.create(title="Stranger in a Strage Land", price='2.00',
                             average_rating=3.0)
-        alex.favorite_books = [b1, b2]
-        aaron.favorite_books = [b1, b3]
+        alex.favorite_books.add(b1, b2)
+        aaron.favorite_books.add(b1, b3)
 
     def test_m2m_relation(self):
         class F(FilterSet):


### PR DESCRIPTION
Fixed `RemovedInDjango20Warning: Direct assignment to the forward side of a many-to-many set is deprecated due to the implicit save() that happens`.