### PR TITLE
List Django as a dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,4 +53,7 @@ setup(
         'Framework :: Django',
     ],
     zip_safe=False,
+    install_requires=[
+        'Django>=1.11',
+    ],
 )


### PR DESCRIPTION
Django is a hard dependency of django-filter, it should be listed in `install_requires` to reflect that.