### PR TITLE
[2.x proposal] Remove 'Meta.together' option

### DIFF
--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -681,67 +681,6 @@ class FilterSetStrictnessTests(TestCase):
         self.assertEqual(F(strict=False).strict, STRICTNESS.IGNORE)
 
 
-class FilterSetTogetherTests(TestCase):
-
-    def setUp(self):
-        self.alex = User.objects.create(username='alex', status=1)
-        self.jacob = User.objects.create(username='jacob', status=2)
-        self.qs = User.objects.all().order_by('id')
-
-    def test_fields_set(self):
-        class F(FilterSet):
-            class Meta:
-                model = User
-                fields = ['username', 'status', 'is_active', 'first_name']
-                together = [
-                    ('username', 'status'),
-                    ('first_name', 'is_active'),
-                ]
-                strict = STRICTNESS.RAISE_VALIDATION_ERROR
-
-        f = F({}, queryset=self.qs)
-        self.assertEqual(f.qs.count(), 2)
-
-        f = F({'username': 'alex'}, queryset=self.qs)
-        with self.assertRaises(ValidationError):
-            f.qs.count()
-
-        f = F({'username': 'alex', 'status': 1}, queryset=self.qs)
-        self.assertEqual(f.qs.count(), 1)
-        self.assertQuerysetEqual(f.qs, [self.alex.pk], lambda o: o.pk)
-
-    def test_single_fields_set(self):
-        class F(FilterSet):
-            class Meta:
-                model = User
-                fields = ['username', 'status']
-                together = ['username', 'status']
-                strict = STRICTNESS.RAISE_VALIDATION_ERROR
-
-        f = F({}, queryset=self.qs)
-        self.assertEqual(f.qs.count(), 2)
-
-        f = F({'username': 'alex'}, queryset=self.qs)
-        with self.assertRaises(ValidationError):
-            f.qs.count()
-
-        f = F({'username': 'alex', 'status': 1}, queryset=self.qs)
-        self.assertEqual(f.qs.count(), 1)
-        self.assertQuerysetEqual(f.qs, [self.alex.pk], lambda o: o.pk)
-
-    def test_empty_values(self):
-        class F(FilterSet):
-            class Meta:
-                model = User
-                fields = ['username', 'status']
-                together = ['username', 'status']
-
-        f = F({'username': '', 'status': ''}, queryset=self.qs)
-        self.assertEqual(f.qs.count(), 2)
-        f = F({'username': 'alex', 'status': ''}, queryset=self.qs)
-        self.assertEqual(f.qs.count(), 0)
-
-
 # test filter.method here, as it depends on its parent FilterSet
 class FilterMethodTests(TestCase):
 


### PR DESCRIPTION
Especially given that the #784 was rejected, I'm somewhat inclined to remove the `Meta.together` option, and replace it with a `Form.clean` example in the docs (which would also cover exclusive filter handling).

**TODO:**
- [x] Add deprecation
- [ ] ~~Add docs example for `Form.clean` together/exclusive handling~~