### PR TITLE
Support active timezone

### DIFF
--- a/django_filters/utils.py
+++ b/django_filters/utils.py
@@ -146,7 +146,7 @@ def resolve_field(model_field, lookup_expr):
 
 def handle_timezone(value, is_dst=None):
     if settings.USE_TZ and timezone.is_naive(value):
-        return make_aware(value, timezone.get_default_timezone(), is_dst)
+        return make_aware(value, timezone.get_current_timezone(), is_dst)
     elif not settings.USE_TZ and timezone.is_aware(value):
         return timezone.make_naive(value, timezone.utc)
     return value

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,5 +9,5 @@ skip=.tox
 atomic=true
 multi_line_output=3
 known_standard_library=mock
-known_third_party=django,rest_framework
+known_third_party=django,pytz,rest_framework
 known_first_party=django_filters


### PR DESCRIPTION
Django can [set timezone](https://docs.djangoproject.com/en/1.11/topics/i18n/timezones/#selecting-the-current-time-zone) per request.

If current timezone is not set, use default timezone. See: [`get_current_timezone`](https://docs.djangoproject.com/en/1.11/_modules/django/utils/timezone/#get_current_timezone).