### PR TITLE
Use DRF BooleanFilter for NullBooleanField in DRF FilterSet (Fixes #842)

### DIFF
--- a/django_filters/rest_framework/filterset.py
+++ b/django_filters/rest_framework/filterset.py
@@ -16,6 +16,7 @@ FILTER_FOR_DBFIELD_DEFAULTS = deepcopy(filterset.FILTER_FOR_DBFIELD_DEFAULTS)
 FILTER_FOR_DBFIELD_DEFAULTS.update({
     models.DateTimeField: {'filter_class': IsoDateTimeFilter},
     models.BooleanField: {'filter_class': BooleanFilter},
+    models.NullBooleanField: {'filter_class': BooleanFilter},
 })
 
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -51,6 +51,7 @@ class User(models.Model):
     status = models.IntegerField(choices=STATUS_CHOICES, default=0)
 
     is_active = models.BooleanField(default=False)
+    is_employed = models.NullBooleanField(default=False)
 
     favorite_books = models.ManyToManyField('Book', related_name='lovers')
 

--- a/tests/rest_framework/test_filterset.py
+++ b/tests/rest_framework/test_filterset.py
@@ -31,6 +31,12 @@ class FilterSetFilterForFieldTests(TestCase):
         self.assertIsInstance(result, filters.BooleanFilter)
         self.assertEqual(result.extra['widget'], BooleanWidget)
 
+    def test_booleanfilter_widget_nullbooleanfield(self):
+        field = User._meta.get_field('is_employed')
+        result = FilterSet.filter_for_field(field, 'is_employed')
+        self.assertIsInstance(result, filters.BooleanFilter)
+        self.assertEqual(result.extra['widget'], BooleanWidget)
+
 
 @skipIf(is_crispy(), 'django_crispy_forms must be installed')
 @override_settings(INSTALLED_APPS=settings.INSTALLED_APPS + ('crispy_forms', ))


### PR DESCRIPTION
Just like how `BooleanFilter` is used for NullBooleanField in the standard FilterSet, BooleanFilter for DRF should also be used for NullBooleanField in DRF FIlterSet.