### PR TITLE
Add support for validation error codes

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -173,7 +173,7 @@ class BaseFilterSet(object):
 
             if not self.form.is_valid():
                 if self.strict == STRICTNESS.RAISE_VALIDATION_ERROR:
-                    raise forms.ValidationError(self.form.errors)
+                    raise forms.ValidationError(self.form.errors.as_data())
                 elif self.strict == STRICTNESS.RETURN_NO_RESULTS:
                     self._qs = self.queryset.none()
                     return self._qs

--- a/django_filters/rest_framework/filterset.py
+++ b/django_filters/rest_framework/filterset.py
@@ -44,9 +44,7 @@ class FilterSet(filterset.FilterSet):
 
     @property
     def qs(self):
-        from rest_framework.exceptions import ValidationError
-
         try:
             return super(FilterSet, self).qs
         except forms.ValidationError as e:
-            raise ValidationError(utils.raw_validation(e))
+            raise utils.translate_validation(e)

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -680,6 +680,26 @@ class FilterSetStrictnessTests(TestCase):
 
         self.assertEqual(F(strict=False).strict, STRICTNESS.IGNORE)
 
+    def test_raise_validation_output(self):
+        class F(FilterSet):
+            class Meta:
+                model = Article
+                fields = ['id', 'author', 'name']
+                strict = STRICTNESS.RAISE_VALIDATION_ERROR
+
+        f = F(data={'id': 'foo', 'author': 'bar', 'name': 'baz'})
+        with self.assertRaises(ValidationError) as exc:
+            f.qs
+
+        # test rendered output
+        self.assertEqual(str(exc.exception), str({
+            'id': ['Enter a number.'],
+            'author': ['Select a valid choice. That choice is not one of the available choices.'],
+        }))
+
+        # test validation error code
+        self.assertEqual(exc.exception.error_dict['author'][0].code, 'invalid_choice')
+
 
 # test filter.method here, as it depends on its parent FilterSet
 class FilterMethodTests(TestCase):


### PR DESCRIPTION
This is for both the base `FilterSet` and the DRF variant. 

- The base `FilterSet` is slightly broken, since it simply raises `ValidationError(self.form.errors)`. This loses the individual validation error codes. 
- The `raw_validation` approach needs to be modified to return an actual `serializers.ValidationError`, since the plain data structure lacks the error codes.

(This is WIP)