### PR TITLE
Fix null filtering for *Choice filters

### DIFF
--- a/django_filters/fields.py
+++ b/django_filters/fields.py
@@ -8,6 +8,7 @@ from django.utils.dateparse import parse_datetime
 from django.utils.encoding import force_str
 from django.utils.translation import ugettext_lazy as _
 
+from .conf import settings
 from .utils import handle_timezone
 from .widgets import BaseCSVWidget, CSVWidget, LookupTypeWidget, RangeWidget
 
@@ -179,3 +180,107 @@ class BaseRangeField(BaseCSVField):
                 code='invalid_values')
 
         return value
+
+
+class ChoiceIterator(object):
+    # Emulates the behavior of ModelChoiceIterator, but instead wraps
+    # the field's _choices iterable.
+
+    def __init__(self, field, choices):
+        self.field = field
+        self.choices = choices
+
+    def __iter__(self):
+        if self.field.empty_label is not None:
+            yield ("", self.field.empty_label)
+        if self.field.null_label is not None:
+            yield (self.field.null_value, self.field.null_label)
+
+        # Python 2 lacks 'yield from'
+        for choice in self.choices:
+            yield choice
+
+    def __len__(self):
+        add = 1 if self.field.empty_label is not None else 0
+        add += 1 if self.field.null_label is not None else 0
+        return len(self.choices) + add
+
+
+class ModelChoiceIterator(forms.models.ModelChoiceIterator):
+    # Extends the base ModelChoiceIterator to add in 'null' choice handling.
+    # This is a bit verbose since we have to insert the null choice after the
+    # empty choice, but before the remainder of the choices.
+
+    def __iter__(self):
+        iterable = super(ModelChoiceIterator, self).__iter__()
+
+        if self.field.empty_label is not None:
+            yield next(iterable)
+        if self.field.null_label is not None:
+            yield (self.field.null_value, self.field.null_label)
+
+        # Python 2 lacks 'yield from'
+        for value in iterable:
+            yield value
+
+    def __len__(self):
+        add = 1 if self.field.null_label is not None else 0
+        return super(ModelChoiceIterator, self).__len__() + add
+
+
+class ChoiceIteratorMixin(object):
+    def __init__(self, *args, **kwargs):
+        self.null_label = kwargs.pop('null_label', settings.NULL_CHOICE_LABEL)
+        self.null_value = kwargs.pop('null_value', settings.NULL_CHOICE_VALUE)
+
+        super(ChoiceIteratorMixin, self).__init__(*args, **kwargs)
+
+    def _get_choices(self):
+        return super(ChoiceIteratorMixin, self)._get_choices()
+
+    def _set_choices(self, value):
+        super(ChoiceIteratorMixin, self)._set_choices(value)
+        value = self.iterator(self, self._choices)
+
+        self._choices = self.widget.choices = value
+    choices = property(_get_choices, _set_choices)
+
+
+# Unlike their Model* counterparts, forms.ChoiceField and forms.MultipleChoiceField do not set empty_label
+class ChoiceField(ChoiceIteratorMixin, forms.ChoiceField):
+    iterator = ChoiceIterator
+
+    def __init__(self, *args, **kwargs):
+        self.empty_label = kwargs.pop('empty_label', settings.EMPTY_CHOICE_LABEL)
+        super(ChoiceField, self).__init__(*args, **kwargs)
+
+
+class MultipleChoiceField(ChoiceIteratorMixin, forms.MultipleChoiceField):
+    iterator = ChoiceIterator
+
+    def __init__(self, *args, **kwargs):
+        self.empty_label = None
+        super(MultipleChoiceField, self).__init__(*args, **kwargs)
+
+
+class ModelChoiceField(ChoiceIteratorMixin, forms.ModelChoiceField):
+    iterator = ModelChoiceIterator
+
+    def to_python(self, value):
+        # bypass the queryset value check
+        if self.null_label is not None and value == self.null_value:
+            return value
+        return super(ModelChoiceField, self).to_python(value)
+
+
+class ModelMultipleChoiceField(ChoiceIteratorMixin, forms.ModelMultipleChoiceField):
+    iterator = ModelChoiceIterator
+
+    def _check_values(self, value):
+        null = self.null_label is not None and value and self.null_value in value
+        if null:  # remove the null value and any potential duplicates
+            value = [v for v in value if v != self.null_value]
+
+        result = list(super(ModelMultipleChoiceField, self)._check_values(value))
+        result += [self.null_value] if null else []
+        return result

--- a/django_filters/fields.py
+++ b/django_filters/fields.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 from collections import namedtuple
 from datetime import datetime, time
 
+import django
 from django import forms
 from django.utils.dateparse import parse_datetime
 from django.utils.encoding import force_str
@@ -236,7 +237,14 @@ class ChoiceIteratorMixin(object):
         super(ChoiceIteratorMixin, self).__init__(*args, **kwargs)
 
     def _get_choices(self):
-        return super(ChoiceIteratorMixin, self)._get_choices()
+        if django.VERSION >= (1, 11):
+            return super(ChoiceIteratorMixin, self)._get_choices()
+
+        # HACK: Django < 1.11 does not allow a custom iterator to be provided.
+        # This code only executes for Model*ChoiceFields.
+        if hasattr(self, '_choices'):
+            return self._choices
+        return self.iterator(self)
 
     def _set_choices(self, value):
         super(ChoiceIteratorMixin, self)._set_choices(value)

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -159,6 +159,7 @@ FILTER_FOR_DBFIELD_DEFAULTS = {
         'extra': lambda f: {
             'queryset': remote_queryset(f),
             'to_field_name': remote_field(f).field_name,
+            'null_label': settings.NULL_CHOICE_LABEL if f.null else None,
         }
     },
     models.ForeignKey: {
@@ -166,6 +167,7 @@ FILTER_FOR_DBFIELD_DEFAULTS = {
         'extra': lambda f: {
             'queryset': remote_queryset(f),
             'to_field_name': remote_field(f).field_name,
+            'null_label': settings.NULL_CHOICE_LABEL if f.null else None,
         }
     },
     models.ManyToManyField: {

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -607,6 +607,18 @@ class ModelMultipleChoiceFilterTests(TestCase):
         f = F({'favorite_books': ['4']}, queryset=qs)
         self.assertQuerysetEqual(f.qs, [], lambda o: o.username)
 
+    @override_settings(FILTERS_NULL_CHOICE_LABEL='No Favorites')
+    def test_filtering_null(self):
+        class F(FilterSet):
+            class Meta:
+                model = User
+                fields = ['favorite_books']
+
+        qs = User.objects.all()
+        f = F({'favorite_books': ['null']}, queryset=qs)
+
+        self.assertQuerysetEqual(f.qs, ['jacob'], lambda o: o.username)
+
     def test_filtering_dictionary(self):
         class F(FilterSet):
             class Meta:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -733,6 +733,16 @@ class ModelChoiceFilterTests(TestCase):
         with self.assertRaises(TypeError):
             f.field
 
+    @override_settings(
+        FILTERS_EMPTY_CHOICE_LABEL='EMPTY',
+        FILTERS_NULL_CHOICE_VALUE='NULL', )
+    def test_empty_choices(self):
+        f = ModelChoiceFilter(queryset=User.objects.all(), null_value='null', null_label='NULL')
+        self.assertEqual(list(f.field.choices), [
+            ('', 'EMPTY'),
+            ('null', 'NULL'),
+        ])
+
     def test_default_field_with_queryset(self):
         qs = mock.NonCallableMock(spec=[])
         f = ModelChoiceFilter(queryset=qs)
@@ -774,6 +784,15 @@ class ModelMultipleChoiceFilterTests(TestCase):
         f = ModelMultipleChoiceFilter()
         with self.assertRaises(TypeError):
             f.field
+
+    @override_settings(
+        FILTERS_EMPTY_CHOICE_LABEL='EMPTY',
+        FILTERS_NULL_CHOICE_VALUE='NULL', )
+    def test_empty_choices(self):
+        f = ModelMultipleChoiceFilter(queryset=User.objects.all(), null_value='null', null_label='NULL')
+        self.assertEqual(list(f.field.choices), [
+            ('null', 'NULL'),
+        ])
 
     def test_default_field_with_queryset(self):
         qs = mock.NonCallableMock(spec=[])
@@ -1178,6 +1197,14 @@ class AllValuesFilterTests(TestCase):
         f.model = mocked
         field = f.field
         self.assertIsInstance(field, forms.ChoiceField)
+
+    def test_empty_value_in_choices(self):
+        f = AllValuesFilter(name='username')
+        f.model = User
+
+        self.assertEqual(list(f.field.choices), [
+            ('', '---------'),
+        ])
 
 
 class LookupTypesTests(TestCase):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -313,35 +313,35 @@ class ChoiceFilterTests(TestCase):
     def test_empty_choice(self):
         # default value
         f = ChoiceFilter(choices=[('a', 'a')])
-        self.assertEqual(f.field.choices, [
+        self.assertEqual(list(f.field.choices), [
             ('', '---------'),
             ('a', 'a'),
         ])
 
         # set value, allow blank label
         f = ChoiceFilter(choices=[('a', 'a')], empty_label='')
-        self.assertEqual(f.field.choices, [
+        self.assertEqual(list(f.field.choices), [
             ('', ''),
             ('a', 'a'),
         ])
 
         # disable empty choice w/ None
         f = ChoiceFilter(choices=[('a', 'a')], empty_label=None)
-        self.assertEqual(f.field.choices, [
+        self.assertEqual(list(f.field.choices), [
             ('a', 'a'),
         ])
 
     def test_null_choice(self):
         # default is to be disabled
         f = ChoiceFilter(choices=[('a', 'a')], )
-        self.assertEqual(f.field.choices, [
+        self.assertEqual(list(f.field.choices), [
             ('', '---------'),
             ('a', 'a'),
         ])
 
         # set label, allow blank label
         f = ChoiceFilter(choices=[('a', 'a')], null_label='')
-        self.assertEqual(f.field.choices, [
+        self.assertEqual(list(f.field.choices), [
             ('', '---------'),
             ('null', ''),
             ('a', 'a'),
@@ -349,7 +349,7 @@ class ChoiceFilterTests(TestCase):
 
         # set null value
         f = ChoiceFilter(choices=[('a', 'a')], null_value='NULL', null_label='')
-        self.assertEqual(f.field.choices, [
+        self.assertEqual(list(f.field.choices), [
             ('', '---------'),
             ('NULL', ''),
             ('a', 'a'),
@@ -357,7 +357,7 @@ class ChoiceFilterTests(TestCase):
 
         # explicitly disable
         f = ChoiceFilter(choices=[('a', 'a')], null_label=None)
-        self.assertEqual(f.field.choices, [
+        self.assertEqual(list(f.field.choices), [
             ('', '---------'),
             ('a', 'a'),
         ])
@@ -395,7 +395,7 @@ class ChoiceFilterTests(TestCase):
         FILTERS_NULL_CHOICE_VALUE='NULL VALUE', )
     def test_settings_overrides(self):
         f = ChoiceFilter(choices=[('a', 'a')], )
-        self.assertEqual(f.field.choices, [
+        self.assertEqual(list(f.field.choices), [
             ('', 'EMPTY LABEL'),
             ('NULL VALUE', 'NULL LABEL'),
             ('a', 'a'),
@@ -413,7 +413,7 @@ class ChoiceFilterTests(TestCase):
             yield ('b', 'b')
 
         f = ChoiceFilter(choices=choices)
-        self.assertEqual(f.field.choices, [
+        self.assertEqual(list(f.field.choices), [
             ('', '---------'),
             ('a', 'a'),
             ('b', 'b'),
@@ -1356,7 +1356,7 @@ class OrderingFilterTests(TestCase):
             fields=(('a', 'c'), ('b', 'd')),
         )
 
-        self.assertSequenceEqual(f.field.choices, (
+        self.assertSequenceEqual(list(f.field.choices), (
             ('', '---------'),
             ('a', 'A'),
             ('b', 'B'),
@@ -1367,7 +1367,7 @@ class OrderingFilterTests(TestCase):
             fields=(('a', 'c'), ('b', 'd')),
         )
 
-        self.assertSequenceEqual(f.field.choices, (
+        self.assertSequenceEqual(list(f.field.choices), (
             ('', '---------'),
             ('c', 'C'),
             ('-c', 'C (descending)'),
@@ -1381,7 +1381,7 @@ class OrderingFilterTests(TestCase):
             field_labels={'a': 'foo'},
         )
 
-        self.assertSequenceEqual(f.field.choices, (
+        self.assertSequenceEqual(list(f.field.choices), (
             ('', '---------'),
             ('c', 'foo'),
             ('-c', 'foo (descending)'),
@@ -1398,7 +1398,7 @@ class OrderingFilterTests(TestCase):
             }
         )
 
-        self.assertEqual(f.field.choices, [
+        self.assertEqual(list(f.field.choices), [
             ('', '---------'),
             ('username', 'BLABLA'),
             ('-username', 'XYZXYZ'),
@@ -1453,7 +1453,7 @@ class OrderingFilterTests(TestCase):
         with translation.override('pl'):
             f = OrderingFilter(fields=['username'])
 
-            self.assertEqual(f.field.choices, [
+            self.assertEqual(list(f.field.choices), [
                 ('', '---------'),
                 ('username', 'Nazwa użytkownika'),
                 ('-username', 'Nazwa użytkownika (malejąco)'),
@@ -1466,7 +1466,7 @@ class OrderingFilterTests(TestCase):
                 field_labels={'username': 'BLABLA'},
             )
 
-            self.assertEqual(f.field.choices, [
+            self.assertEqual(list(f.field.choices), [
                 ('', '---------'),
                 ('username', 'BLABLA'),
                 ('-username', 'BLABLA (malejąco)'),

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -362,6 +362,33 @@ class ChoiceFilterTests(TestCase):
             ('a', 'a'),
         ])
 
+    def test_null_multiplechoice(self):
+        # default is to be disabled
+        f = MultipleChoiceFilter(choices=[('a', 'a')], )
+        self.assertEqual(list(f.field.choices), [
+            ('a', 'a'),
+        ])
+
+        # set label, allow blank label
+        f = MultipleChoiceFilter(choices=[('a', 'a')], null_label='')
+        self.assertEqual(list(f.field.choices), [
+            ('null', ''),
+            ('a', 'a'),
+        ])
+
+        # set null value
+        f = MultipleChoiceFilter(choices=[('a', 'a')], null_value='NULL', null_label='')
+        self.assertEqual(list(f.field.choices), [
+            ('NULL', ''),
+            ('a', 'a'),
+        ])
+
+        # explicitly disable
+        f = MultipleChoiceFilter(choices=[('a', 'a')], null_label=None)
+        self.assertEqual(list(f.field.choices), [
+            ('a', 'a'),
+        ])
+
     @override_settings(
         FILTERS_EMPTY_CHOICE_LABEL='EMPTY LABEL',
         FILTERS_NULL_CHOICE_LABEL='NULL LABEL',
@@ -370,6 +397,12 @@ class ChoiceFilterTests(TestCase):
         f = ChoiceFilter(choices=[('a', 'a')], )
         self.assertEqual(f.field.choices, [
             ('', 'EMPTY LABEL'),
+            ('NULL VALUE', 'NULL LABEL'),
+            ('a', 'a'),
+        ])
+
+        f = MultipleChoiceFilter(choices=[('a', 'a')], )
+        self.assertEqual(list(f.field.choices), [
             ('NULL VALUE', 'NULL LABEL'),
             ('a', 'a'),
         ])

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -419,6 +419,11 @@ class ChoiceFilterTests(TestCase):
             ('b', 'b'),
         ])
 
+    def test_callable_choices_is_lazy(self):
+        def choices():
+            self.fail('choices should not be called during initialization')
+        ChoiceFilter(choices=choices)
+
 
 class MultipleChoiceFilterTests(TestCase):
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -63,7 +63,7 @@ class FilterSetFormTests(TestCase):
         self.assertEqual(len(f.fields), 1)
         self.assertIn('status', f.fields)
         self.assertSequenceEqual(
-            f.fields['status'].choices,
+            list(f.fields['status'].choices),
             (('', '---------'), ) + STATUS_CHOICES
         )
 
@@ -116,7 +116,7 @@ class FilterSetFormTests(TestCase):
         self.assertIn('status', f.fields)
         self.assertIn('username', f.fields)
         self.assertSequenceEqual(
-            f.fields['status'].choices,
+            list(f.fields['status'].choices),
             STATUS_CHOICES
         )
         self.assertIsInstance(f.fields['status'].widget, forms.RadioSelect)


### PR DESCRIPTION
This is an update that should supersede/close #639. Thanks @michael-mri for an initial implementation and some test cases.

----

**TODO**:
- [x] Add test for lazy choice callable evaluation. See #710 and #744.

In short, the null option handling is moved to a set of custom fields and out of the `ChoiceFilter`. This code largely emulates and extends what's done by `forms.ModelChoiceField` already. eg, the `ChoiceIterator` basically copies the behavior of `ModelChoiceIterator` and adds `empty_label` handling to `ChoiceField` & `MultipleChoiceField`. Null choice handling is just an extension of the empty choice.

**Notes**:
- The `ChoiceIteratorMixin` is probably the most confusing bit to reason about, due to how `ModelChoiceField`s can set both `queryset` and `choices`.
- `ModelChoiceField` & `ModelMultipleChoiceField` both validate the incoming values as part of the queryset. This check essentially has to be bypassed for `null_value`s.
- Unlike, `ModelChoiceField`, `ChoiceField` doesn't already support `empty_label` (added in the PR). 
- `MultipleChoiceField` explicitly sets `empty_label` to none, since it's an option that never makes sense. This is the same behavior as `forms.ModelMultipleChoiceField`.
- The auto-generation explicitly disables the null choice for non-nullable fields.
- There is no `null_label` handling for `ManyToManyField`s in `FILTER_FOR_DBFIELD_DEFAULTS` since the null option is not present/implicit. 
- Since the empty option handling is now provided by the field, custom filters can create their own choices without having to explicitly handle these options (eg, `AllValuesFilter`, which should be fixed).