### PR TITLE
Add SuffixedMultiWidget

### DIFF
--- a/django_filters/widgets.py
+++ b/django_filters/widgets.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 from collections import Iterable
 from itertools import chain
+from re import search, sub
 
 import django
 from django import forms
@@ -116,6 +117,22 @@ class SuffixedMultiWidget(forms.MultiWidget):
             widget.value_omitted_from_data(data, files, self.suffixed(name, suffix))
             for widget, suffix in zip(self.widgets, self.suffixes)
         )
+
+    # Django < 1.11 compat
+    def format_output(self, rendered_widgets):
+        rendered_widgets = [
+            self.replace_name(output, i)
+            for i, output in enumerate(rendered_widgets)
+        ]
+        return '\n'.join(rendered_widgets)
+
+    def replace_name(self, output, index):
+        result = search(r'name="(?P<name>.*)_%d"' % index, output)
+        name = result.group('name')
+        name = self.suffixed(name, self.suffixes[index])
+        name = 'name="%s"' % name
+
+        return sub(r'name=".*_%d"' % index, name, output)
 
 
 class RangeWidget(forms.MultiWidget):

--- a/django_filters/widgets.py
+++ b/django_filters/widgets.py
@@ -134,6 +134,11 @@ class SuffixedMultiWidget(forms.MultiWidget):
 
         return sub(r'name=".*_%d"' % index, name, output)
 
+    def decompress(self, value):
+        if value is None:
+            return [None, None]
+        return value
+
 
 class RangeWidget(forms.MultiWidget):
     template_name = 'django_filters/widgets/multiwidget.html'

--- a/docs/ref/widgets.txt
+++ b/docs/ref/widgets.txt
@@ -61,3 +61,28 @@ a ``RangeField``:
 .. code-block:: python
 
   date_range = DateFromToRangeFilter(widget=RangeWidget(attrs={'placeholder': 'YYYY/MM/DD'}))
+
+
+``SuffixedMultiWidget``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Extends Django's builtin ``MultiWidget`` to append custom suffixes instead of
+indices. For example, take a range widget that accepts minimum and maximum
+bounds. By default, the resulting query params would look like the following:
+
+.. code-block:: http
+
+    GET /products?price_0=10&price_1=25 HTTP/1.1
+
+By using ``SuffixedMultiWidget`` instead, you can provide human-friendly suffixes.
+
+.. code-block:: python
+
+    class RangeWidget(SuffixedMultiWidget):
+        suffixes = ['min', 'max']
+
+The query names are now a little more ergonomic.
+
+.. code-block:: http
+
+    GET /products?price_min=10&price_max=25 HTTP/1.1


### PR DESCRIPTION
Resolves #425. Not sure if this would be considered for a major/minor release given the API changes.

**Changes:**
- Add `SuffixedMultiWidget`
- Change `RangeWidget` to use `min`/`max` suffixes
- Add `DateRangeWidget` that uses `after`/`before suffixes (could remove and just use `RangeWidget`)
- Change `LookupTypeWidget` to just the field name and a `lookup` suffix. So, `?price=15&price_lookup=lt`

**TODO:**
- [x] docs.
- [x] tests?