### PR TITLE
Fix Schema warnings

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -113,10 +113,9 @@ class Filter(object):
 
     def label():
         def fget(self):
-            if self._label is None and hasattr(self, 'parent'):
-                model = self.parent._meta.model
+            if self._label is None and hasattr(self, 'model'):
                 self._label = label_for_filter(
-                    model, self.field_name, self.lookup_expr, self.exclude
+                    self.model, self.field_name, self.lookup_expr, self.exclude
                 )
             return self._label
 

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -141,10 +141,12 @@ class BaseFilterSet(object):
     FILTER_DEFAULTS = FILTER_FOR_DBFIELD_DEFAULTS
 
     def __init__(self, data=None, queryset=None, *, request=None, prefix=None, strict=None):
-        self.is_bound = data is not None
-        self.data = data or {}
         if queryset is None:
             queryset = self._meta.model._default_manager.all()
+        model = queryset.model
+
+        self.is_bound = data is not None
+        self.data = data or {}
         self.queryset = queryset
         self.request = request
         self.form_prefix = prefix
@@ -161,9 +163,9 @@ class BaseFilterSet(object):
 
         self.filters = copy.deepcopy(self.base_filters)
 
+        # propagate the model and filterset to the filters
         for filter_ in self.filters.values():
-            # propagate the model and filterset to the filters
-            filter_.model = self._meta.model
+            filter_.model = model
             filter_.parent = self
 
     @property

--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -23,15 +23,17 @@ class DjangoFilterBackend(object):
         filter_fields = getattr(view, 'filter_fields', None)
 
         if filter_class:
-            filter_model = filter_class.Meta.model
+            filter_model = filter_class._meta.model
 
-            assert issubclass(queryset.model, filter_model), \
-                'FilterSet model %s does not match queryset model %s' % \
-                (filter_model, queryset.model)
+            # FilterSets do not need to specify a Meta class
+            if filter_model and queryset is not None:
+                assert issubclass(queryset.model, filter_model), \
+                    'FilterSet model %s does not match queryset model %s' % \
+                    (filter_model, queryset.model)
 
             return filter_class
 
-        if filter_fields:
+        if filter_fields and queryset is not None:
             MetaBase = getattr(self.default_filter_set, 'Meta', object)
 
             class AutoFilterSet(self.default_filter_set):

--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -82,15 +82,15 @@ class DjangoFilterBackend(object):
         assert compat.coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
         assert compat.coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
 
-        filter_class = getattr(view, 'filter_class', None)
-        if filter_class is None:
-            try:
-                filter_class = self.get_filter_class(view, view.get_queryset())
-            except Exception:
-                warnings.warn(
-                    "{} is not compatible with schema generation".format(view.__class__)
-                )
-                filter_class = None
+        try:
+            queryset = view.get_queryset()
+        except Exception:
+            queryset = None
+            warnings.warn(
+                "{} is not compatible with schema generation".format(view.__class__)
+            )
+
+        filter_class = self.get_filter_class(view, queryset)
 
         return [] if not filter_class else [
             compat.coreapi.Field(

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -150,6 +150,17 @@ class GetSchemaFieldsTests(TestCase):
             self.assertEqual(len(w), 1)
             self.assertEqual(str(w[0].message), warning)
 
+    def test_malformed_filter_fields(self):
+        # Malformed filter fields should raise an exception
+        class View(FilterFieldsRootView):
+            filter_fields = ['non_existent']
+
+        backend = DjangoFilterBackend()
+
+        msg = "'Meta.fields' contains fields that are not defined on this FilterSet: non_existent"
+        with self.assertRaisesMessage(TypeError, msg):
+            backend.get_schema_fields(View())
+
     def test_fields_with_filter_fields_dict(self):
         class DictFilterFieldsRootView(FilterFieldsRootView):
             filter_fields = {

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -25,14 +25,6 @@ class FilterableItemSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
-# Basic filter on a list view.
-class FilterFieldsRootView(generics.ListCreateAPIView):
-    queryset = FilterableItem.objects.all()
-    serializer_class = FilterableItemSerializer
-    filter_fields = ['decimal', 'date']
-    filter_backends = (DjangoFilterBackend,)
-
-
 # These class are used to test a filter class.
 class SeveralFieldsFilter(FilterSet):
     text = filters.CharFilter(lookup_expr='icontains')
@@ -44,11 +36,19 @@ class SeveralFieldsFilter(FilterSet):
         fields = ['text', 'decimal', 'date']
 
 
-class FilterClassRootView(generics.ListCreateAPIView):
+# Basic filter on a list view.
+class FilterableItemView(generics.ListCreateAPIView):
     queryset = FilterableItem.objects.all()
     serializer_class = FilterableItemSerializer
-    filter_class = SeveralFieldsFilter
     filter_backends = (DjangoFilterBackend,)
+
+
+class FilterFieldsRootView(FilterableItemView):
+    filter_fields = ['decimal', 'date']
+
+
+class FilterClassRootView(FilterableItemView):
+    filter_class = SeveralFieldsFilter
 
 
 @skipIf(compat.coreapi is None, 'coreapi must be installed')

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -7,7 +7,6 @@ from django.test import TestCase, override_settings
 from django.utils import timezone
 from django.utils.timezone import now
 
-from django_filters.exceptions import FieldLookupError
 from django_filters.filters import (
     AllValuesFilter,
     AllValuesMultipleFilter,
@@ -1944,16 +1943,3 @@ class MiscFilterSetTests(TestCase):
         f = F({'status': '2'}, queryset=qs)
         self.assertEqual(len(f.qs), 2)
         self.assertEqual(f.qs.count(), 2)
-
-    def test_invalid_field_lookup(self):
-        # We want to ensure that non existent lookups (or just simple misspellings)
-        # throw a useful exception containg the field and lookup expr.
-        with self.assertRaises(FieldLookupError) as context:
-            class F(FilterSet):
-                class Meta:
-                    model = User
-                    fields = {'username': ['flub']}
-
-        exc = str(context.exception)
-        self.assertIn('tests.User.username', exc)
-        self.assertIn('flub', exc)

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1888,6 +1888,13 @@ class MiscFilterSetTests(TestCase):
         self.assertNotEqual(qs, result)
         qs.all.return_value.filter.assert_called_with(username__exact='jdoe')
 
+    def test_filtering_without_meta(self):
+        class F(FilterSet):
+            username = CharFilter()
+
+        f = F({'username': 'alex'}, queryset=User.objects.all())
+        self.assertQuerysetEqual(f.qs, ['alex'], lambda o: o.username)
+
     def test_filtering_with_multiple_filters(self):
         class F(FilterSet):
             class Meta:

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -1,11 +1,11 @@
 import mock
 import unittest
 
-from django.core.exceptions import ValidationError
 from django.db import models
 from django.test import TestCase, override_settings
 
 from django_filters.constants import STRICTNESS
+from django_filters.exceptions import FieldLookupError
 from django_filters.filters import (
     BaseInFilter,
     BaseRangeFilter,
@@ -444,6 +444,19 @@ class FilterSetClassCreationTests(TestCase):
                               'title': ['exact'],
                               'other': ['exact'],
                               }
+
+    def test_meta_fields_invalid_lookup(self):
+        # We want to ensure that non existent lookups (or just simple misspellings)
+        # throw a useful exception containg the field and lookup expr.
+        with self.assertRaises(FieldLookupError) as context:
+            class F(FilterSet):
+                class Meta:
+                    model = User
+                    fields = {'username': ['flub']}
+
+        exc = str(context.exception)
+        self.assertIn('tests.User.username', exc)
+        self.assertIn('flub', exc)
 
     def test_meta_exlude_with_declared_and_declared_wins(self):
         class F(FilterSet):


### PR DESCRIPTION
The original purpose of this PR was to fix #802, however it was necessary to make a few other changes.

**Changes:**
- `DjangoFilterBackend.get_schema_fields()` no longer catches FilterSet class creation errors (ref #743)
- `DjangoFilterBackend.get_filter_class()` only performs the model check when applicable. The queryset may not have been provided, or the `filter_class` may not have set `Meta.model`.
- `Filter.label` has been fixed to reference `self.model` instead of `self.parent._meta.model`