### PR TITLE
Fully exclude tests modules in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     maintainer='Carlton Gibson',
     maintainer_email='carlton.gibson@noumenal.es',
     url='https://github.com/carltongibson/django-filter/tree/master',
-    packages=find_packages(exclude=['tests']),
+    packages=find_packages(exclude=['tests*']),
     include_package_data=True,
     license='BSD',
     classifiers=[


### PR DESCRIPTION
Just excluding 'tests' doesn't seem to be enough: it results in
tests/rest_framework being installed systemwide when you run
`python setup.py install`. Excluding 'tests*' seems to do the
trick.