### PR TITLE
Fix distinct call for range filters

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -390,16 +390,15 @@ class NumericRangeFilter(Filter):
     def filter(self, qs, value):
         if value:
             if value.start is not None and value.stop is not None:
-                lookup = '%s__%s' % (self.field_name, self.lookup_expr)
-                return self.get_method(qs)(**{lookup: (value.start, value.stop)})
-            else:
-                if value.start is not None:
-                    qs = self.get_method(qs)(**{'%s__startswith' % self.field_name: value.start})
-                if value.stop is not None:
-                    qs = self.get_method(qs)(**{'%s__endswith' % self.field_name: value.stop})
-            if self.distinct:
-                qs = qs.distinct()
-        return qs
+                value = (value.start, value.stop)
+            elif value.start is not None:
+                self.lookup_expr = 'startswith'
+                value = value.start
+            elif value.stop is not None:
+                self.lookup_expr = 'endswith'
+                value = value.stop
+
+        return super().filter(qs, value)
 
 
 class RangeFilter(Filter):
@@ -408,16 +407,16 @@ class RangeFilter(Filter):
     def filter(self, qs, value):
         if value:
             if value.start is not None and value.stop is not None:
-                lookup = '%s__range' % self.field_name
-                return self.get_method(qs)(**{lookup: (value.start, value.stop)})
-            else:
-                if value.start is not None:
-                    qs = self.get_method(qs)(**{'%s__gte' % self.field_name: value.start})
-                if value.stop is not None:
-                    qs = self.get_method(qs)(**{'%s__lte' % self.field_name: value.stop})
-            if self.distinct:
-                qs = qs.distinct()
-        return qs
+                self.lookup_expr = 'range'
+                value = (value.start, value.stop)
+            elif value.start is not None:
+                self.lookup_expr = 'gte'
+                value = value.start
+            elif value.stop is not None:
+                self.lookup_expr = 'lte'
+                value = value.stop
+
+        return super().filter(qs, value)
 
 
 def _truncate(dt):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -915,6 +915,27 @@ class NumericRangeFilterTests(TestCase):
         f.filter(qs, value)
         qs.filter.assert_called_once_with(None__endswith=30)
 
+    def test_filtering_distinct(self):
+        f = NumericRangeFilter(distinct=True)
+
+        # range
+        qs = mock.Mock()
+        f.filter(qs, mock.Mock(start=20, stop=30))
+        qs.distinct.assert_called_once()
+        qs.distinct.return_value.filter.assert_called_once_with(None__exact=(20, 30))
+
+        # min
+        qs = mock.Mock()
+        f.filter(qs, mock.Mock(start=20, stop=None))
+        qs.distinct.assert_called_once()
+        qs.distinct.return_value.filter.assert_called_once_with(None__startswith=20)
+
+        # max
+        qs = mock.Mock()
+        f.filter(qs, mock.Mock(start=None, stop=30))
+        qs.distinct.assert_called_once()
+        qs.distinct.return_value.filter.assert_called_once_with(None__endswith=30)
+
 
 class RangeFilterTests(TestCase):
 
@@ -963,6 +984,27 @@ class RangeFilterTests(TestCase):
         f = RangeFilter(lookup_expr='gte')
         f.filter(qs, value)
         qs.filter.assert_called_once_with(None__range=(20, 30))
+
+    def test_filtering_distinct(self):
+        f = RangeFilter(distinct=True)
+
+        # range
+        qs = mock.Mock()
+        f.filter(qs, mock.Mock(start=20, stop=30))
+        qs.distinct.assert_called_once()
+        qs.distinct.return_value.filter.assert_called_once_with(None__range=(20, 30))
+
+        # min
+        qs = mock.Mock()
+        f.filter(qs, mock.Mock(start=20, stop=None))
+        qs.distinct.assert_called_once()
+        qs.distinct.return_value.filter.assert_called_once_with(None__gte=20)
+
+        # max
+        qs = mock.Mock()
+        f.filter(qs, mock.Mock(start=None, stop=30))
+        qs.distinct.assert_called_once()
+        qs.distinct.return_value.filter.assert_called_once_with(None__lte=30)
 
 
 class DateRangeFilterTests(TestCase):


### PR DESCRIPTION
Per @joinworldtv with https://github.com/carltongibson/django-filter/pull/417#issuecomment-357722081

Instead of reimplementing the `.filter()` method entirely, the override simply alters the `.lookup_expr` and value, then calls the base method.