### PR TITLE
[wip] Improve coreschema use, add schema multiwidget support

### DIFF
--- a/django_filters/compat.py
+++ b/django_filters/compat.py
@@ -21,5 +21,11 @@ except ImportError:
 
 try:
     import coreschema
+    from coreschema import schemas
 except ImportError:
+    class _NullSchemas:
+        def __getattr__(self, name):
+            return None
+
     coreschema = None
+    schemas = _NullSchemas()

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -10,6 +10,7 @@ from django.utils.itercompat import is_iterable
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
 
+from .compat import coreschema, schemas
 from .conf import settings
 from .constants import EMPTY_VALUES
 from .fields import (
@@ -67,6 +68,7 @@ LOOKUP_TYPES = sorted(QUERY_TERMS)
 class Filter(object):
     creation_counter = 0
     field_class = forms.Field
+    schema_class = schemas.String
 
     def __init__(self, field_name=None, lookup_expr='exact', *, label=None,
                  method=None, distinct=False, exclude=False, **kwargs):
@@ -174,13 +176,29 @@ class Filter(object):
         qs = self.get_method(qs)(**{'%s__%s' % (self.field_name, lookup): value})
         return qs
 
+    @property
+    def schema(self):
+        assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
+
+        return self.schema_class(
+            description=str(self.extra.get('help_text', '')),
+        )
+
 
 class CharFilter(Filter):
     field_class = forms.CharField
 
+    @property
+    def schema(self):
+        schema = super().schema
+        schema.min_length = self.extra.get('min_length')
+        schema.max_length = self.extra.get('max_length')
+        return schema
+
 
 class BooleanFilter(Filter):
     field_class = forms.NullBooleanField
+    schema_class = schemas.Boolean
 
 
 class ChoiceFilter(Filter):
@@ -291,9 +309,21 @@ class TypedMultipleChoiceFilter(MultipleChoiceFilter):
 class DateFilter(Filter):
     field_class = forms.DateField
 
+    @property
+    def schema(self):
+        schema = super().schema
+        schema.format = 'date'
+        return schema
+
 
 class DateTimeFilter(Filter):
     field_class = forms.DateTimeField
+
+    @property
+    def schema(self):
+        schema = super().schema
+        schema.format = 'date-time'
+        return schema
 
 
 class IsoDateTimeFilter(DateTimeFilter):
@@ -312,9 +342,21 @@ class IsoDateTimeFilter(DateTimeFilter):
 class TimeFilter(Filter):
     field_class = forms.TimeField
 
+    @property
+    def schema(self):
+        schema = super().schema
+        schema.format = 'time'
+        return schema
+
 
 class DurationFilter(Filter):
     field_class = forms.DurationField
+
+    @property
+    def schema(self):
+        schema = super().schema
+        schema.format = 'duration'
+        return schema
 
 
 class QuerySetRequestMixin(object):
@@ -382,6 +424,7 @@ class ModelMultipleChoiceFilter(QuerySetRequestMixin, MultipleChoiceFilter):
 
 class NumberFilter(Filter):
     field_class = forms.DecimalField
+    schema_class = schemas.Number
 
 
 class NumericRangeFilter(Filter):
@@ -475,13 +518,31 @@ class DateRangeFilter(ChoiceFilter):
 class DateFromToRangeFilter(RangeFilter):
     field_class = DateRangeField
 
+    @property
+    def schema(self):
+        schema = super().schema
+        schema.format = 'date'
+        return schema
+
 
 class DateTimeFromToRangeFilter(RangeFilter):
     field_class = DateTimeRangeField
 
+    @property
+    def schema(self):
+        schema = super().schema
+        schema.format = 'date-time'
+        return schema
+
 
 class TimeRangeFilter(RangeFilter):
     field_class = TimeRangeField
+
+    @property
+    def schema(self):
+        schema = super().schema
+        schema.format = 'time'
+        return schema
 
 
 class AllValuesFilter(ChoiceFilter):
@@ -546,6 +607,12 @@ class BaseCSVFilter(Filter):
         # DateTimeYearInField
         return str('%s%sField' % (type_name, expression_name))
 
+    @property
+    def schema(self):
+        schema = super().schema
+        schema = schemas.Array(schema)
+        return schema
+
 
 class BaseInFilter(BaseCSVFilter):
 
@@ -560,6 +627,12 @@ class BaseRangeFilter(BaseCSVFilter):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('lookup_expr', 'range')
         super(BaseRangeFilter, self).__init__(*args, **kwargs)
+
+    @property
+    def schema(self):
+        schema = super().schema
+        schema.max_items = 2
+        return schema
 
 
 class OrderingFilter(BaseCSVFilter, ChoiceFilter):

--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -100,6 +100,6 @@ class DjangoFilterBackend(object):
                 name=field_name,
                 required=field.extra['required'],
                 location='query',
-                schema=self.get_coreschema_field(field)
+                schema=field.schema
             ) for field_name, field in filter_class.base_filters.items()
         ]

--- a/django_filters/widgets.py
+++ b/django_filters/widgets.py
@@ -86,7 +86,8 @@ class SuffixedMultiWidget(forms.MultiWidget):
         assert len(self.widgets) == len(self.suffixes)
         assert len(self.suffixes) == len(set(self.suffixes))
 
-    def suffixed(self, name, suffix):
+    @classmethod
+    def suffixed(cls, name, suffix):
         return '_'.join([name, suffix]) if suffix else name
 
     def get_context(self, name, value, attrs):

--- a/django_filters/widgets.py
+++ b/django_filters/widgets.py
@@ -1,6 +1,5 @@
 from collections import Iterable
 from itertools import chain
-from re import search, sub
 
 from django import forms
 from django.db.models.fields import BLANK_CHOICE_DASH
@@ -108,14 +107,6 @@ class SuffixedMultiWidget(forms.MultiWidget):
             widget.value_omitted_from_data(data, files, self.suffixed(name, suffix))
             for widget, suffix in zip(self.widgets, self.suffixes)
         )
-
-    def replace_name(self, output, index):
-        result = search(r'name="(?P<name>.*)_%d"' % index, output)
-        name = result.group('name')
-        name = self.suffixed(name, self.suffixes[index])
-        name = 'name="%s"' % name
-
-        return sub(r'name=".*_%d"' % index, name, output)
 
     def decompress(self, value):
         if value is None:


### PR DESCRIPTION
Hi @carltongibson, this is just a wip that potentially fixes #810. I don't have an urgent need to see this merged, but would like to get your sentiment on this approach before continuing further with tests and etc..

**Changes:**
- Adds a `Filter.schema_class` and `Filter.schema` property, a la `Filter.field_class` and `Filter.field`.
- Adds more extensive coreschema support (not just string/number schemas, also adds validation, formats, other types)
- The backend expects a list of *coreapi fields* per filter. The idea being that some filters (aka SuffixedMultiWidget) expect multiple query params.

**Notes:**
- Filters return a coreschema instead of a coreapi field. This is due to the filter not knowing it's attribute name on the filterset, thus it cannot fully construct it's set of coreapi fields. 
- Note the `_NullSchemas` class. 

**TODO:**
- [ ] Add tests for the Filter schema API ([DRF schema tests](https://github.com/encode/django-rest-framework/blob/b2ec681d8d4c5a4a5ff3febb43449be5eea07883/tests/test_schemas.py#L114))
- [ ] Add tests for the various schemas, especially CSV/Array schemas.
- [ ] Should `ChoiceField`/`ModelChoiceField` present their choices as an `schemas.Enum`?
- [ ] How do CSV filters differ in schema from `MultipleChoiceFilter`?
- [ ] Handle typed filters?
- [ ] Disable generated schemas for `MultiWidget`-based filters (but allow user override?)