### PR TITLE
return a coreschema.Number if the field filter is a NumberFilter

### DIFF
--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -6,7 +6,7 @@ from django.template import loader
 from django.utils import six
 
 from .. import compat
-from . import filterset
+from . import filterset, filters
 
 
 class DjangoFilterBackend(object):
@@ -67,6 +67,16 @@ class DjangoFilterBackend(object):
 
         return template.render(context, request)
 
+    def get_coreschema_field(self, field):
+        if isinstance(field, filters.NumberFilter):
+            return compat.coreschema.Number(
+                description=six.text_type(field.field.help_text)
+                )
+        else:
+            return compat.coreschema.String(
+                description=six.text_type(field.field.help_text)
+                )
+
     def get_schema_fields(self, view):
         # This is not compatible with widgets where the query param differs from the
         # filter's attribute name. Notably, this includes `MultiWidget`, where query
@@ -89,9 +99,7 @@ class DjangoFilterBackend(object):
                 name=field_name,
                 required=False,
                 location='query',
-                schema=compat.coreschema.String(
-                    description=six.text_type(field.field.help_text)
+                schema=self.get_coreschema_field(field)
                 )
-            )
             for field_name, field in filter_class().filters.items()
-        ]
+            ]

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -160,9 +160,13 @@ class GetSchemaFieldsTests(TestCase):
     def test_fields_with_filter_class(self):
         backend = DjangoFilterBackend()
         fields = backend.get_schema_fields(FilterClassRootView())
+        schemas = [f.schema for f in fields]
         fields = [f.name for f in fields]
 
         self.assertEqual(fields, ['text', 'decimal', 'date'])
+        self.assertIsInstance(schemas[0], compat.coreschema.String)
+        self.assertIsInstance(schemas[1], compat.coreschema.Number)
+        self.assertIsInstance(schemas[2], compat.coreschema.String)
 
 
 class CommonFilteringTestCase(TestCase):


### PR DESCRIPTION
in the `get_schema_field()`, return a `coreschema.Number` if the field filter is a `NumberFilter`