### PR TITLE
PoC of fix for #812 (without breaking changes)

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from datetime import timedelta
 
 from django import forms
+from django.db import models
 from django.db.models import Q
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.sql.constants import QUERY_TERMS
@@ -84,7 +85,12 @@ def _extra_attr(attr):
 
 class Filter(object):
     creation_counter = 0
-    field_class = forms.Field
+    model_field = None
+
+    def field_class(self, **kwargs):
+        if self.model_field is None:
+            self.model_field = models.Field()
+        return self.model_field.formfield(**kwargs)
 
     def __init__(self, field_name=None, label=None, method=None, lookup_expr='exact',
                  distinct=False, exclude=False, **kwargs):

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -352,6 +352,11 @@ class BaseFilterSet(object):
         filter_class, params = cls.filter_for_lookup(f, lookup_type)
         default.update(params)
 
+        if filter_class is None:
+            filter = Filter(**default)
+            filter.model_field = f
+            return filter
+
         assert filter_class is not None, (
             "%s resolved field '%s' with '%s' lookup to an unrecognized field "
             "type %s. Try adding an override to 'Meta.filter_overrides'. See: "

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -4,6 +4,7 @@ import mock
 import unittest
 
 import django
+from django import forms
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.test import TestCase, override_settings
@@ -167,6 +168,14 @@ class FilterSetFilterForFieldTests(TestCase):
             "FilterSet resolved field 'mask' with 'exact' lookup "
             "to an unrecognized field type SubnetMaskField",
             excinfo.exception.args[0])
+
+    def test_unknown_field_type_supported(self):
+        f = NetworkSetting._meta.get_field('mask')
+
+        result = FilterSet.filter_for_field(f, 'mask')
+
+        self.assertIsInstance(result, Filter)
+        self.assertIsInstance(result.field_class(), forms.GenericIPAddressField)
 
     def test_symmetrical_selfref_m2m_field(self):
         f = Node._meta.get_field('adjacents')


### PR DESCRIPTION
PoC of a change to support arbitrary Field types.  Passes all test except two:

 - A test that tries to use `self.field_class` (temporarily a method) as a parent class
 - A test that expects an "unknown field" to fail (which is what this is supposed to fix).

I added the parallel test for the "unknown field" that correctly resolves to the form specified by the field type.