### PR TITLE
Add isort to CI & re-add warnings 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,13 @@ script:
   - coverage erase
   - detox
 
+matrix:
+  include:
+    - python: 3.6
+      env: TOXENV=isort
+    - python: 3.6
+      env: TOXENV=warnings
+
 after_success:
   - coverage combine --append
   - coverage report -m

--- a/django_filters/rest_framework/filterset.py
+++ b/django_filters/rest_framework/filterset.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from django import forms
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
+
 from django_filters import filterset
 
 from .. import compat, utils

--- a/docs/dev/tests.txt
+++ b/docs/dev/tests.txt
@@ -65,3 +65,26 @@ supported versions of Python and Django. Install tox, and then simply run:
 
     $ pip install tox
     $ tox
+
+
+Housekeeping
+------------
+
+The ``isort`` utility is used to maintain module imports. You can either test
+the module imports with the appropriate `tox` env, or with `isort` directly.
+
+.. code-block:: bash
+
+    $ pip install tox
+    $ tox -e isort
+
+    # or
+
+    $ pip install isort
+    $ isort --check-only --recursive django_filters tests
+
+To sort the imports, simply remove the ``--check-only`` option.
+
+.. code-block:: bash
+
+    $ isort --recursive django_filters tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,9 @@ license-file = LICENSE
 universal=1
 
 [isort]
+skip=.tox
+atomic=true
 multi_line_output=3
+known_standard_library=mock
+known_third_party=django,rest_framework
+known_first_party=django_filters

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -8,14 +8,15 @@ from unittest import skipIf
 from django.db.models import BooleanField
 from django.test import TestCase
 from django.test.utils import override_settings
+from rest_framework import generics, serializers
+from rest_framework.test import APIRequestFactory
+
 from django_filters import compat, filters
 from django_filters.rest_framework import (
     DjangoFilterBackend,
     FilterSet,
     backends
 )
-from rest_framework import generics, serializers
-from rest_framework.test import APIRequestFactory
 
 from .models import FilterableItem
 

--- a/tests/rest_framework/test_filters.py
+++ b/tests/rest_framework/test_filters.py
@@ -1,5 +1,6 @@
 
 from django.test import TestCase
+
 from django_filters.rest_framework import filters
 from django_filters.widgets import BooleanWidget
 

--- a/tests/rest_framework/test_filterset.py
+++ b/tests/rest_framework/test_filterset.py
@@ -3,6 +3,7 @@ from unittest import skipIf
 from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
+
 from django_filters.compat import is_crispy
 from django_filters.rest_framework import FilterSet, filters
 from django_filters.widgets import BooleanWidget

--- a/tests/rest_framework/test_integration.py
+++ b/tests/rest_framework/test_integration.py
@@ -7,10 +7,11 @@ from django.conf.urls import url
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils.dateparse import parse_date
-from django_filters import STRICTNESS, filters
-from django_filters.rest_framework import DjangoFilterBackend, FilterSet
 from rest_framework import generics, serializers, status
 from rest_framework.test import APIRequestFactory
+
+from django_filters import STRICTNESS, filters
+from django_filters.rest_framework import DjangoFilterBackend, FilterSet
 
 from .models import (
     BaseFilterableItem,

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,5 +1,6 @@
 
 from django.test import TestCase, override_settings
+
 from django_filters import STRICTNESS, FilterSet
 from django_filters.conf import is_callable, settings
 from tests.models import User

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -6,6 +6,7 @@ from datetime import datetime, time, timedelta, tzinfo
 from django import forms
 from django.test import TestCase, override_settings
 from django.utils.timezone import get_default_timezone, make_aware
+
 from django_filters.fields import (
     BaseCSVField,
     BaseRangeField,

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1,14 +1,15 @@
 from __future__ import absolute_import, unicode_literals
 
 import datetime
+import mock
 import unittest
 
 import django
-import mock
 from django import forms
 from django.test import TestCase, override_settings
 from django.utils import six, timezone
 from django.utils.timezone import now
+
 from django_filters.exceptions import FieldLookupError
 from django_filters.filters import (
     AllValuesFilter,

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -2,14 +2,15 @@
 from __future__ import absolute_import, unicode_literals
 
 import inspect
+import mock
 from collections import OrderedDict
 from datetime import date, datetime, time, timedelta
 
-import mock
 from django import forms
 from django.test import TestCase, override_settings
 from django.utils import translation
 from django.utils.translation import ugettext as _
+
 from django_filters import filters, widgets
 from django_filters.fields import (
     BaseCSVField,

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -1,12 +1,13 @@
 from __future__ import absolute_import, unicode_literals
 
+import mock
 import unittest
 
 import django
-import mock
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.test import TestCase, override_settings
+
 from django_filters.constants import STRICTNESS
 from django_filters.filters import (
     BaseInFilter,

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 from django import forms
 from django.test import TestCase, override_settings
+
 from django_filters.filters import CharFilter, ChoiceFilter
 from django_filters.filterset import FilterSet
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ from django.forms import ValidationError
 from django.test import TestCase, override_settings
 from django.utils.functional import Promise
 from django.utils.timezone import get_default_timezone
+
 from django_filters import STRICTNESS, FilterSet
 from django_filters.exceptions import FieldLookupError
 from django_filters.utils import (

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
+
 from django_filters.filterset import FilterSet, filterset_factory
 from django_filters.views import FilterView
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 from django.forms import Select, TextInput
 from django.test import TestCase
+
 from django_filters.widgets import (
     BaseCSVWidget,
     BooleanWidget,

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import url
+
 from django_filters.views import FilterView, object_filter
 
 from .models import Book

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
        {py27,py34,py35}-django{19,110}-restframework36,
        {py35,py36}-django111-restframework36,
        {py35,py36}-djangolatest-restframeworklatest,
-       warnings
+       isort, warnings,
 
 [testenv]
 commands = coverage run --parallel-mode --source django_filters ./runtests.py {posargs}
@@ -21,6 +21,10 @@ deps =
     restframework36: djangorestframework>=3.6,<3.7
     restframeworklatest: https://github.com/tomchristie/django-rest-framework/archive/master.tar.gz
     -rrequirements/test-ci.txt
+
+[testenv:isort]
+commands = isort --check-only --recursive django_filters tests {posargs}
+deps = isort
 
 [testenv:warnings]
 ignore_outcome = True


### PR DESCRIPTION
- Adds `isort` tox env.
- Fleshes out the isort configuration with first/third party packages (mostly copied from DRF)
  - django and rest_framework will now precede django_filters imports
- Re-adds `warnings` job to CI