### PR TITLE
Rework validation, add queryset filter method

### DIFF
--- a/django_filters/__init__.py
+++ b/django_filters/__init__.py
@@ -1,7 +1,6 @@
 # flake8: noqa
 import pkgutil
 
-from .constants import STRICTNESS
 from .filterset import FilterSet
 from .filters import *
 

--- a/django_filters/conf.py
+++ b/django_filters/conf.py
@@ -2,7 +2,6 @@ from django.conf import settings as dj_settings
 from django.core.signals import setting_changed
 from django.utils.translation import ugettext_lazy as _
 
-from .constants import STRICTNESS
 from .utils import deprecate
 
 DEFAULTS = {
@@ -12,8 +11,6 @@ DEFAULTS = {
     'EMPTY_CHOICE_LABEL': '---------',
     'NULL_CHOICE_LABEL': None,
     'NULL_CHOICE_VALUE': 'null',
-
-    'STRICTNESS': STRICTNESS.RETURN_NO_RESULTS,
 
     'VERBOSE_LOOKUPS': {
         # transforms don't need to be verbose, since their expressions are chained

--- a/django_filters/constants.py
+++ b/django_filters/constants.py
@@ -3,22 +3,3 @@ ALL_FIELDS = '__all__'
 
 
 EMPTY_VALUES = ([], (), {}, '', None)
-
-
-class STRICTNESS(object):
-    class IGNORE(object):
-        pass
-
-    class RETURN_NO_RESULTS(object):
-        pass
-
-    class RAISE_VALIDATION_ERROR(object):
-        pass
-
-    # Values of False & True chosen for backward compatability reasons.
-    # Originally, these were the only options.
-    _LEGACY = {
-        False: IGNORE,
-        True: RETURN_NO_RESULTS,
-        "RAISE": RAISE_VALIDATION_ERROR,
-    }

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -47,8 +47,6 @@ class FilterSetOptions(object):
 
         self.filter_overrides = getattr(options, 'filter_overrides', {})
 
-        self.strict = getattr(options, 'strict', None)
-
         self.form = getattr(options, 'form', forms.Form)
 
 
@@ -140,7 +138,7 @@ FILTER_FOR_DBFIELD_DEFAULTS = {
 class BaseFilterSet(object):
     FILTER_DEFAULTS = FILTER_FOR_DBFIELD_DEFAULTS
 
-    def __init__(self, data=None, queryset=None, *, request=None, prefix=None, strict=None):
+    def __init__(self, data=None, queryset=None, *, request=None, prefix=None):
         if queryset is None:
             queryset = self._meta.model._default_manager.all()
         model = queryset.model
@@ -150,16 +148,6 @@ class BaseFilterSet(object):
         self.queryset = queryset
         self.request = request
         self.form_prefix = prefix
-
-        # What to do on on validation errors
-        # Fallback to meta, then settings strictness
-        if strict is None:
-            strict = self._meta.strict
-        if strict is None:
-            strict = settings.STRICTNESS
-
-        # transform legacy values
-        self.strict = STRICTNESS._LEGACY.get(strict, strict)
 
         self.filters = copy.deepcopy(self.base_filters)
 

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -173,27 +173,28 @@ class BaseFilterSet(object):
         if not hasattr(self, '_qs'):
             if not self.is_bound:
                 self._qs = self.queryset.all()
-                return self._qs
-
-            if not self.form.is_valid():
-                if self.strict == STRICTNESS.RAISE_VALIDATION_ERROR:
-                    raise forms.ValidationError(self.form.errors)
-                elif self.strict == STRICTNESS.RETURN_NO_RESULTS:
-                    self._qs = self.queryset.none()
-                    return self._qs
-                # else STRICTNESS.IGNORE...  ignoring
-
-            # start with all the results and filter from there
-            qs = self.queryset.all()
-            for name, filter_ in self.filters.items():
-                value = self.form.cleaned_data.get(name)
-
-                if value is not None:  # valid & clean data
-                    qs = filter_.filter(qs, value)
-
-            self._qs = qs
-
+            else:
+                self._qs = self.filter_queryset(self.queryset.all())
         return self._qs
+
+    def filter_queryset(self, queryset):
+        """
+        Validate the query data and then filter the queryset.
+
+        This method should be overridden if additional filtering needs to be
+        applied to the queryset before it is cached.
+        """
+        if not self.form.is_valid():
+            if self.strict == STRICTNESS.RAISE_VALIDATION_ERROR:
+                raise forms.ValidationError(self.form.errors)
+            elif self.strict == STRICTNESS.RETURN_NO_RESULTS:
+                return self.queryset.none()
+            elif self.strict == STRICTNESS.IGNORE:
+                pass  # ignoring...
+
+        for name, value in self.form.cleaned_data.items():
+            queryset = self.filters[name].filter(queryset, value)
+        return queryset
 
     @property
     def form(self):

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -192,15 +192,24 @@ class BaseFilterSet(object):
             self._qs = qs
         return self._qs
 
+    def get_form_class(self):
+        """
+        Returns a django Form suitable of validating the filterset data.
+
+        This method should be overridden if the form class needs to be
+        customized relative to the filterset instance.
+        """
+        fields = OrderedDict([
+            (name, filter_.field)
+            for name, filter_ in self.filters.items()])
+
+        return type(str('%sForm' % self.__class__.__name__),
+                    (self._meta.form,), fields)
+
     @property
     def form(self):
         if not hasattr(self, '_form'):
-            fields = OrderedDict([
-                (name, filter_.field)
-                for name, filter_ in self.filters.items()])
-
-            Form = type(str('%sForm' % self.__class__.__name__),
-                        (self._meta.form,), fields)
+            Form = self.get_form_class()
             if self.is_bound:
                 self._form = Form(self.data, prefix=self.form_prefix)
             else:

--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -52,9 +52,7 @@ class DjangoFilterBackend(object):
         if filter_class:
             filterset = filter_class(request.query_params, queryset=queryset, request=request)
             if not filterset.is_valid() and self.raise_exception:
-                from rest_framework.exceptions import ValidationError
-
-                raise ValidationError(utils.raw_validation(filterset.errors))
+                raise utils.translate_validation(filterset.errors)
             return filterset.qs
         return queryset
 

--- a/django_filters/rest_framework/filterset.py
+++ b/django_filters/rest_framework/filterset.py
@@ -1,12 +1,11 @@
 from copy import deepcopy
 
-from django import forms
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
 from django_filters import filterset
 
-from .. import compat, utils
+from .. import compat
 from .filters import BooleanFilter, IsoDateTimeFilter
 
 FILTER_FOR_DBFIELD_DEFAULTS = deepcopy(filterset.FILTER_FOR_DBFIELD_DEFAULTS)
@@ -38,12 +37,3 @@ class FilterSet(filterset.FilterSet):
             form.helper = helper
 
         return form
-
-    @property
-    def qs(self):
-        from rest_framework.exceptions import ValidationError
-
-        try:
-            return super(FilterSet, self).qs
-        except forms.ValidationError as e:
-            raise ValidationError(utils.raw_validation(e))

--- a/django_filters/utils.py
+++ b/django_filters/utils.py
@@ -1,4 +1,5 @@
 import warnings
+from collections import OrderedDict
 
 import django
 from django.conf import settings
@@ -8,7 +9,6 @@ from django.db.models.constants import LOOKUP_SEP
 from django.db.models.expressions import Expression
 from django.db.models.fields import FieldDoesNotExist
 from django.db.models.fields.related import ForeignObjectRel, RelatedField
-from django.forms import ValidationError
 from django.utils import timezone
 from django.utils.encoding import force_text
 from django.utils.text import capfirst
@@ -233,22 +233,17 @@ def label_for_filter(model, field_name, lookup_expr, exclude=False):
     return verbose_expression
 
 
-def raw_validation(error):
+def translate_validation(error_dict):
     """
-    Deconstruct a django.forms.ValidationError into a primitive structure
-    eg, plain dicts and lists.
+    Translate a Django ErrorDict into its DRF ValidationError.
     """
-    if isinstance(error, ValidationError):
-        if hasattr(error, 'error_dict'):
-            error = error.error_dict
-        elif not hasattr(error, 'message'):
-            error = error.error_list
-        else:
-            error = error.message
+    # it's necessary to lazily import the exception, as it can otherwise create
+    # an import loop when importing django_filters inside the project settings.
+    from rest_framework.exceptions import ValidationError, ErrorDetail
 
-    if isinstance(error, dict):
-        return {key: raw_validation(value) for key, value in error.items()}
-    elif isinstance(error, list):
-        return [raw_validation(value) for value in error]
-    else:
-        return error
+    exc = OrderedDict(
+        (key, [ErrorDetail(e.message, code=e.code) for e in error_list])
+        for key, error_list in error_dict.as_data().items()
+    )
+
+    return ValidationError(exc)

--- a/docs/ref/filterset.txt
+++ b/docs/ref/filterset.txt
@@ -130,6 +130,26 @@ This is a map of model fields to filter classes with options::
 Overriding ``FilterSet`` methods
 --------------------------------
 
+When overriding classmethods, calling ``super(MyFilterSet, cls)`` may result
+in a ``NameError`` exception. This is due to the ``FilterSetMetaclass`` calling
+these classmethods before the ``FilterSet`` class has been fully created.
+There are two recommmended workarounds:
+
+1. If using python 3.6 or newer, use the argumentless ``super()`` syntax.
+2. For older versions of python, use an intermediate class. Ex::
+
+    class Intermediate(django_filters.FilterSet):
+
+        @classmethod
+        def method(cls, arg):
+            super(Intermediate, cls).method(arg)
+            ...
+
+    class ProductFilter(Intermediate):
+        class Meta:
+            model = Product
+            fields = ['...']
+
 ``filter_for_lookup()``
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -159,4 +179,4 @@ filters for a model field, you can override ``filter_for_lookup()``. Ex::
                 return django_filters.DateRangeFilter, {}
 
             # use default behavior otherwise
-            return super(ProductFilter, cls).filter_for_lookup(f, lookup_type)
+            return super().filter_for_lookup(f, lookup_type)

--- a/docs/ref/filterset.txt
+++ b/docs/ref/filterset.txt
@@ -11,9 +11,7 @@ Meta options
 - :ref:`fields <fields>`
 - :ref:`exclude <exclude>`
 - :ref:`form <form>`
-- :ref:`together <together>`
 - :ref:`filter_overrides <filter_overrides>`
-- :ref:`strict <strict>`
 
 
 .. _model:
@@ -101,26 +99,6 @@ form class from which ``FilterSet.form`` will subclass.  This works similar to
 the ``form`` option on a ``ModelAdmin.``
 
 
-.. _together:
-
-Group fields with ``together``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The inner ``Meta`` class also takes an optional ``together`` argument.  This
-is a list of lists, each containing field names. For convenience can be a
-single list/tuple when dealing with a single set of fields. Fields within a
-field set must either be all or none present in the request for
-``FilterSet.form`` to be valid::
-
-    import django_filters
-
-    class ProductFilter(django_filters.FilterSet):
-        class Meta:
-            model = Product
-            fields = ['price', 'release_date', 'rating']
-            together = ['rating', 'price']
-
-
 .. _filter_overrides:
 
 Customise filter generation with ``filter_overrides``
@@ -148,37 +126,6 @@ This is a map of model fields to filter classes with options::
                     },
                 },
             }
-
-
-.. _strict:
-
-Handling validation errors with ``strict``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``strict`` option determines the filterset's behavior when filters fail to validate. Example use:
-
-.. code-block:: python
-
-    from django_filters import FilterSet, STRICTNESS
-
-    class ProductFilter(FilterSet):
-        class Meta:
-            model = Product
-            fields = ['name', 'release_date']
-            strict = STRICTNESS.RETURN_NO_RESULTS
-
-Currently, there are three different behaviors:
-
-- ``STRICTNESS.RETURN_NO_RESULTS`` (default) This returns an empty queryset. The
-  filterset form can then be rendered to display the input errors.
-- ``STRICTNESS.IGNORE`` Instead of returning an empty queryset, invalid filters
-  effectively become a noop. Valid filters are applied to the queryset however.
-- ``STRICTNESS.RAISE_VALIDATION_ERROR`` This raises a ``ValidationError`` for
-  all invalid filters. This behavior is generally useful with APIs.
-
-If the ``strict`` option is not provided, then the filterset will default to the
-value of the ``FILTERS_STRICTNESS`` setting.
-
 
 Overriding ``FilterSet`` methods
 --------------------------------

--- a/tests/rest_framework/test_integration.py
+++ b/tests/rest_framework/test_integration.py
@@ -9,7 +9,7 @@ from django.utils.dateparse import parse_date
 from rest_framework import generics, serializers, status
 from rest_framework.test import APIRequestFactory
 
-from django_filters import STRICTNESS, filters
+from django_filters import filters
 from django_filters.rest_framework import DjangoFilterBackend, FilterSet
 
 from .models import (
@@ -287,7 +287,6 @@ class IntegrationTestFiltering(CommonFilteringTestCase):
         response = view(request).render()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    @override_settings(FILTERS_STRICTNESS=STRICTNESS.RAISE_VALIDATION_ERROR)
     def test_strictness_validation_error(self):
         """
         Ensure validation errors return a proper error response instead of

--- a/tests/rest_framework/test_integration.py
+++ b/tests/rest_framework/test_integration.py
@@ -287,7 +287,7 @@ class IntegrationTestFiltering(CommonFilteringTestCase):
         response = view(request).render()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    def test_strictness_validation_error(self):
+    def test_raise_validation_error(self):
         """
         Ensure validation errors return a proper error response instead of
         an internal server error.
@@ -297,6 +297,26 @@ class IntegrationTestFiltering(CommonFilteringTestCase):
         response = view(request).render()
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data, {'decimal': ['Enter a number.']})
+
+    def test_permissive(self):
+        """
+        Permissive handling should return a partially filtered result set.
+        """
+        FilterableItem.objects.create(decimal=Decimal('1.23'), date='2017-01-01')
+        FilterableItem.objects.create(decimal=Decimal('1.23'), date='2016-01-01')
+
+        class Backend(DjangoFilterBackend):
+            raise_exception = False
+
+        class View(FilterFieldsRootView):
+            filter_backends = (Backend,)
+
+        view = View.as_view()
+        request = factory.get('/?decimal=foobar&date=2017-01-01')
+        response = view(request).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data[0]['date'], '2017-01-01')
+        self.assertEqual(len(response.data), 1)
 
 
 @override_settings(ROOT_URLCONF='tests.rest_framework.test_integration')

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,6 +1,5 @@
 
 # ensure package/conf is importable
-from django_filters import STRICTNESS
 from django_filters.conf import DEFAULTS
 
 DATABASES = {
@@ -40,6 +39,3 @@ STATIC_URL = '/static/'
 # help verify that DEFAULTS is importable from conf.
 def FILTERS_VERBOSE_LOOKUPS():
     return DEFAULTS['VERBOSE_LOOKUPS']
-
-
-FILTERS_STRICTNESS = STRICTNESS.RETURN_NO_RESULTS

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,9 +1,7 @@
 
 from django.test import TestCase, override_settings
 
-from django_filters import STRICTNESS, FilterSet
 from django_filters.conf import is_callable, settings
-from tests.models import User
 
 
 class DefaultSettingsTests(TestCase):
@@ -15,9 +13,6 @@ class DefaultSettingsTests(TestCase):
     def test_disable_help_text(self):
         self.assertFalse(settings.DISABLE_HELP_TEXT)
 
-    def test_strictness(self):
-        self.assertEqual(settings.STRICTNESS, STRICTNESS.RETURN_NO_RESULTS)
-
     def test_empty_choice_label(self):
         self.assertEqual(settings.EMPTY_CHOICE_LABEL, '---------')
 
@@ -26,45 +21,6 @@ class DefaultSettingsTests(TestCase):
 
     def test_null_choice_value(self):
         self.assertEqual(settings.NULL_CHOICE_VALUE, 'null')
-
-
-class StrictnessTests(TestCase):
-    class F(FilterSet):
-        class Meta:
-            model = User
-            fields = []
-
-    def test_settings_default(self):
-        self.assertEqual(self.F().strict, STRICTNESS.RETURN_NO_RESULTS)
-
-    def test_ignore(self):
-        with override_settings(FILTERS_STRICTNESS=STRICTNESS.IGNORE):
-            self.assertEqual(self.F().strict, STRICTNESS.IGNORE)
-
-    def test_return_no_results(self):
-        with override_settings(FILTERS_STRICTNESS=STRICTNESS.RETURN_NO_RESULTS):
-            self.assertEqual(self.F().strict, STRICTNESS.RETURN_NO_RESULTS)
-
-    def test_raise_validation_error(self):
-        with override_settings(FILTERS_STRICTNESS=STRICTNESS.RAISE_VALIDATION_ERROR):
-            self.assertEqual(self.F().strict, STRICTNESS.RAISE_VALIDATION_ERROR)
-
-    def test_legacy_ignore(self):
-        with override_settings(FILTERS_STRICTNESS=False):
-            self.assertEqual(self.F().strict, STRICTNESS.IGNORE)
-
-    def test_legacy_return_no_results(self):
-        with override_settings(FILTERS_STRICTNESS=True):
-            self.assertEqual(self.F().strict, STRICTNESS.RETURN_NO_RESULTS)
-
-    def test_legacy_raise_validation_error(self):
-        with override_settings(FILTERS_STRICTNESS='RAISE'):
-            self.assertEqual(self.F().strict, STRICTNESS.RAISE_VALIDATION_ERROR)
-
-    def test_legacy_differentiation(self):
-        self.assertNotEqual(STRICTNESS.IGNORE, False)
-        self.assertNotEqual(STRICTNESS.RETURN_NO_RESULTS, True)
-        self.assertNotEqual(STRICTNESS.RAISE_VALIDATION_ERROR, 'RAISE')
 
 
 class OverrideSettingsTests(TestCase):

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1086,25 +1086,9 @@ class AllValuesFilterTests(TestCase):
         self.assertEqual(list(F().qs), list(User.objects.all()))
         self.assertEqual(list(F({'username': 'alex'}).qs),
                          [User.objects.get(username='alex')])
-        self.assertEqual(list(F({'username': 'jose'}).qs),
-                         list())
 
-    def test_filtering_without_strict(self):
-        User.objects.create(username='alex')
-        User.objects.create(username='jacob')
-        User.objects.create(username='aaron')
-
-        class F(FilterSet):
-            username = AllValuesFilter()
-
-            class Meta:
-                model = User
-                fields = ['username']
-                strict = False
-
-        self.assertEqual(list(F().qs), list(User.objects.all()))
-        self.assertEqual(list(F({'username': 'alex'}).qs),
-                         [User.objects.get(username='alex')])
+        # invalid choice
+        self.assertFalse(F({'username': 'jose'}).is_valid())
         self.assertEqual(list(F({'username': 'jose'}).qs),
                          list(User.objects.all()))
 
@@ -1128,8 +1112,11 @@ class AllValuesMultipleFilterTests(TestCase):
                          [User.objects.get(username='alex')])
         self.assertEqual(list(F({'username': ['alex', 'jacob']}).qs),
                          list(User.objects.filter(username__in=['alex', 'jacob'])))
-        self.assertEqual(list(F({'username': ['jose']}).qs),
-                         list())
+
+        # invalid choice
+        self.assertFalse(F({'username': 'jose'}).is_valid())
+        self.assertEqual(list(F({'username': 'jose'}).qs),
+                         list(User.objects.all()))
 
 
 class FilterMethodTests(TestCase):

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -2,9 +2,8 @@ import mock
 import unittest
 
 from django.db import models
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
-from django_filters.constants import STRICTNESS
 from django_filters.exceptions import FieldLookupError
 from django_filters.filters import (
     BaseInFilter,
@@ -645,49 +644,6 @@ class FilterSetInstantiationTests(TestCase):
         m = mock.Mock()
         f = F(request=m)
         self.assertEqual(f.request, m)
-
-
-class FilterSetStrictnessTests(TestCase):
-
-    def test_settings_default(self):
-        class F(FilterSet):
-            class Meta:
-                model = User
-                fields = []
-
-        # Ensure default is not IGNORE
-        self.assertEqual(F().strict, STRICTNESS.RETURN_NO_RESULTS)
-
-        # override and test
-        with override_settings(FILTERS_STRICTNESS=STRICTNESS.IGNORE):
-            self.assertEqual(F().strict, STRICTNESS.IGNORE)
-
-    def test_meta_value(self):
-        class F(FilterSet):
-            class Meta:
-                model = User
-                fields = []
-                strict = STRICTNESS.IGNORE
-
-        self.assertEqual(F().strict, STRICTNESS.IGNORE)
-
-    def test_init_default(self):
-        class F(FilterSet):
-            class Meta:
-                model = User
-                fields = []
-                strict = STRICTNESS.IGNORE
-
-        strict = STRICTNESS.RAISE_VALIDATION_ERROR
-        self.assertEqual(F(strict=strict).strict, strict)
-
-    def test_legacy_value(self):
-        class F(FilterSet):
-            class Meta:
-                model = User
-                fields = []
-
-        self.assertEqual(F(strict=False).strict, STRICTNESS.IGNORE)
 
 
 # test filter.method here, as it depends on its parent FilterSet

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -223,3 +223,35 @@ class FilterSetFormTests(TestCase):
                 F().form.fields['title__in'].help_text,
                 ''
             )
+
+
+class FilterSetValidityTests(TestCase):
+
+    class F(FilterSet):
+        class Meta:
+            model = Book
+            fields = ['title', 'price']
+
+    def test_not_bound(self):
+        f = self.F()
+
+        self.assertFalse(f.is_bound)
+        self.assertFalse(f.is_valid())
+        self.assertEqual(f.data, {})
+        self.assertEqual(f.errors, {})
+
+    def test_is_bound_and_valid(self):
+        f = self.F({'title': 'Some book'})
+
+        self.assertTrue(f.is_bound)
+        self.assertTrue(f.is_valid())
+        self.assertEqual(f.data, {'title': 'Some book'})
+        self.assertEqual(f.errors, {})
+
+    def test_is_bound_and_not_valid(self):
+        f = self.F({'price': 'four dollars'})
+
+        self.assertTrue(f.is_bound)
+        self.assertFalse(f.is_valid())
+        self.assertEqual(f.data, {'price': 'four dollars'})
+        self.assertEqual(f.errors, {'price': ['Enter a number.']})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,12 +3,11 @@ import datetime
 from django.db import models
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.fields.related import ForeignObjectRel
-from django.forms import ValidationError
 from django.test import TestCase, override_settings
 from django.utils.functional import Promise
 from django.utils.timezone import get_default_timezone
 
-from django_filters import STRICTNESS, FilterSet
+from django_filters import FilterSet
 from django_filters.exceptions import FieldLookupError
 from django_filters.utils import (
     get_field_parts,
@@ -348,13 +347,10 @@ class RawValidationDataTests(TestCase):
             class Meta:
                 model = Article
                 fields = ['id', 'author', 'name']
-                strict = STRICTNESS.RAISE_VALIDATION_ERROR
 
         f = F(data={'id': 'foo', 'author': 'bar', 'name': 'baz'})
-        with self.assertRaises(ValidationError) as exc:
-            f.qs
 
-        self.assertDictEqual(raw_validation(exc.exception), {
+        self.assertDictEqual(raw_validation(f.errors), {
             'id': ['Enter a number.'],
             'author': ['Select a valid choice. That choice is not one of the available choices.'],
         })

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -71,6 +71,26 @@ class GenericClassBasedViewTests(GenericViewTestCase):
         for b in ['Ender&#39;s Game', 'Rainbow Six', 'Snowcrash']:
             self.assertContains(response, b)
 
+    def test_view_with_strict_errors(self):
+        factory = RequestFactory()
+        request = factory.get(self.base_url + '?title=Snowcrash&price=four dollars')
+        view = FilterView.as_view(model=Book)
+        response = view(request)
+        titles = [o.title for o in response.context_data['object_list']]
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(titles, [])
+
+    def test_view_with_non_strict_errors(self):
+        factory = RequestFactory()
+        request = factory.get(self.base_url + '?title=Snowcrash&price=four dollars')
+        view = FilterView.as_view(model=Book, strict=False)
+        response = view(request)
+        titles = [o.title for o in response.context_data['object_list']]
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(titles, ['Snowcrash'],)
+
     def test_view_without_filterset_or_model(self):
         factory = RequestFactory()
         request = factory.get(self.base_url)


### PR DESCRIPTION
This is an evolution of #783. In short, I think the validation/strictness behavior can be improved by moving it out of the FilterSet and into the view code. The current `.qs` implementation is somewhat difficult to extend, and is a little confusing given that it performs both form validation *and* queryset filtering. 

### Overall changes:
- Expands the FilterSet API to include the following:
    - `.is_valid()` - proxies `form.is_valid()`
    - `.errors` - proxies `form.errors`
    - `.filter_queryset(qs)` - allows users to easily override queryset handling. Cached by `.qs`
    - `.get_form_class()` - easier overriding of the form class on a per-instance basis, cached by `.form`
- `FilterSet`-level strictness handling is removed in favor of shifting it to the view layer
    - Generic View has a strict/non-strict attribute (previously, `RETURN_NO_RESULTS`/`IGNORE`)
    - DjangoFilterBackend has a raise/non-raise attribute (previously, `RAISE_VALIDATION_ERROR`/`IGNORE`)
- Reworked `raw_validation`. Error details now include codes. However, these codes are only reachable via `exc.get_full_details()`, and do not automatically show up in the rendered error response.
- Other small testing/docs changes

#### Additional thoughts:
- #136 is definitely targeting API use. Raising a `forms.ValidationError` in the context of a Django view does not make any sense, especially given that none of the provided view code actually handles this exception. Raising an exception has been moved to the backend, where it uses the same utility code to raise the `filterset.errors`.
- The 'no results'/'ignore' handling is capable of being handled at the view layer, dependent on a `FilterMixin.strict` option. 
- Given that views are easily customizable, the `FILTERS_STRICTNESS` setting is no longer necessary.
- This slightly changes the `Meta.together` handling by 
    - Allowing multiple 'together' set errors to be displayed (instead of just one).
    - Removes the fields from the `form.cleaned_data`

**TODO**:
- [x] ~~Determine how much deprecation warning needs to occur (if at all)~~ no deprecation for strictness
- [x] Add tests for `FilterBackend`/`FilterMixin` validation behavior
- [x] Deprecate strictness in docs (remove relevant docs, add migration)
- [x] ~~Document new public FilterSet API~~ postponing to docs overhaul

----

Additionally, this resolves #740 by extending #738. Inlining the original PR comment:

> I was thinking about #740 a while back, and realized that overriding the `FilterSet.qs` property is slightly awkward, due to the `_qs` caching. In the case of #740, `Prefetch` calls can only occur once, as duplicate calls can raise an exception. If you want to cache the prefetch, a correct solution looks like the following:
> ```python
> @property
> def qs(self):
>     # ensure that we haven't already cached, as this also implies prefetching
>     already_prefetched = hasattr(self, '_qs')
>     super().qs
>     if self.is_bound and not already_prefetched:
>         self._qs = self._qs.prefetch_related(...)
>     return self._qs
> ```
> Overriding `filter_queyset()` is a little more intuitive, as it would only be executed once.
> ```python
> def filter_queryset(self, queryset):
>     qs = super().filter_queryset(queryset)
>     return qs.prefetch_related(...)
> ```