### PR TITLE
Simplify tox config, drop python 3.3 & django 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/README.rst
+++ b/README.rst
@@ -19,9 +19,9 @@ Full documentation on `read the docs`_.
 Requirements
 ------------
 
-* **Python**: 2.7, 3.3, 3.4, 3.5
+* **Python**: 2.7, 3.4, 3.5, 3.6
 * **Django**: 1.8, 1.10, 1.11
-* **DRF**: 3.6
+* **DRF**: 3.7
 
 Installation
 ------------

--- a/docs/guide/install.txt
+++ b/docs/guide/install.txt
@@ -29,6 +29,6 @@ __ http://www.django-rest-framework.org/
 
 
 
-* **Python**: 2.7, 3.3, 3.4, 3.5
-* **Django**: 1.8, 1.9, 1.10, 1.11
-* **DRF**:  3.5
+* **Python**: 2.7, 3.4, 3.5, 3.6
+* **Django**: 1.10, 1.11
+* **DRF**:  3.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,26 @@
 [tox]
 envlist =
-       {py27,py33,py34,py35}-django18-restframework36,
-       {py27,py34,py35}-django110-restframework36,
-       {py35,py36}-django111-restframework36,
-       {py35,py36}-djangolatest-restframeworklatest,
+       {py27,py34,py35}-django110,
+       {py27,py35,py36}-django111,
+       {py35,py36}-latest,
        isort, warnings,
+
+[latest]
+deps =
+    https://github.com/django/django/archive/master.tar.gz
+    https://github.com/tomchristie/django-rest-framework/archive/master.tar.gz
 
 [testenv]
 commands = coverage run --parallel-mode --source django_filters ./runtests.py {posargs}
 ignore_outcome =
-    djangolatest: True
+    latest: True
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
-    django18: django>=1.8.0,<1.9.0
     django110: django>=1.10.0,<1.11.0
     django111: django>=1.11.0,<2.0
-    djangolatest: https://github.com/django/django/archive/master.tar.gz
-    restframework36: djangorestframework>=3.6,<3.7
-    restframeworklatest: https://github.com/tomchristie/django-rest-framework/archive/master.tar.gz
+    djangorestframework>=3.7,<3.8
+    latest: {[latest]deps}
     -rrequirements/test-ci.txt
 
 [testenv:isort]
@@ -29,6 +31,5 @@ deps = isort
 ignore_outcome = True
 commands = python -Werror ./runtests.py {posargs}
 deps =
-    https://github.com/django/django/archive/master.tar.gz
-    https://github.com/tomchristie/django-rest-framework/archive/master.tar.gz
+    {[latest]deps}
     -rrequirements/test-ci.txt


### PR DESCRIPTION
A couple of simplifications in the tox config here:
- there isn't a need to specify a 'restframework' factor, as we only test against the latest version
- no need for a verbose latest, since we're testing the latest versions of each package
- dropped python 3.3 * django 1.8, as DRF 3.7 no longer supports them. 
