### PR TITLE
Support for PostgreSQL to_tsvector function with multiple fields

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 from datetime import timedelta
 
 from django import forms
+from django.contrib.postgres.search import SearchVector
 from django.db.models import Q
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.sql.constants import QUERY_TERMS
@@ -53,6 +54,7 @@ __all__ = [
     'NumericRangeFilter',
     'OrderingFilter',
     'RangeFilter',
+    'SearchVectorFilter',
     'TimeFilter',
     'TimeRangeFilter',
     'TypedChoiceFilter',
@@ -482,6 +484,18 @@ class DateTimeFromToRangeFilter(RangeFilter):
 
 class TimeRangeFilter(RangeFilter):
     field_class = TimeRangeField
+
+
+class SearchVectorFilter(CharFilter):
+
+    def __init__(self, field_name=None, lookup_expr='exact', *, search_fields, **kwargs):
+        super().__init__(field_name, lookup_expr, **kwargs)
+        self.search_fields = search_fields
+
+    def filter(self, qs, value):
+        search_vectors = SearchVector(*self.search_fields)
+        query = Q(**{'%s__%s' % ('search_vector', self.lookup_expr): value})
+        return qs.annotate(search_vector=search_vectors).filter(query)
 
 
 class AllValuesFilter(ChoiceFilter):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -49,7 +49,7 @@ from django_filters.filters import (
     TypedMultipleChoiceFilter,
     UUIDFilter
 )
-from .models import Book, User
+from models import Book, User
 
 
 class ModuleImportTests(TestCase):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from datetime import date, datetime, time, timedelta
 
 from django import forms
+from django.contrib.postgres.search import SearchVector
 from django.test import TestCase, override_settings
 from django.utils import translation
 from django.utils.translation import ugettext as _
@@ -42,12 +43,13 @@ from django_filters.filters import (
     NumericRangeFilter,
     OrderingFilter,
     RangeFilter,
+    SearchVectorFilter,
     TimeFilter,
     TimeRangeFilter,
     TypedMultipleChoiceFilter,
     UUIDFilter
 )
-from tests.models import Book, User
+from .models import Book, User
 
 
 class ModuleImportTests(TestCase):
@@ -1136,6 +1138,23 @@ class DateTimeFromToRangeFilterTests(TestCase):
         f.filter(qs, value)
         qs.filter.assert_called_once_with(
             None__range=(datetime(2015, 4, 7, 8, 30), datetime(2015, 9, 6, 11, 45)))
+
+
+class SearchVectorFilterTest(TestCase):
+
+    def test_default_field(self):
+        f = SearchVectorFilter(search_fields=['one', 'other'])
+        field = f.field
+        self.assertIsInstance(field, forms.CharField)
+
+    def test_filter(self):
+        search_fields = ['one', 'other']
+        qs = mock.Mock(spec=['annotate', 'filter'])
+        f = SearchVectorFilter(search_fields=search_fields)
+        result = f.filter(qs, 'value')
+        qs.annotate.assert_called_once_with(search_vector=SearchVector(*search_fields))
+        qs.annotate().filter.assert_called_once_with(search_vector__exact='value')
+        self.assertNotEqual(qs, result)
 
 
 class TimeRangeFilterTests(TestCase):


### PR DESCRIPTION
This is a second try (previous #884) to add SearchVectorFilter to support to_tsvector function for full text search.

Case of use:

**models.py**
```python

class Person(models.Model):

    name = models.CharField(max_length=128, verbose_name='person name')
    surname = models.CharField(max_length=128, verbose_name='person surname')
```
**views.py**

```python
class PersonFilter(filters.FilterSet):
    person = SearchVectorFilter(field_name='name', search_fields=['name', 'surname'], lookup_expr='icontains')
```

##test.py**

```python
u1 = User.objects.create(username='SpaceKitty99', first_name='Joe', last_name='Cox')
u2 = User.objects.create(username='Darth_vader', first_name='John', last_name='Doe')
u3 = User.objects.create(username='Kobza', first_name='Taras', last_name='Shevchenko')

class F(FilterSet):

    person = SearchVectorFilter(field_name='first_name',
                                search_fields=['first_name', 'last_name'],
                                lookup_expr='icontains')

    class Meta:
        model = User
        fields = ['person']

qs = User.objects.all()

f = F({'person': 'John'}, queryset=qs)
f.qs == [u2.pk] #only user with first_name=John match

f = F({'person': 'oE'}, queryset=qs)
f.qs == [u1.pk, u2.pk]  #now user with first_name=Joe and last_name=Doe match
```