### PR TITLE
Fix declared filters disabling on child filtersets

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -104,7 +104,11 @@ class FilterSetMetaclass(type):
         # merge declared filters from base classes
         for base in reversed(bases):
             if hasattr(base, 'declared_filters'):
-                filters = list(base.declared_filters.items()) + filters
+                filters = [
+                    (name, f) for name, f
+                    in base.declared_filters.items()
+                    if name not in attrs
+                ] + filters
 
         return OrderedDict(filters)
 

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -571,6 +571,21 @@ class FilterSetClassCreationTests(TestCase):
             list(F.base_filters) + ['amount_saved'],
             list(FtiF.base_filters))
 
+    def test_declared_filter_disabling(self):
+        class Parent(FilterSet):
+            f1 = CharFilter()
+            f2 = CharFilter()
+
+        class Child(Parent):
+            f1 = None
+
+        class Grandchild(Child):
+            pass
+
+        self.assertEqual(len(Parent.base_filters), 2)
+        self.assertEqual(len(Child.base_filters), 1)
+        self.assertEqual(len(Grandchild.base_filters), 1)
+
 
 class FilterSetInstantiationTests(TestCase):
 


### PR DESCRIPTION
This should fix #590 by checking that the declared filters on base classes are not present in the class's attrs.