### PR TITLE
Prevent circular ImportError hiding for rest_framework sub-package

### DIFF
--- a/django_filters/__init__.py
+++ b/django_filters/__init__.py
@@ -1,15 +1,17 @@
 # flake8: noqa
 from __future__ import absolute_import
+
+import pkgutil
+
 from .constants import STRICTNESS
 from .filterset import FilterSet
 from .filters import *
 
 # We make the `rest_framework` module available without an additional import.
-#   If DRF is not installed we simply set None.
-try:
+#   If DRF is not installed, no-op.
+if pkgutil.find_loader('rest_framework'):
     from . import rest_framework
-except ImportError:
-    rest_framework = None
+del pkgutil
 
 __version__ = '1.0.4'
 

--- a/django_filters/__init__.py
+++ b/django_filters/__init__.py
@@ -9,7 +9,7 @@ from .filters import *
 
 # We make the `rest_framework` module available without an additional import.
 #   If DRF is not installed, no-op.
-if pkgutil.find_loader('rest_framework'):
+if pkgutil.find_loader('rest_framework') is not None:
     from . import rest_framework
 del pkgutil
 


### PR DESCRIPTION
The try/catch block doesn't discriminate the origin of import errors. While it's intended to no-op when DRF isn't installed, it also hides circular import errors, leading to a cryptic "NoneType has no attribute..." exception instead of the original import error.