### PR TITLE
Fix empty value check for CSV range

### DIFF
--- a/django_filters/fields.py
+++ b/django_filters/fields.py
@@ -191,7 +191,9 @@ class BaseRangeField(BaseCSVField):
     def clean(self, value):
         value = super().clean(value)
 
-        if value is not None and len(value) != 2:
+        assert value is None or isinstance(value, list)
+
+        if value and len(value) != 2:
             raise forms.ValidationError(
                 self.error_messages['invalid_values'],
                 code='invalid_values')

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -260,12 +260,11 @@ class BaseRangeFieldTests(TestCase):
 
     def test_clean(self):
         self.assertEqual(self.field.clean(None), None)
+        self.assertEqual(self.field.clean(''), [])
+        self.assertEqual(self.field.clean([]), [])
         self.assertEqual(self.field.clean(['1', '2']), [1, 2])
 
     def test_validation_error(self):
-        with self.assertRaises(forms.ValidationError):
-            self.field.clean('')
-
         with self.assertRaises(forms.ValidationError):
             self.field.clean([''])
 

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1592,13 +1592,11 @@ class NonSymmetricalSelfReferentialRelationshipTests(TestCase):
         self.assertQuerysetEqual(f.qs, [2], lambda o: o.pk)
 
 
-# use naive datetimes, as pytz is required to perform
-# date lookups when timezones are involved.
-@override_settings(USE_TZ=False)
+@override_settings(TIME_ZONE='UTC')
 class TransformedQueryExpressionFilterTests(TestCase):
 
     def test_filtering(self):
-        now_dt = datetime.datetime.now()
+        now_dt = now()
         after_5pm = now_dt.replace(hour=18)
         before_5pm = now_dt.replace(hour=16)
 
@@ -1675,9 +1673,7 @@ class LookupChoiceFilterTests(TestCase):
         })
 
 
-# use naive datetimes, as pytz is required to perform
-# date lookups when timezones are involved.
-@override_settings(USE_TZ=False)
+@override_settings(TIME_ZONE='UTC')
 class CSVFilterTests(TestCase):
 
     def setUp(self):
@@ -1686,7 +1682,7 @@ class CSVFilterTests(TestCase):
         User.objects.create(username='aaron', status=2)
         User.objects.create(username='carl', status=0)
 
-        now_dt = datetime.datetime.now()
+        now_dt = now()
         after_5pm = now_dt.replace(hour=18)
         before_5pm = now_dt.replace(hour=16)
 


### PR DESCRIPTION
CSV ranges currently don't accept empty values. This is acceptable in API use, but not for forms. 