### PR TITLE
Improve view-related attribute name consistency

### DIFF
--- a/django_filters/utils.py
+++ b/django_filters/utils.py
@@ -18,9 +18,14 @@ from .exceptions import FieldLookupError
 
 
 def deprecate(msg, level_modifier=0):
-    warnings.warn(
-        "%s See: https://django-filter.readthedocs.io/en/master/guide/migration.html" % msg,
-        DeprecationWarning, stacklevel=3 + level_modifier)
+    warnings.warn(msg, MigrationNotice, stacklevel=3 + level_modifier)
+
+
+class MigrationNotice(DeprecationWarning):
+    url = 'https://django-filter.readthedocs.io/en/master/guide/migration.html'
+
+    def __init__(self, message):
+        super().__init__('%s See: %s' % (message, self.url))
 
 
 def try_dbfield(fn, field_class):

--- a/django_filters/views.py
+++ b/django_filters/views.py
@@ -7,14 +7,22 @@ from django.views.generic.list import (
 
 from .constants import ALL_FIELDS
 from .filterset import filterset_factory
+from .utils import MigrationNotice, RenameAttributesBase
 
 
-class FilterMixin(object):
+# TODO: remove metaclass in 2.1
+class FilterMixinRenames(RenameAttributesBase):
+    renamed_attributes = (
+        ('filter_fields', 'filterset_fields', MigrationNotice),
+    )
+
+
+class FilterMixin(metaclass=FilterMixinRenames):
     """
     A mixin that provides a way to show and handle a FilterSet in a request.
     """
     filterset_class = None
-    filter_fields = ALL_FIELDS
+    filterset_fields = ALL_FIELDS
     strict = True
 
     def get_filterset_class(self):

--- a/django_filters/views.py
+++ b/django_filters/views.py
@@ -32,7 +32,7 @@ class FilterMixin(metaclass=FilterMixinRenames):
         if self.filterset_class:
             return self.filterset_class
         elif self.model:
-            return filterset_factory(model=self.model, fields=self.filter_fields)
+            return filterset_factory(model=self.model, fields=self.filterset_fields)
         else:
             msg = "'%s' must define 'filterset_class' or 'model'"
             raise ImproperlyConfigured(msg % self.__class__.__name__)

--- a/docs/guide/migration.txt
+++ b/docs/guide/migration.txt
@@ -45,6 +45,20 @@ The ``Filter.lookup_expr`` argument no longer accepts ``None`` or a list of
 expressions. Use the :ref:`LookupChoiceFilter <lookup-choice-filter>` instead.
 
 
+View attributes renamed (`#867`__)
+----------------------------------
+__ https://github.com/carltongibson/django-filter/pull/867
+
+Several view-related attributes have been renamed to improve consistency with
+other parts of the library. The following classes are affected:
+
+* DRF ``ViewSet.filter_class`` => ``filterset_class``
+* DRF ``ViewSet.filter_fields`` => ``filterset_fields``
+* ``DjangoFilterBackend.default_filter_set`` => ``filterset_base``
+* ``DjangoFilterBackend.get_filter_class()`` => ``get_filterset_class()``
+* ``FilterMixin.filter_fields`` => ``filterset_fields``
+
+
 FilterSet ``Meta.together`` option removed (`#791`__)
 -----------------------------------------------------
 __ https://github.com/carltongibson/django-filter/pull/791

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -136,6 +136,9 @@ class GetSchemaFieldsTests(TestCase):
           * https://github.com/carltongibson/django-filter/issues/551
         """
         class BadGetQuerySetView(FilterFieldsRootView):
+            # TODO: temporary, remove me
+            filterset_fields = ['decimal', 'date']
+
             def get_queryset(self):
                 raise AttributeError("I don't have that")
 
@@ -354,6 +357,44 @@ class RenamedBackendAttributesTests(TestCase):
 
             class Backend(DjangoFilterBackend):
                 default_filter_set = None
+
+        message = str(recorded.pop().message)
+        self.assertEqual(message, expected)
+        self.assertEqual(len(recorded), 0)
+
+
+class RenamedViewSetAttributesTests(TestCase):
+
+    def test_filter_class(self):
+        expected = "`View.filter_class` attribute should be renamed `filterset_class`. " \
+                   "See: https://django-filter.readthedocs.io/en/master/guide/migration.html"
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter('always')
+
+            class View(generics.ListCreateAPIView):
+                filter_class = None
+
+            view = View()
+            backend = DjangoFilterBackend()
+            backend.get_filterset_class(view, None)
+
+        message = str(recorded.pop().message)
+        self.assertEqual(message, expected)
+        self.assertEqual(len(recorded), 0)
+
+    def test_filter_fields(self):
+        expected = "`View.filter_fields` attribute should be renamed `filterset_fields`. " \
+                   "See: https://django-filter.readthedocs.io/en/master/guide/migration.html"
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter('always')
+
+            class View(generics.ListCreateAPIView):
+                filter_fields = None
+
+            view = View()
+            backend = DjangoFilterBackend()
+            # import pdb; pdb.set_trace()
+            backend.get_filterset_class(view, None)
 
         message = str(recorded.pop().message)
         self.assertEqual(message, expected)

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -45,16 +45,16 @@ class FilterableItemView(generics.ListCreateAPIView):
 
 
 class FilterFieldsRootView(FilterableItemView):
-    filter_fields = ['decimal', 'date']
+    filterset_fields = ['decimal', 'date']
 
 
 class FilterClassRootView(FilterableItemView):
-    filter_class = SeveralFieldsFilter
+    filterset_class = SeveralFieldsFilter
 
 
 class GetFilterClassTests(TestCase):
 
-    def test_filter_class(self):
+    def test_filterset_class(self):
         class Filter(FilterSet):
             class Meta:
                 model = FilterableItem
@@ -62,25 +62,25 @@ class GetFilterClassTests(TestCase):
 
         backend = DjangoFilterBackend()
         view = FilterableItemView()
-        view.filter_class = Filter
+        view.filterset_class = Filter
         queryset = FilterableItem.objects.all()
 
-        filter_class = backend.get_filter_class(view, queryset)
-        self.assertIs(filter_class, Filter)
+        filterset_class = backend.get_filterset_class(view, queryset)
+        self.assertIs(filterset_class, Filter)
 
-    def test_filter_class_no_meta(self):
+    def test_filterset_class_no_meta(self):
         class Filter(FilterSet):
             pass
 
         backend = DjangoFilterBackend()
         view = FilterableItemView()
-        view.filter_class = Filter
+        view.filterset_class = Filter
         queryset = FilterableItem.objects.all()
 
-        filter_class = backend.get_filter_class(view, queryset)
-        self.assertIs(filter_class, Filter)
+        filterset_class = backend.get_filterset_class(view, queryset)
+        self.assertIs(filterset_class, Filter)
 
-    def test_filter_class_no_queryset(self):
+    def test_filterset_class_no_queryset(self):
         class Filter(FilterSet):
             class Meta:
                 model = FilterableItem
@@ -88,55 +88,54 @@ class GetFilterClassTests(TestCase):
 
         backend = DjangoFilterBackend()
         view = FilterableItemView()
-        view.filter_class = Filter
+        view.filterset_class = Filter
 
-        filter_class = backend.get_filter_class(view, None)
-        self.assertIs(filter_class, Filter)
+        filterset_class = backend.get_filterset_class(view, None)
+        self.assertIs(filterset_class, Filter)
 
-    def test_filter_fields(self):
+    def test_filterset_fields(self):
         backend = DjangoFilterBackend()
         view = FilterableItemView()
-        view.filter_fields = ['text', 'decimal', 'date']
+        view.filterset_fields = ['text', 'decimal', 'date']
         queryset = FilterableItem.objects.all()
 
-        filter_class = backend.get_filter_class(view, queryset)
-        self.assertEqual(filter_class._meta.fields, view.filter_fields)
+        filterset_class = backend.get_filterset_class(view, queryset)
+        self.assertEqual(filterset_class._meta.fields, view.filterset_fields)
 
-    def test_filter_fields_malformed(self):
+    def test_filterset_fields_malformed(self):
         backend = DjangoFilterBackend()
         view = FilterableItemView()
-        view.filter_fields = ['non_existent']
+        view.filterset_fields = ['non_existent']
         queryset = FilterableItem.objects.all()
 
         msg = "'Meta.fields' contains fields that are not defined on this FilterSet: non_existent"
         with self.assertRaisesMessage(TypeError, msg):
-            backend.get_filter_class(view, queryset)
+            backend.get_filterset_class(view, queryset)
 
-    def test_filter_fields_no_queryset(self):
+    def test_filterset_fields_no_queryset(self):
         backend = DjangoFilterBackend()
         view = FilterableItemView()
-        view.filter_fields = ['text', 'decimal', 'date']
+        view.filterset_fields = ['text', 'decimal', 'date']
 
-        filter_class = backend.get_filter_class(view, None)
-        self.assertIsNone(filter_class)
+        filterset_class = backend.get_filterset_class(view, None)
+        self.assertIsNone(filterset_class)
 
 
 @skipIf(compat.coreapi is None, 'coreapi must be installed')
 class GetSchemaFieldsTests(TestCase):
-    def test_fields_with_filter_fields_list(self):
+    def test_fields_with_filterset_fields_list(self):
         backend = DjangoFilterBackend()
         fields = backend.get_schema_fields(FilterFieldsRootView())
         fields = [f.name for f in fields]
 
         self.assertEqual(fields, ['decimal', 'date'])
 
-    def test_filter_fields_list_with_bad_get_queryset(self):
+    def test_filterset_fields_list_with_bad_get_queryset(self):
         """
         See:
           * https://github.com/carltongibson/django-filter/issues/551
         """
         class BadGetQuerySetView(FilterFieldsRootView):
-            # TODO: temporary, remove me
             filterset_fields = ['decimal', 'date']
 
             def get_queryset(self):
@@ -154,10 +153,10 @@ class GetSchemaFieldsTests(TestCase):
             self.assertEqual(len(w), 1)
             self.assertEqual(str(w[0].message), warning)
 
-    def test_malformed_filter_fields(self):
+    def test_malformed_filterset_fields(self):
         # Malformed filter fields should raise an exception
         class View(FilterFieldsRootView):
-            filter_fields = ['non_existent']
+            filterset_fields = ['non_existent']
 
         backend = DjangoFilterBackend()
 
@@ -165,9 +164,9 @@ class GetSchemaFieldsTests(TestCase):
         with self.assertRaisesMessage(TypeError, msg):
             backend.get_schema_fields(View())
 
-    def test_fields_with_filter_fields_dict(self):
+    def test_fields_with_filterset_fields_dict(self):
         class DictFilterFieldsRootView(FilterFieldsRootView):
-            filter_fields = {
+            filterset_fields = {
                 'decimal': ['exact', 'lt', 'gt'],
             }
 
@@ -177,7 +176,7 @@ class GetSchemaFieldsTests(TestCase):
 
         self.assertEqual(fields, ['decimal', 'decimal__lt', 'decimal__gt'])
 
-    def test_fields_with_filter_class(self):
+    def test_fields_with_filterset_class(self):
         backend = DjangoFilterBackend()
         fields = backend.get_schema_fields(FilterClassRootView())
         schemas = [f.schema for f in fields]
@@ -196,7 +195,7 @@ class GetSchemaFieldsTests(TestCase):
                 fields = SeveralFieldsFilter.Meta.fields + ['required_text']
 
         class FilterClassWithRequiredFieldsView(FilterClassRootView):
-            filter_class = RequiredFieldsFilter
+            filterset_class = RequiredFieldsFilter
 
         backend = DjangoFilterBackend()
         fields = backend.get_schema_fields(FilterClassWithRequiredFieldsView())
@@ -219,7 +218,7 @@ class GetSchemaFieldsTests(TestCase):
             f = filters.ModelChoiceFilter(queryset=qs)
 
         class View(FilterClassRootView):
-            filter_class = F
+            filterset_class = F
 
         view = View()
         view.request = factory.get('/')
@@ -287,8 +286,8 @@ class TemplateTests(TestCase):
             self.test_backend_output()
 
 
-class DefaultFilterSetTests(TestCase):
-    def test_default_meta_inheritance(self):
+class AutoFilterSetTests(TestCase):
+    def test_autofilter_meta_inheritance(self):
         # https://github.com/carltongibson/django-filter/issues/663
 
         class F(FilterSet):
@@ -296,15 +295,15 @@ class DefaultFilterSetTests(TestCase):
                 filter_overrides = {BooleanField: {}}
 
         class Backend(DjangoFilterBackend):
-            default_filter_set = F
+            filterset_base = F
 
         view = FilterFieldsRootView()
         backend = Backend()
 
-        filter_class = backend.get_filter_class(view, view.get_queryset())
-        filter_overrides = filter_class._meta.filter_overrides
+        filterset_class = backend.get_filterset_class(view, view.get_queryset())
+        filter_overrides = filterset_class._meta.filter_overrides
 
-        # derived filter_class.Meta should inherit from default_filter_set.Meta
+        # derived filterset_class.Meta should inherit from default_filter_set.Meta
         self.assertIn(BooleanField, filter_overrides)
         self.assertDictEqual(filter_overrides[BooleanField], {})
 
@@ -322,7 +321,7 @@ class ValidationErrorTests(TestCase):
         request = factory.get('/?id=foo&author=bar&name=baz')
         request = view.initialize_request(request)
         queryset = Article.objects.all()
-        view.filter_class = F
+        view.filterset_class = F
 
         with self.assertRaises(serializers.ValidationError) as exc:
             backend.filter_queryset(request, queryset, view)

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -329,3 +329,32 @@ class ValidationErrorTests(TestCase):
             'id': ['Enter a number.'],
             'author': ['Select a valid choice. That choice is not one of the available choices.'],
         })
+
+
+class RenamedBackendAttributesTests(TestCase):
+    def test_get_filter_class(self):
+        expected = "`Backend.get_filter_class` method should be renamed `get_filterset_class`. " \
+                   "See: https://django-filter.readthedocs.io/en/master/guide/migration.html"
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter('always')
+
+            class Backend(DjangoFilterBackend):
+                def get_filter_class(self):
+                    pass
+
+        message = str(recorded.pop().message)
+        self.assertEqual(message, expected)
+        self.assertEqual(len(recorded), 0)
+
+    def test_default_filter_set(self):
+        expected = "`Backend.default_filter_set` attribute should be renamed `filterset_base`. " \
+                   "See: https://django-filter.readthedocs.io/en/master/guide/migration.html"
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter('always')
+
+            class Backend(DjangoFilterBackend):
+                default_filter_set = None
+
+        message = str(recorded.pop().message)
+        self.assertEqual(message, expected)
+        self.assertEqual(len(recorded), 0)

--- a/tests/rest_framework/test_integration.py
+++ b/tests/rest_framework/test_integration.py
@@ -32,7 +32,7 @@ class FilterableItemSerializer(serializers.ModelSerializer):
 class FilterFieldsRootView(generics.ListCreateAPIView):
     queryset = FilterableItem.objects.all()
     serializer_class = FilterableItemSerializer
-    filter_fields = ['decimal', 'date']
+    filterset_fields = ['decimal', 'date']
     filter_backends = (DjangoFilterBackend,)
 
 
@@ -50,7 +50,7 @@ class SeveralFieldsFilter(FilterSet):
 class FilterClassRootView(generics.ListCreateAPIView):
     queryset = FilterableItem.objects.all()
     serializer_class = FilterableItemSerializer
-    filter_class = SeveralFieldsFilter
+    filterset_class = SeveralFieldsFilter
     filter_backends = (DjangoFilterBackend,)
 
 
@@ -66,14 +66,14 @@ class MisconfiguredFilter(FilterSet):
 class IncorrectlyConfiguredRootView(generics.ListCreateAPIView):
     queryset = FilterableItem.objects.all()
     serializer_class = FilterableItemSerializer
-    filter_class = MisconfiguredFilter
+    filterset_class = MisconfiguredFilter
     filter_backends = (DjangoFilterBackend,)
 
 
 class FilterClassDetailView(generics.RetrieveAPIView):
     queryset = FilterableItem.objects.all()
     serializer_class = FilterableItemSerializer
-    filter_class = SeveralFieldsFilter
+    filterset_class = SeveralFieldsFilter
     filter_backends = (DjangoFilterBackend,)
 
 
@@ -89,7 +89,7 @@ class BaseFilterableItemFilter(FilterSet):
 class BaseFilterableItemFilterRootView(generics.ListCreateAPIView):
     queryset = FilterableItem.objects.all()
     serializer_class = FilterableItemSerializer
-    filter_class = BaseFilterableItemFilter
+    filterset_class = BaseFilterableItemFilter
     filter_backends = (DjangoFilterBackend,)
 
 
@@ -97,13 +97,13 @@ class BaseFilterableItemFilterRootView(generics.ListCreateAPIView):
 class FilterFieldsQuerysetView(generics.ListCreateAPIView):
     queryset = FilterableItem.objects.all()
     serializer_class = FilterableItemSerializer
-    filter_fields = ['decimal', 'date']
+    filterset_fields = ['decimal', 'date']
     filter_backends = (DjangoFilterBackend,)
 
 
 class GetQuerysetView(generics.ListCreateAPIView):
     serializer_class = FilterableItemSerializer
-    filter_class = SeveralFieldsFilter
+    filterset_class = SeveralFieldsFilter
     filter_backends = (DjangoFilterBackend,)
 
     def get_queryset(self):
@@ -198,7 +198,7 @@ class IntegrationTestFiltering(CommonFilteringTestCase):
 
     def test_get_filtered_class_root_view(self):
         """
-        GET requests to filtered ListCreateAPIView that have a filter_class set
+        GET requests to filtered ListCreateAPIView that have a filterset_class set
         should return filtered results.
         """
         view = FilterClassRootView.as_view()
@@ -257,7 +257,7 @@ class IntegrationTestFiltering(CommonFilteringTestCase):
 
     def test_base_model_filter(self):
         """
-        The `get_filter_class` model checks should allow base model filters.
+        The `get_filterset_class` model checks should allow base model filters.
         """
         view = BaseFilterableItemFilterRootView.as_view()
 
@@ -330,8 +330,8 @@ class IntegrationTestDetailFiltering(CommonFilteringTestCase):
 
     def test_get_filtered_detail_view(self):
         """
-        GET requests to filtered RetrieveAPIView that have a filter_class set
-        should return filtered results.
+        GET requests to filtered RetrieveAPIView that have a filterset_class
+        set should return filtered results.
         """
         item = self.objects.all()[0]
         data = self._serialize_object(item)
@@ -400,7 +400,7 @@ class DjangoFilterOrderingTests(TestCase):
             serializer_class = DjangoFilterOrderingSerializer
             queryset = DjangoFilterOrderingModel.objects.all()
             filter_backends = (DjangoFilterBackend,)
-            filter_fields = ['text']
+            filterset_fields = ['text']
             ordering = ('-date',)
 
         view = DjangoFilterOrderingView.as_view()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,7 @@ from django.utils.timezone import get_default_timezone
 from django_filters import FilterSet
 from django_filters.exceptions import FieldLookupError
 from django_filters.utils import (
+    MigrationNotice,
     get_field_parts,
     get_model_field,
     handle_timezone,
@@ -29,6 +30,15 @@ from .models import (
     NetworkSetting,
     User
 )
+
+
+class MigrationNoticeTests(TestCase):
+
+    def test_message(self):
+        self.assertEqual(
+            str(MigrationNotice('Message.')),
+            'Message. See: https://django-filter.readthedocs.io/en/master/guide/migration.html'
+        )
 
 
 class GetFieldPartsTests(TestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -58,7 +58,7 @@ class GenericClassBasedViewTests(GenericViewTestCase):
     def test_view_with_model_and_fields_no_filterset(self):
         factory = RequestFactory()
         request = factory.get(self.base_url + '?price=1.0')
-        view = FilterView.as_view(model=Book, filter_fields=['price'])
+        view = FilterView.as_view(model=Book, filterset_fields=['price'])
 
         # filtering only by price
         response = view(request)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
@@ -107,6 +109,19 @@ class GenericClassBasedViewTests(GenericViewTestCase):
         view = FilterView.as_view(filterset_class=MyFilterSet)
         with self.assertRaises(ImproperlyConfigured):
             view(request)
+
+    def test_filter_fields_removed(self):
+        expected = "`View.filter_fields` attribute should be renamed `filterset_fields`. " \
+                   "See: https://django-filter.readthedocs.io/en/master/guide/migration.html"
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter('always')
+
+            class View(FilterView):
+                filter_fields = None
+
+        message = str(recorded.pop().message)
+        self.assertEqual(message, expected)
+        self.assertEqual(len(recorded), 0)
 
 
 class GenericFunctionalViewTests(GenericViewTestCase):


### PR DESCRIPTION
Separating out the attribute renaming from #865, since getting the deprecations to work correctly required a bit of work. This required some utility code:

- Use the `RenameMethodsBase` metaclass, from `django.utils.deprecation`
- Add `RenameAttributesBase` metaclass (based on `RenameMethodsBase`)
- Add `MigrationNotice` exception, which inherits from `DeprecationWarning`. This integrates with the above metaclass designs, and allows us to use migration exceptions instead of standard assertions.

Here are the various attribute renames... thoughts?

- DRF `ViewSet.filter_class` => `filterset_class`
- DRF `ViewSet.filter_fields` => `filterset_fields`
- `DjangoFilterBackend.default_filter_set` => `filterset_base`
- `DjangoFilterBackend.get_filter_class()` => `get_filterset_class()`
- `FilterMixin.filter_fields` => `filterset_fields`

Submitting the changes first without the updated tests, to help demonstrate that the metaclasses work.