### PR TITLE
Add support for dict in together config of FilterSet

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -52,12 +52,23 @@ def get_full_clean_override(together):
 
         super(form.__class__, form).full_clean()
         message = 'Following fields must be together: %s'
-        if isinstance(together[0], (list, tuple)):
+        if isinstance(together[0], six.string_types):
+            if all_valid(together):
+                return add_error(message % ','.join(together))
+        else:
             for each in together:
-                if all_valid(each):
-                    return add_error(message % ','.join(each))
-        elif all_valid(together):
-            return add_error(message % ','.join(together))
+                if isinstance(each, (tuple, list)):
+                    if all_valid(each):
+                        return add_error(message % ','.join(each))
+                elif isinstance(each, dict):
+                    for k, v in each.items():
+                        if k in form.data:
+                            together_item = (k,) + tuple(v)
+                            if all_valid(together_item):
+                                return add_error(message % ','.join(together_item))
+                else:
+                    raise NotImplementedError(
+                        'Type of together value not supported {}'.format(each))
     return full_clean
 
 

--- a/docs/ref/filterset.txt
+++ b/docs/ref/filterset.txt
@@ -121,6 +121,25 @@ field set must either be all or none present in the request for
             together = ['rating', 'price']
 
 
+Additionally, a dict value can be given within the list, in that case
+the key of the dict tell that a filter needs the presence of other filters in
+its value to function.
+
+``FilterSet.form`` to be valid::
+
+    import django_filters
+
+    class ProductFilter(django_filters.FilterSet):
+        class Meta:
+            model = Product
+            fields = ['price', 'release_date', 'rating']
+            together = [{'rating': ['price']}]
+
+
+In this example, ``rating`` requires ``price``, but ``price`` doesn't need
+``rating`` to work.
+
+
 .. _filter_overrides:
 
 Customise filter generation with ``filter_overrides``

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -718,6 +718,27 @@ class FilterSetTogetherTests(TestCase):
         self.assertEqual(f.qs.count(), 1)
         self.assertQuerysetEqual(f.qs, [self.alex.pk], lambda o: o.pk)
 
+    def test_fields_set_with_dict(self):
+        class F(FilterSet):
+            class Meta:
+                model = User
+                fields = ['username', 'status', 'is_active', 'first_name']
+                together = [
+                    ({'username': ['status']}),
+                    ({'first_name': ['is_active']}),
+                ]
+
+        f = F({}, queryset=self.qs)
+        self.assertEqual(f.qs.count(), 2)
+        f = F({'username': 'alex'}, queryset=self.qs)
+        self.assertEqual(f.qs.count(), 0)
+        f = F({'username': 'alex', 'status': 1}, queryset=self.qs)
+        self.assertEqual(f.qs.count(), 1)
+        self.assertQuerysetEqual(f.qs, [self.alex.pk], lambda o: o.pk)
+        f = F({'status': 1}, queryset=self.qs)
+        self.assertEqual(f.qs.count(), 1)
+        self.assertQuerysetEqual(f.qs, [self.alex.pk], lambda o: o.pk)
+
 
 # test filter.method here, as it depends on its parent FilterSet
 class FilterMethodTests(TestCase):


### PR DESCRIPTION
Allows to tell a filter is dependent of others, but others
can still be used independently.

Example `name` filter needs `surname` filter to work, but
`surname` filter doesn't `name` to function.
In that case the together entry will be written:

```python
class Meta:
    together = [{'name': ['surname']}]
```