### PR TITLE
add missing 'self.' to request.user in code example

### DIFF
--- a/docs/guide/usage.txt
+++ b/docs/guide/usage.txt
@@ -190,7 +190,7 @@ those that are published and those that are owned by the logged-in user
         def qs(self):
             parent = super(ArticleFilter, self).qs
             return parent.filter(is_published=True) \
-                | parent.filter(author=request.user)
+                | parent.filter(author=self.request.user)
 
 
 Filtering the related queryset for ``ModelChoiceFilter``


### PR DESCRIPTION
A code example of related queryset was missing the `self.` prefix :)