### PR TITLE
Use docker for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,15 @@
-sudo: false
+sudo: required
+
+services:
+  - docker
 
 language: python
-python: "3.5"
 
-cache: pip
+# TODO: Re-add coverage.
 
-install:
-  - pip install coverage detox
+before_install:
+  - docker build -t carltongibson/django-filter .
 
 script:
-  - coverage erase
-  - detox
+  - docker run --rm carltongibson/django-filter
 
-after_success:
-  - coverage combine --append
-  - coverage report -m

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ ADD . /src/
 # Whilst .gitignored we may be using pyenv locally...
 RUN if [ -f .python-version ] ; then rm .python-version; fi
 
-CMD ["tox"]
+CMD ["detox"]
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM carlton/django-docker-testing:dev
 RUN mkdir /src
 WORKDIR /src
 ADD . /src/
-RUN rm .python-version
+
+# Whilst .gitignored we may be using pyenv locally...
+RUN if [ -f .python-version ] ; then rm .python-version; fi
 
 CMD ["tox"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM python:3.6
-
+FROM carlton/django-docker-testing:dev
 
 RUN mkdir /src
 WORKDIR /src
 ADD . /src/
+RUN rm .python-version
 
-RUN pip install tox
-RUN tox -e py36-djangolatest-restframeworklatest
+CMD ["tox"]
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.6
+
+
+RUN mkdir /src
+WORKDIR /src
+ADD . /src/
+
+RUN pip install tox
+RUN tox -e py36-djangolatest-restframeworklatest

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ ADD . /src/
 # Whilst .gitignored we may be using pyenv locally...
 RUN if [ -f .python-version ] ; then rm .python-version; fi
 
+# Prime pip cache
+RUN pip install -r requirements/test-ci.txt
+
 CMD ["detox"]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
        {py27,py33,py34,py35}-django18-restframework35,
        {py27,py34,py35}-django{19,110,111}-restframework35,
-       {py35}-djangolatest-restframeworklatest,
+       {py35,py36}-djangolatest-restframeworklatest,
        warnings
 
 [testenv]


### PR DESCRIPTION
Having played with Travis for Python 3.6 support, and not wanting to duplicate the tox config if possible, I thought to try using a preconfigured image with docker. 

Not sure whether to merge this. A little slow-down would OK — I **really** don't want to duplicate the build matrix — that is a pain — but it would be nice to do better that 2x

* [ ] Re-add coverage
* [ ] Investigate caching first image fetch (≈50secs.)
* [ ] Why no time difference between `tox` build and `detox` build? (cp 1065 vs 1066 — diff of 2s)
* [ ] Why slower than before (even allowing for image fetch)? [Build 1024 2m10s](https://travis-ci.org/carltongibson/django-filter/builds/200094690) vs [Build 1066 5m34s?](https://travis-ci.org/carltongibson/django-filter/builds/200733744) — so if we could cache the image fetch we're looking at 2mins vs 4...