### PR TITLE
Use detox instead of tox in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ python: '3.5'
 cache: pip
 
 install:
-  - pip install coverage tox
+  - pip install coverage detox
 
 script:
   - coverage erase
-  - tox
+  - detox
 
 after_success:
   - coverage combine


### PR DESCRIPTION
If you're not familiar with [detox](https://github.com/tox-dev/detox), it's an official, distributed version of tox. This should make CI jobs significantly faster. (8 min to ~1.5 min)