### PR TITLE
Add python 3.6 to test matrix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
        {py27,py33,py34,py35}-django18-restframework{34,35},
        {py27,py34,py35}-django{19,110}-restframework{34,35},
-       {py27,py34,py35}-django111-restframework35,
-       {py35}-djangolatest-restframeworklatest,
+       {py27,py34,py35,py36}-django111-restframework35,
+       {py35,py36}-djangolatest-restframeworklatest,
        warnings
 
 [testenv]


### PR DESCRIPTION
Django 1.11 adds support for Python 3.6.  https://docs.djangoproject.com/en/dev/releases/1.11/

Regards carltongibson/django-filter#624