### PR TITLE
Fixed widget.render due to widget.build_attrs behaviour change.

### DIFF
--- a/django_filters/widgets.py
+++ b/django_filters/widgets.py
@@ -8,6 +8,7 @@ try:
 except:
     from urllib import urlencode  # noqa
 
+import django
 from django import forms
 from django.db.models.fields import BLANK_CHOICE_DASH
 
@@ -38,7 +39,10 @@ class LinkWidget(forms.Widget):
             self.data = {}
         if value is None:
             value = ''
-        final_attrs = self.build_attrs(attrs)
+        if django.VERSION < (1, 11):
+            final_attrs = self.build_attrs(attrs)
+        else:
+            final_attrs = self.build_attrs(self.attrs, extra_attrs=attrs)
         output = ['<ul%s>' % flatatt(final_attrs)]
         options = self.render_options(choices, [value], name)
         if options:


### PR DESCRIPTION
Fixed  `test_widget`, `test_widget_with_blank_choice`, `test_widget_with_option_groups`, `test_widget_without_choices` `AttributeError`, e.g.:
```
======================================================================
ERROR: test_widget (tests.test_widgets.LinkWidgetTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django-filter/tests/test_widgets.py", line 60, in test_widget
    self.assertHTMLEqual(w.render('price', ''), """
  File "/django-filter/django_filters/widgets.py", line 41, in render
    final_attrs = self.build_attrs(attrs)
  File "/django-filter/.tox/warnings/lib/python3.5/site-packages/django/forms/widgets.py", line 231, in build_attrs
    attrs = base_attrs.copy()

AttributeError: 'NoneType' object has no attribute 'copy'
```
Since Django>1.10 `django.forms.Widget.build_attrs` has changed (see commit [b52c7300](https://github.com/django/django/commit/b52c73008a9d67e9ddbb841872dc15cdd3d6ee01#diff-aee6730bae795d31efec3c5d014804a9R229) line 229).