### PR TITLE
Remove more deprecations

### DIFF
--- a/django_filters/conf.py
+++ b/django_filters/conf.py
@@ -10,8 +10,6 @@ from .utils import deprecate
 
 DEFAULTS = {
     'DISABLE_HELP_TEXT': False,
-    'HELP_TEXT_FILTER': True,
-    'HELP_TEXT_EXCLUDE': True,
 
     # empty/null choices
     'EMPTY_CHOICE_LABEL': '---------',
@@ -63,8 +61,6 @@ DEFAULTS = {
 
 
 DEPRECATED_SETTINGS = [
-    'HELP_TEXT_FILTER',
-    'HELP_TEXT_EXCLUDE',
 ]
 
 

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -30,7 +30,7 @@ from .fields import (
     RangeField,
     TimeRangeField
 )
-from .utils import deprecate, label_for_filter
+from .utils import label_for_filter
 
 __all__ = [
     'AllValuesFilter',
@@ -65,21 +65,6 @@ __all__ = [
 
 
 LOOKUP_TYPES = sorted(QUERY_TERMS)
-
-
-def _extra_attr(attr):
-    fmt = ("The `.%s` attribute has been deprecated in favor of making it accessible "
-           "alongside the other field kwargs. You should now access it as `.extra['%s']`.")
-
-    def fget(self):
-        deprecate(fmt % (attr, attr))
-        return self.extra.get(attr)
-
-    def fset(self, value):
-        deprecate(fmt % (attr, attr))
-        self.extra[attr] = value
-
-    return {'fget': fget, 'fset': fset}
 
 
 class Filter(object):
@@ -143,10 +128,6 @@ class Filter(object):
 
         return locals()
     label = property(**label())
-
-    # deprecated field props
-    widget = property(**_extra_attr('widget'))
-    required = property(**_extra_attr('required'))
 
     @property
     def field(self):

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -18,12 +18,6 @@ class DefaultSettingsTests(TestCase):
     def test_strictness(self):
         self.assertEqual(settings.STRICTNESS, STRICTNESS.RETURN_NO_RESULTS)
 
-    def test_help_text_filter(self):
-        self.assertTrue(settings.HELP_TEXT_FILTER)
-
-    def test_help_text_exclude(self):
-        self.assertTrue(settings.HELP_TEXT_EXCLUDE)
-
     def test_empty_choice_label(self):
         self.assertEqual(settings.EMPTY_CHOICE_LABEL, '---------')
 
@@ -89,16 +83,16 @@ class OverrideSettingsTests(TestCase):
         # ensure that changed setting behaves correctly when
         # not originally present in the user's settings.
         from django.conf import settings as dj_settings
-        self.assertFalse(hasattr(dj_settings, 'FILTERS_HELP_TEXT_FILTER'))
+        self.assertFalse(hasattr(dj_settings, 'FILTERS_DISABLE_HELP_TEXT'))
 
         # Default value
-        self.assertTrue(settings.HELP_TEXT_FILTER)
+        self.assertFalse(settings.DISABLE_HELP_TEXT)
 
-        with override_settings(FILTERS_HELP_TEXT_FILTER=None):
-            self.assertIsNone(settings.HELP_TEXT_FILTER)
+        with override_settings(FILTERS_DISABLE_HELP_TEXT=True):
+            self.assertTrue(settings.DISABLE_HELP_TEXT)
 
         # Revert to default
-        self.assertTrue(settings.HELP_TEXT_FILTER)
+        self.assertFalse(settings.DISABLE_HELP_TEXT)
 
     def test_non_filters_setting(self):
         self.assertFalse(hasattr(settings, 'USE_TZ'))


### PR DESCRIPTION
Ach, forgot this in the deprecations.

Also removes the old/deprecated help_text settings. Seems they were forgotten