### PR TITLE
Drop DRF 3.4 from test matrix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Requirements
 
 * **Python**: 2.7, 3.3, 3.4, 3.5
 * **Django**: 1.8, 1.9, 1.10
-* **DRF**: 3.4, 3.5
+* **DRF**: 3.5
 
 Installation
 ------------

--- a/docs/guide/install.txt
+++ b/docs/guide/install.txt
@@ -15,7 +15,7 @@ Requirements
 ------------
 
 Django-filter is tested against all supported versions of Python and `Django`__,
-as well as the latest versions of Django REST Framework (`DRF`__).
+as well as the latest version of Django REST Framework (`DRF`__).
 
 __ https://www.djangoproject.com/download/
 __ http://www.django-rest-framework.org/
@@ -24,4 +24,4 @@ __ http://www.django-rest-framework.org/
 
 * **Python**: 2.7, 3.3, 3.4, 3.5
 * **Django**: 1.8, 1.9, 1.10
-* **DRF**: 3.4, 3.5
+* **DRF**: 3.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-       {py27,py33,py34,py35}-django18-restframework{34,35},
-       {py27,py34,py35}-django{19,110,111}-restframework{34,35},
+       {py27,py33,py34,py35}-django18-restframework35,
+       {py27,py34,py35}-django{19,110,111}-restframework35,
        {py35}-djangolatest-restframeworklatest,
        warnings
 
@@ -17,7 +17,6 @@ deps =
     django110: django>=1.10.0,<1.11.0
     django111: django>=1.11a1,<2.0
     djangolatest: https://github.com/django/django/archive/master.tar.gz
-    restframework34: djangorestframework>=3.4,<3.5
     restframework35: djangorestframework>=3.5,<3.6
     restframeworklatest: https://github.com/tomchristie/django-rest-framework/archive/master.tar.gz
     -rrequirements/test-ci.txt


### PR DESCRIPTION
It's probably overkill to support the latest two minor versions of DRF.