### PR TITLE
'Together' form override fixups

### DIFF
--- a/django_filters/constants.py
+++ b/django_filters/constants.py
@@ -2,6 +2,9 @@
 ALL_FIELDS = '__all__'
 
 
+EMPTY_VALUES = ([], (), {}, '', None)
+
+
 class STRICTNESS(object):
     class IGNORE(object):
         pass

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -14,6 +14,7 @@ from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
 
 from .conf import settings
+from .constants import EMPTY_VALUES
 from .fields import (
     Lookup, LookupTypeField, BaseCSVField, BaseRangeField, RangeField,
     DateRangeField, DateTimeRangeField, TimeRangeField, IsoDateTimeField
@@ -54,9 +55,6 @@ __all__ = [
 
 
 LOOKUP_TYPES = sorted(QUERY_TERMS)
-
-
-EMPTY_VALUES = ([], (), {}, '', None)
 
 
 class Filter(object):

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -40,15 +40,15 @@ def get_full_clean_override(together):
         def all_valid(fieldset):
             cleaned_data = form.cleaned_data
             count = len([i for i in fieldset if cleaned_data.get(i)])
-            return 0 < count < len(fieldset)
+            return not (0 < count < len(fieldset))
 
         super(form.__class__, form).full_clean()
         message = 'Following fields must be together: %s'
         if isinstance(together[0], (list, tuple)):
             for each in together:
-                if all_valid(each):
+                if not all_valid(each):
                     return form.add_error(None, message % ','.join(each))
-        elif all_valid(together):
+        elif not all_valid(together):
             return form.add_error(None, message % ','.join(together))
     return full_clean
 

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -36,6 +36,10 @@ def get_filter_name(field_name, lookup_expr):
 
 
 def get_full_clean_override(together):
+    # coerce together to list of pairs
+    if isinstance(together[0], (six.string_types)):
+        together = [together]
+
     def full_clean(form):
         def all_valid(fieldset):
             field_presence = [
@@ -49,12 +53,11 @@ def get_full_clean_override(together):
 
         super(form.__class__, form).full_clean()
         message = 'Following fields must be together: %s'
-        if isinstance(together[0], (list, tuple)):
-            for each in together:
-                if not all_valid(each):
-                    return form.add_error(None, message % ','.join(each))
-        elif not all_valid(together):
-            return form.add_error(None, message % ','.join(together))
+
+        for each in together:
+            if not all_valid(each):
+                return form.add_error(None, message % ','.join(each))
+
     return full_clean
 
 

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -5,7 +5,6 @@ import copy
 from collections import OrderedDict
 
 from django import forms
-from django.forms.forms import NON_FIELD_ERRORS
 from django.db import models
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.fields.related import ForeignObjectRel
@@ -38,13 +37,6 @@ def get_filter_name(field_name, lookup_expr):
 
 def get_full_clean_override(together):
     def full_clean(form):
-
-        def add_error(message):
-            try:
-                form.add_error(None, message)
-            except AttributeError:
-                form._errors[NON_FIELD_ERRORS] = message
-
         def all_valid(fieldset):
             cleaned_data = form.cleaned_data
             count = len([i for i in fieldset if cleaned_data.get(i)])
@@ -55,9 +47,9 @@ def get_full_clean_override(together):
         if isinstance(together[0], (list, tuple)):
             for each in together:
                 if all_valid(each):
-                    return add_error(message % ','.join(each))
+                    return form.add_error(None, message % ','.join(each))
         elif all_valid(together):
-            return add_error(message % ','.join(together))
+            return form.add_error(None, message % ','.join(together))
     return full_clean
 
 

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -718,6 +718,18 @@ class FilterSetTogetherTests(TestCase):
         self.assertEqual(f.qs.count(), 1)
         self.assertQuerysetEqual(f.qs, [self.alex.pk], lambda o: o.pk)
 
+    def test_empty_values(self):
+        class F(FilterSet):
+            class Meta:
+                model = User
+                fields = ['username', 'status']
+                together = ['username', 'status']
+
+        f = F({'username': '', 'status': ''}, queryset=self.qs)
+        self.assertEqual(f.qs.count(), 2)
+        f = F({'username': 'alex', 'status': ''}, queryset=self.qs)
+        self.assertEqual(f.qs.count(), 0)
+
 
 # test filter.method here, as it depends on its parent FilterSet
 class FilterMethodTests(TestCase):


### PR DESCRIPTION
While reviewing #647, it got me looking at the 'together' code. Just a few incremental changes that (imo) improve readability. 

- Remove unnecessary `form.add_error` compat.
- `all_valid` seemed to return the opposite result?
- the count testing in `all_valid` seems kind of unpythonic? Refactored w/ `any`/`all`.
- Coerced `together` into a list of lists, allowing the duplicate `all_valid` check to be removed.
- `all_valid` was unnecessarily redefined at every call. broke it out & renamed as a private module function.


Closes #561 