### PR TITLE
Add 'help_text' django model field option support

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -358,6 +358,8 @@ class BaseFilterSet(object):
         data = try_dbfield(DEFAULTS.get, field.__class__) or {}
         filter_class = data.get('filter_class')
         params = data.get('extra', lambda field: {})(field)
+        if 'help_text' not in params and field.help_text:
+            params['help_text'] = field.help_text
 
         # if there is no filter class, exit early
         if not filter_class:
@@ -365,13 +367,19 @@ class BaseFilterSet(object):
 
         # perform lookup specific checks
         if lookup_type == 'exact' and field.choices:
-            return ChoiceFilter, {'choices': field.choices}
+            params = {'choices': field.choices}
+            if 'help_text' not in params and field.help_text:
+                params['help_text'] = field.help_text
+            return ChoiceFilter, params
 
         if lookup_type == 'isnull':
             data = try_dbfield(DEFAULTS.get, models.BooleanField)
 
             filter_class = data.get('filter_class')
             params = data.get('extra', lambda field: {})(field)
+            if 'help_text' not in params and field.help_text:
+                params['help_text'] = field.help_text
+
             return filter_class, params
 
         if lookup_type == 'in':

--- a/tests/models.py
+++ b/tests/models.py
@@ -89,7 +89,7 @@ class Comment(models.Model):
 class Article(models.Model):
     name = models.CharField(verbose_name='title', max_length=200, blank=True)
     published = models.DateTimeField()
-    author = models.ForeignKey(User, null=True, on_delete=models.CASCADE)
+    author = models.ForeignKey(User, null=True, on_delete=models.CASCADE, help_text='Article model author field help text')
 
     def __str__(self):
         if self.author_id:

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -208,7 +208,7 @@ class FilterSetFilterForLookupTests(TestCase):
         f = Article._meta.get_field('author')
         result, params = FilterSet.filter_for_lookup(f, 'isnull')
         self.assertEqual(result, BooleanFilter)
-        self.assertDictEqual(params, {})
+        self.assertDictEqual(params, {'help_text': 'Article model author field help text'})
 
     def test_filter_for_IN_lookup(self):
         f = Article._meta.get_field('author')


### PR DESCRIPTION
It useful, for example, in coreapi documentation of DRF