### PR TITLE
Use direct import. That fixes Django pre-1.11

### DIFF
--- a/django_filters/widgets.py
+++ b/django_filters/widgets.py
@@ -10,7 +10,13 @@ except:
 
 from django import forms
 from django.db.models.fields import BLANK_CHOICE_DASH
-from django.forms.widgets import flatatt
+
+try:
+    from django.forms.utils import flatatt
+except ImportError:
+    # Before Django 1.7
+    from django.forms.util import flatatt
+
 from django.utils.datastructures import MultiValueDict
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe

--- a/django_filters/widgets.py
+++ b/django_filters/widgets.py
@@ -11,11 +11,7 @@ except:
 from django import forms
 from django.db.models.fields import BLANK_CHOICE_DASH
 
-try:
-    from django.forms.utils import flatatt
-except ImportError:
-    # Before Django 1.7
-    from django.forms.util import flatatt
+from django.forms.utils import flatatt
 
 from django.utils.datastructures import MultiValueDict
 from django.utils.encoding import force_text


### PR DESCRIPTION
New import takes function from the module where it is originally defined. That fixes Django trunk (i.e. pre-1.11) where there is no more intermediate import of flatatt in from django.forms.widgets

That also makes code more independent from future changes

Use fallback to support Django 1.5 and 1.6