### PR TITLE
Fix setting name in docs

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -58,7 +58,7 @@ Default:
 .. code-block:: python
 
     # refer to 'django_filters.conf.DEFAULTS'
-    'VERBOSE_LOOKUPS': {
+    FILTERS_VERBOSE_LOOKUPS = {
         'exact': _(''),
         'iexact': _(''),
         'contains': _('contains'),


### PR DESCRIPTION
It looks as if the setting is missing the `FILTERS_` prefix, and that we should be setting a variable with `=` rather than a dictionary key.

I'm not really familiar with django_filter, so apologies if I have misread the docs.