### PR TITLE
Fix premature form initialization w/ crispy forms

### DIFF
--- a/django_filters/rest_framework/filterset.py
+++ b/django_filters/rest_framework/filterset.py
@@ -21,14 +21,15 @@ FILTER_FOR_DBFIELD_DEFAULTS.update({
 class FilterSet(filterset.FilterSet):
     FILTER_DEFAULTS = FILTER_FOR_DBFIELD_DEFAULTS
 
-    def __init__(self, *args, **kwargs):
-        super(FilterSet, self).__init__(*args, **kwargs)
+    @property
+    def form(self):
+        form = super(FilterSet, self).form
 
         if compat.is_crispy():
             from crispy_forms.helper import FormHelper
             from crispy_forms.layout import Layout, Submit
 
-            layout_components = list(self.form.fields.keys()) + [
+            layout_components = list(form.fields.keys()) + [
                 Submit('', _('Submit'), css_class='btn-default'),
             ]
             helper = FormHelper()
@@ -36,7 +37,9 @@ class FilterSet(filterset.FilterSet):
             helper.template_pack = 'bootstrap3'
             helper.layout = Layout(*layout_components)
 
-            self.form.helper = helper
+            form.helper = helper
+
+        return form
 
     @property
     def qs(self):

--- a/requirements/test-ci.txt
+++ b/requirements/test-ci.txt
@@ -1,5 +1,6 @@
 markdown==2.6.4
 coreapi
+django-crispy-forms
 
 coverage
 mock

--- a/tests/rest_framework/test_filterset.py
+++ b/tests/rest_framework/test_filterset.py
@@ -1,10 +1,20 @@
+from unittest import skipIf
 
+from django.conf import settings
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from django_filters.rest_framework import FilterSet, filters
+from django_filters.compat import is_crispy
 from django_filters.widgets import BooleanWidget
 
 from ..models import User, Article
+
+
+class ArticleFilter(FilterSet):
+    class Meta:
+        model = Article
+        fields = ['author']
 
 
 class FilterSetFilterForFieldTests(TestCase):
@@ -20,3 +30,16 @@ class FilterSetFilterForFieldTests(TestCase):
         result = FilterSet.filter_for_field(field, 'is_active')
         self.assertIsInstance(result, filters.BooleanFilter)
         self.assertEqual(result.widget, BooleanWidget)
+
+
+@skipIf(is_crispy(), 'django_crispy_forms must be installed')
+@override_settings(INSTALLED_APPS=settings.INSTALLED_APPS + ('crispy_forms', ))
+class CrispyFormsCompatTests(TestCase):
+
+    def test_crispy_helper(self):
+        # ensure the helper is present on the form
+        self.assertTrue(hasattr(ArticleFilter().form, 'helper'))
+
+    def test_form_initialization(self):
+        # ensure that crispy compat does not prematurely initialize the form
+        self.assertFalse(hasattr(ArticleFilter(), '_form'))


### PR DESCRIPTION
The crispy forms helper code accesses the `form` during FilterSet initialization, which causes the form to be cached. This prevents FilterSet subclasses from dynamically modifying filters, as the filters will be out of sync with the form's fields. The solution is to just add the helper code to the `.form` property instead.