### PR TITLE
Fix #599

### DIFF
--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -757,7 +757,7 @@ If you wish to sort by non-model fields, you'll need to add custom handling to a
 
         def __init__(self, *args, **kwargs):
             super(CustomOrderingFilter, self).__init__(*args, **kwargs)
-            self.choices += [
+            self.extra['choices'] += [
                 ('relevance', 'Relevance'),
                 ('-relevance', 'Relevance (descending)'),
             ]


### PR DESCRIPTION
`OrderingFilter` does not actually have a `choices` property. It's stored under the `extra` kwargs that are passed to the form field.