### PR TITLE
Add new feature to extend FILTER_FOR_DBFIELD_DEFAULTS extras

### DIFF
--- a/django_filters/conf.py
+++ b/django_filters/conf.py
@@ -21,6 +21,8 @@ DEFAULTS = {
 
     'STRICTNESS': STRICTNESS.RETURN_NO_RESULTS,
 
+    'FILTER_OPTIONS': {},
+
     'VERBOSE_LOOKUPS': {
         # transforms don't need to be verbose, since their expressions are chained
         'date': _('date'),

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -17,7 +17,7 @@ from .constants import ALL_FIELDS, STRICTNESS
 from .filters import (Filter, CharFilter, BooleanFilter, BaseInFilter, BaseRangeFilter,
                       ChoiceFilter, DateFilter, DateTimeFilter, TimeFilter, ModelChoiceFilter,
                       ModelMultipleChoiceFilter, NumberFilter, UUIDFilter, DurationFilter)
-from .utils import try_dbfield, get_all_model_fields, get_model_field, resolve_field
+from .utils import try_dbfield, get_all_model_fields, get_model_field, resolve_field, update_filter_options_settings
 
 
 def get_filter_name(field_name, lookup_expr):
@@ -157,6 +157,7 @@ FILTER_FOR_DBFIELD_DEFAULTS = {
         }
     },
 }
+FILTER_FOR_DBFIELD_DEFAULTS = update_filter_options_settings(FILTER_FOR_DBFIELD_DEFAULTS, settings.FILTER_OPTIONS)
 
 
 class BaseFilterSet(object):


### PR DESCRIPTION
Hi,

I need to be able to customize the behavior of all text fields in my project filters. For this reason you have worked on overwriting the extra attributes of FILTER_FOR_DBFIELD_DEFAULTS from the django application settings.
How do you see the changes?
In case you were interested in them, I would do the tests and documentation.

Regards.