### PR TITLE
Fixed RangeWidget. Used custom template instead of format_output.

### DIFF
--- a/django_filters/templates/django_filters/widgets/multiwidget.html
+++ b/django_filters/templates/django_filters/widgets/multiwidget.html
@@ -1,0 +1,1 @@
+{% for widget in widget.subwidgets %}{% include widget.template_name %}{% if forloop.first %}-{% endif %}{% endfor %}

--- a/django_filters/widgets.py
+++ b/django_filters/widgets.py
@@ -87,17 +87,20 @@ class LinkWidget(forms.Widget):
 
 
 class RangeWidget(forms.MultiWidget):
+    template_name = 'django_filters/widgets/multiwidget.html'
+
     def __init__(self, attrs=None):
         widgets = (forms.TextInput, forms.TextInput)
         super(RangeWidget, self).__init__(widgets, attrs)
+
+    def format_output(self, rendered_widgets):
+        # Method was removed in Django 1.11.
+        return '-'.join(rendered_widgets)
 
     def decompress(self, value):
         if value:
             return [value.start, value.stop]
         return [None, None]
-
-    def format_output(self, rendered_widgets):
-        return '-'.join(rendered_widgets)
 
 
 class LookupTypeWidget(forms.MultiWidget):


### PR DESCRIPTION
Fixed `test_widget` and `test_widget_attributes` i.e.:
```
======================================================================
FAIL: test_widget_attributes (tests.test_widgets.RangeWidgetTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django-filter/tests/test_widgets.py", line 145, in test_widget_attributes
    <input type="date" name="date_1" />""")
  File "/django-filter/.tox/py34-djangolatest-restframeworklatest/lib/python3.4/site-packages/django/test/testcases.py", line 708, in assertHTMLEqual
    self.fail(self._formatMessage(msg, standardMsg))
AssertionError:
- <input name="date_0" type="date" /><input name="date_1" type="date" />
+ <input name="date_0" type="date" />-<input name="date_1" type="date" />
```
Since Django>1.10 `Widget.format_output` method is removed (see commit [b52c7300](https://github.com/django/django/commit/b52c73008a9d67e9ddbb841872dc15cdd3d6ee01#diff-aee6730bae795d31efec3c5d014804a9R229) and [doc](https://docs.djangoproject.com/en/dev/releases/1.11/#changes-due-to-the-introduction-of-template-based-widget-rendering)).