### PR TITLE
Add markdown dependency for testing

### DIFF
--- a/requirements/test-ci.txt
+++ b/requirements/test-ci.txt
@@ -1,3 +1,4 @@
+markdown==2.6.4
 coreapi
 
 coverage


### PR DESCRIPTION
Ref https://travis-ci.org/carltongibson/django-filter/jobs/208346670#L1428

Merging #655 broke the build, failing a `markdown` import for latest DRF.

```
django.template.library.InvalidTemplateLibrary: Invalid template library specified. ImportError raised when trying to load 'rest_framework.templatetags.rest_framework': No module named 'markdown'
```

This adds the dependency.