### PR TITLE
Fixed field widget AssertionError.

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -202,9 +202,10 @@ class BaseCSVFieldTests(TestCase):
         self.assertIn("'BaseCSVField.widget' must be a widget class", msg)
         self.assertIn("RangeWidget", msg)
 
-        widget = CSVWidget()
+        widget = CSVWidget(attrs={'class': 'class'})
         field = BaseCSVField(widget=widget)
-        self.assertIs(field.widget, widget)
+        self.assertIsInstance(field.widget, CSVWidget)
+        self.assertEqual(field.widget.attrs, {'class': 'class'})
 
         field = BaseCSVField(widget=CSVWidget)
         self.assertIsInstance(field.widget, CSVWidget)


### PR DESCRIPTION
Fixed field widget `AssertionError`:
```
======================================================================
FAIL: test_derived_widget (tests.test_fields.BaseCSVFieldTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/carltongibson/django-filter/tests/test_fields.py", line 207, in test_derived_widget
    self.assertIs(field.widget, widget)
AssertionError: <django_filters.widgets.CSVWidget object at 0x7f8cef9b5198> is not <django_filters.widgets.CSVWidget object at 0x7f8cef9b5240>
```
Due to [09da1e79](https://github.com/django/django/commit/09da1e79de5a03a63610822bd4e5fc2adcbeb38a) commit (Django > 1.10) widget is a copy rather than exactly the same object that was passed to `__init__`.