### PR TITLE
An empty `data` can result in an empty queryset (even if data exists)

### DIFF
--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1160,6 +1160,7 @@ class FilterMethodTests(TestCase):
                 return queryset.filter(**{name: value})
 
         self.assertEqual(list(F().qs), list(User.objects.all()))
+        self.assertEqual(list(F(queryset=User.objects.all())), list(User.objects.all()))
         self.assertEqual(list(F({'username': 'alex'}).qs),
                          [User.objects.get(username='alex')])
         self.assertEqual(list(F({'username': 'jose'}).qs),


### PR DESCRIPTION
The attached shows a behavior that strikes me as counter-intuitive but may be intentional.  

It's my assumption that a FilterSet that receives no `data` should not apply any filters *whether or not a queryset is provided*.

 - In the previous assertion (of the same test), this is verified for `data=None` and `queryset=None`.
 - I've added a version of the test where `queryset` is not None (i.e. the caller starts by providing `all()`).

The test now fails because `F(data=None, queryset=User.objects.all())` actually returns `User.objects.none()`.  This happens because:

 - `CharFilter` depends on Django's `forms.CharField`
 - `forms.CharField` defaults to `''` for the value `None` ([as of 1.11](https://docs.djangoproject.com/en/2.0/ref/forms/fields/#django.forms.CharField.empty_value), this value is configurable, but it only made explicit the old hard-coded behavior)
 - the `qs` property on `BaseFilterSet` only ignores the filter [if the cleaned value `is None`](https://github.com/carltongibson/django-filter/blob/1.1.0/django_filters/filterset.py#L219)
