### PR TITLE
Method signature improvements

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -68,12 +68,12 @@ class Filter(object):
     creation_counter = 0
     field_class = forms.Field
 
-    def __init__(self, field_name=None, label=None, method=None, lookup_expr='exact',
-                 distinct=False, exclude=False, **kwargs):
+    def __init__(self, field_name=None, lookup_expr='exact', *, label=None,
+                 method=None, distinct=False, exclude=False, **kwargs):
         self.field_name = field_name
+        self.lookup_expr = lookup_expr
         self.label = label
         self.method = method
-        self.lookup_expr = lookup_expr
         self.distinct = distinct
         self.exclude = exclude
 

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -140,12 +140,13 @@ FILTER_FOR_DBFIELD_DEFAULTS = {
 class BaseFilterSet(object):
     FILTER_DEFAULTS = FILTER_FOR_DBFIELD_DEFAULTS
 
-    def __init__(self, data=None, queryset=None, prefix=None, strict=None, request=None):
+    def __init__(self, data=None, queryset=None, *, request=None, prefix=None, strict=None):
         self.is_bound = data is not None
         self.data = data or {}
         if queryset is None:
             queryset = self._meta.model._default_manager.all()
         self.queryset = queryset
+        self.request = request
         self.form_prefix = prefix
 
         # What to do on on validation errors
@@ -157,8 +158,6 @@ class BaseFilterSet(object):
 
         # transform legacy values
         self.strict = STRICTNESS._LEGACY.get(strict, strict)
-
-        self.request = request
 
         self.filters = copy.deepcopy(self.base_filters)
 


### PR DESCRIPTION
- Rename `f` => `field` in FilterSet classmethods
- Reorder `Filter.__init__` args to be mostly keyword-only (depends on going py3-only).