### PR TITLE
Add 'exclusive' fields option

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -63,17 +63,34 @@ def _together_valid(form, fieldset):
     return True
 
 
-def get_full_clean_override(together):
-    # coerce together to list of pairs
-    if isinstance(together[0], (six.string_types)):
+def _exclusive_valid(form, fieldset):
+    field_presence = [
+        form.cleaned_data.get(field) not in EMPTY_VALUES
+        for field in fieldset
+    ]
+
+    if any(field_presence):
+        return not all(field_presence)
+    return True
+
+
+def get_full_clean_override(together, exclusive):
+    # coerce together/exclusive to list of pairs
+    if together and isinstance(together[0], (six.string_types)):
         together = [together]
+    if exclusive and isinstance(exclusive[0], (six.string_types)):
+        exclusive = [exclusive]
 
     def full_clean(form):
         super(form.__class__, form).full_clean()
         message = 'Following fields must be together: %s'
-
         for each in together:
             if not _together_valid(form, each):
+                return form.add_error(None, message % ','.join(each))
+
+        message = 'Following fields are exclusive to each other: %s'
+        for each in exclusive:
+            if not _exclusive_valid(form, each):
                 return form.add_error(None, message % ','.join(each))
 
     return full_clean
@@ -92,6 +109,7 @@ class FilterSetOptions(object):
         self.form = getattr(options, 'form', forms.Form)
 
         self.together = getattr(options, 'together', None)
+        self.exclusive = getattr(options, 'exclusive', None)
 
 
 class FilterSetMetaclass(type):
@@ -245,8 +263,9 @@ class BaseFilterSet(object):
 
             Form = type(str('%sForm' % self.__class__.__name__),
                         (self._meta.form,), fields)
-            if self._meta.together:
-                Form.full_clean = get_full_clean_override(self._meta.together)
+            if self._meta.together or self._meta.exclusive:
+                together, exclusive = self._meta.together or [], self._meta.exclusive or []
+                Form.full_clean = get_full_clean_override(together, exclusive)
             if self.is_bound:
                 self._form = Form(self.data, prefix=self.form_prefix)
             else:

--- a/docs/ref/filterset.txt
+++ b/docs/ref/filterset.txt
@@ -12,6 +12,7 @@ Meta options
 - :ref:`exclude <exclude>`
 - :ref:`form <form>`
 - :ref:`together <together>`
+- :ref:`exclusive <exclusive>`
 - :ref:`filter_overrides <filter_overrides>`
 - :ref:`strict <strict>`
 
@@ -119,6 +120,26 @@ field set must either be all or none present in the request for
             model = Product
             fields = ['price', 'release_date', 'rating']
             together = ['rating', 'price']
+
+
+.. _exclusive:
+
+Define ``exclusive`` filters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The inner ``Meta`` class also takes an optional ``exclusive`` argument.  This
+is a list of lists, each containing field names. For convenience can be a
+single list/tuple when dealing with a single set of fields. There must not be
+more than one field present in a field set in the request for ``FilterSet.form``
+to be valid::
+
+    import django_filters
+
+    class PlaceFilter(django_filters.FilterSet):
+        class Meta:
+            model = Place
+            fields = ['country', 'state']
+            exclusive = ['country', 'state']
 
 
 .. _filter_overrides:

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -742,6 +742,67 @@ class FilterSetTogetherTests(TestCase):
         self.assertEqual(f.qs.count(), 0)
 
 
+class FilterSetExclusiveTests(TestCase):
+
+    def setUp(self):
+        self.alex = User.objects.create(username='alex', status=1)
+        self.jacob = User.objects.create(username='jacob', status=2)
+        self.qs = User.objects.all().order_by('id')
+
+    def test_fields_set(self):
+        class F(FilterSet):
+            class Meta:
+                model = User
+                fields = ['username', 'status', 'is_active', 'first_name']
+                exclusive = [
+                    ('username', 'status'),
+                    ('first_name', 'is_active'),
+                ]
+                strict = STRICTNESS.RAISE_VALIDATION_ERROR
+
+        f = F({}, queryset=self.qs)
+        self.assertEqual(f.qs.count(), 2)
+
+        f = F({'username': 'alex'}, queryset=self.qs)
+        self.assertEqual(f.qs.count(), 1)
+        self.assertQuerysetEqual(f.qs, [self.alex.pk], lambda o: o.pk)
+
+        f = F({'username': 'alex', 'status': 1}, queryset=self.qs)
+        with self.assertRaises(ValidationError):
+            f.qs.count()
+
+    def test_single_fields_set(self):
+        class F(FilterSet):
+            class Meta:
+                model = User
+                fields = ['username', 'status']
+                exclusive = ['username', 'status']
+                strict = STRICTNESS.RAISE_VALIDATION_ERROR
+
+        f = F({}, queryset=self.qs)
+        self.assertEqual(f.qs.count(), 2)
+
+        f = F({'username': 'alex'}, queryset=self.qs)
+        self.assertEqual(f.qs.count(), 1)
+        self.assertQuerysetEqual(f.qs, [self.alex.pk], lambda o: o.pk)
+
+        f = F({'username': 'alex', 'status': 1}, queryset=self.qs)
+        with self.assertRaises(ValidationError):
+            f.qs.count()
+
+    def test_empty_values(self):
+        class F(FilterSet):
+            class Meta:
+                model = User
+                fields = ['username', 'status']
+                exclusive = ['username', 'status']
+
+        f = F({'username': '', 'status': ''}, queryset=self.qs)
+        self.assertEqual(f.qs.count(), 2)
+        f = F({'username': 'alex', 'status': ''}, queryset=self.qs)
+        self.assertEqual(f.qs.count(), 1)
+
+
 # test filter.method here, as it depends on its parent FilterSet
 class FilterMethodTests(TestCase):
 


### PR DESCRIPTION
Alternative solution to, and resolves #782. One nice aspect is that it uses the same API as `Meta.together`, while exposing the opposite behavior. 

@ad-m, would this work for your use case? The primary difference is that a `ValidationError` is raised instead of just silently ignoring the field.