### PR TITLE
Fixed coverage combine.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ script:
   - detox
 
 after_success:
-  - coverage combine
-  - coverage report
+  - coverage combine --append
+  - coverage report -m

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
        warnings
 
 [testenv]
-commands = coverage run --source django_filters ./runtests.py {posargs}
+commands = coverage run --parallel-mode --source django_filters ./runtests.py {posargs}
 ignore_outcome =
     django{111,latest}: True
 setenv =


### PR DESCRIPTION
Due to `coverage` backward incompatibility (see v.4.2 [release notes](http://coverage.readthedocs.io/en/coverage-4.2/changes.html?highlight=append#version-4-2-2016-07-26)). I also added flag to show the line numbers of missing statements.