### PR TITLE
Remove support for Django 1.9 (EOL)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Requirements
 ------------
 
 * **Python**: 2.7, 3.3, 3.4, 3.5
-* **Django**: 1.8, 1.9, 1.10, 1.11
+* **Django**: 1.8, 1.10, 1.11
 * **DRF**: 3.6
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         'Operating System :: OS Independent',
         'Framework :: Django',
         'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
         'Programming Language :: Python',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
        {py27,py33,py34,py35}-django18-restframework36,
-       {py27,py34,py35}-django{19,110}-restframework36,
+       {py27,py34,py35}-django110-restframework36,
        {py35,py36}-django111-restframework36,
        {py35,py36}-djangolatest-restframeworklatest,
        warnings
@@ -14,7 +14,6 @@ setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
     django18: django>=1.8.0,<1.9.0
-    django19: django>=1.9.0,<1.10.0
     django110: django>=1.10.0,<1.11.0
     django111: django>=1.11.0,<2.0
     djangolatest: https://github.com/django/django/archive/master.tar.gz


### PR DESCRIPTION
Django 1.9 reached its end of life in April 2017; see
https://www.djangoproject.com/weblog/2017/apr/04/security-releases/