### PR TITLE
[WIP] Final Django 1.11 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 
 language: python
-python: "3.6"
+python: "3.5"
 
 cache: pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,7 @@
 sudo: false
 
 language: python
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
+python: "3.6"
 
 cache: pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 sudo: false
 
 language: python
-python: '3.5'
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+
 cache: pip
 
 install:

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Requirements
 
 * **Python**: 2.7, 3.3, 3.4, 3.5
 * **Django**: 1.8, 1.9, 1.10
-* **DRF**: 3.4, 3.5
+* **DRF**: 3.5
 
 Installation
 ------------

--- a/docs/guide/install.txt
+++ b/docs/guide/install.txt
@@ -15,7 +15,7 @@ Requirements
 ------------
 
 Django-filter is tested against all supported versions of Python and `Django`__,
-as well as the latest versions of Django REST Framework (`DRF`__).
+as well as the latest version of Django REST Framework (`DRF`__).
 
 __ https://www.djangoproject.com/download/
 __ http://www.django-rest-framework.org/
@@ -24,4 +24,4 @@ __ http://www.django-rest-framework.org/
 
 * **Python**: 2.7, 3.3, 3.4, 3.5
 * **Django**: 1.8, 1.9, 1.10
-* **DRF**: 3.4, 3.5
+* **DRF**:  3.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 envlist =
-       {py27,py33,py34,py35}-django18-restframework{34,35},
-       {py27,py34,py35}-django{19,110}-restframework{34,35},
-       {py27,py34,py35}-django111-restframework35,
+       {py27,py33,py34,py35}-django18-restframework35,
+       {py27,py34,py35}-django{19,110,111}-restframework35,
        {py35}-djangolatest-restframeworklatest,
        warnings
 
@@ -18,7 +17,6 @@ deps =
     django110: django>=1.10.0,<1.11.0
     django111: django>=1.11a1,<2.0
     djangolatest: https://github.com/django/django/archive/master.tar.gz
-    restframework34: djangorestframework>=3.4,<3.5
     restframework35: djangorestframework>=3.5,<3.6
     restframeworklatest: https://github.com/tomchristie/django-rest-framework/archive/master.tar.gz
     -rrequirements/test-ci.txt

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
        {py27,py33,py34,py35}-django18-restframework{34,35},
        {py27,py34,py35}-django{19,110}-restframework{34,35},
-       {py27,py34,py35,py36}-django111-restframework35,
-       {py35,py36}-djangolatest-restframeworklatest,
+       {py27,py34,py35}-django111-restframework35,
+       {py35}-djangolatest-restframeworklatest,
        warnings
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
 [testenv]
 commands = coverage run --parallel-mode --source django_filters ./runtests.py {posargs}
 ignore_outcome =
-    django{111,latest}: True
+    djangolatest: True
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
        {py27,py33,py34,py35}-django18-restframework{34,35},
-       {py27,py34,py35}-django{19,110,111}-restframework{34,35},
+       {py27,py34,py35}-django{19,110}-restframework{34,35},
+       {py27,py34,py35}-django111-restframework35,
        {py35}-djangolatest-restframeworklatest,
        warnings
 


### PR DESCRIPTION
Closed #607

...should now just be correcting the test matrix...

* [x] Make 1.11 build required. 
* [ ] Fix what broke (remove incompatible options from matrix)
    * [x] Drop DRF 3.4. with Django 1.11
    * [x] Query if/when DRF 3.5.4 will land
* [ ] Anything else?

Then: merge #577 and release