### PR TITLE
Fixed value_from_datadict due to django.utils.datastructures.MultiValueDict.getlist behaviour change.

### DIFF
--- a/django_filters/widgets.py
+++ b/django_filters/widgets.py
@@ -187,6 +187,10 @@ class QueryArrayWidget(BaseCSVWidget, forms.TextInput):
 
     def value_from_datadict(self, data, files, name):
         if not isinstance(data, MultiValueDict):
+            for key, value in data.items():
+                # treat value as csv string: ?foo=1,2
+                if isinstance(value, string_types):
+                    data[key] = [x.strip() for x in value.rstrip(',').split(',') if x]
             data = MultiValueDict(data)
 
         values_list = data.getlist(name, data.getlist('%s[]' % name)) or []
@@ -197,12 +201,8 @@ class QueryArrayWidget(BaseCSVWidget, forms.TextInput):
         # apparently its an array, so no need to process it's values as csv
         # ?foo=1&foo=2 -> data.getlist(foo) -> foo = [1, 2]
         # ?foo[]=1&foo[]=2 -> data.getlist(foo[]) -> foo = [1, 2]
-        if len(values_list) > 1:
+        if len(values_list) > 0:
             ret = [x for x in values_list if x]
-        elif len(values_list) == 1:
-            # treat first element as csv string
-            # ?foo=1,2 -> data.getlist(foo) -> foo = ['1,2']
-            ret = [x.strip() for x in values_list[0].rstrip(',').split(',') if x]
         else:
             ret = []
 


### PR DESCRIPTION
Fixed `test_widget_value_from_datadict` `AssertionError`:
```
======================================================================
FAIL: test_widget_value_from_datadict (tests.test_widgets.QueryArrayWidgetTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "django-filter/tests/test_widgets.py", line 300, in test_widget_value_from_datadict
    self.assertEqual(sorted(result), ['1', '2'])
AssertionError: Lists differ: [',', '1', '2'] != ['1', '2']
```
Since Django>1.10 `django.utils.datastructures.MultiValueDict.getlist` cast values to `list` type (see commit [727d7ce6](https://github.com/django/django/commit/727d7ce6cba21363470aaefb2dc5353017531be3) line [149](https://github.com/django/django/blob/master/django/utils/datastructures.py#L149)). I moved CSV string values processing before passing it to `MultiValueDict`.