### PR TITLE
Аdd context to filterset and backend

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -138,7 +138,8 @@ FILTER_FOR_DBFIELD_DEFAULTS = {
 class BaseFilterSet(object):
     FILTER_DEFAULTS = FILTER_FOR_DBFIELD_DEFAULTS
 
-    def __init__(self, data=None, queryset=None, *, request=None, prefix=None):
+    def __init__(self, data=None, queryset=None, *, request=None, prefix=None,
+                 context={}):
         if queryset is None:
             queryset = self._meta.model._default_manager.all()
         model = queryset.model
@@ -148,6 +149,7 @@ class BaseFilterSet(object):
         self.queryset = queryset
         self.request = request
         self.form_prefix = prefix
+        self.context = context
 
         self.filters = copy.deepcopy(self.base_filters)
 

--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -46,11 +46,12 @@ class DjangoFilterBackend(object):
 
         return None
 
-    def filter_queryset(self, request, queryset, view):
+    def filter_queryset(self, request, queryset, view, context={}):
         filter_class = self.get_filter_class(view, queryset)
 
         if filter_class:
-            filterset = filter_class(request.query_params, queryset=queryset, request=request)
+            filterset = filter_class(request.query_params, queryset=queryset, request=request,
+                                     context=context)
             if not filterset.is_valid() and self.raise_exception:
                 raise utils.translate_validation(filterset.errors)
             return filterset.qs


### PR DESCRIPTION
Add `context` property to `BaseFilterSet`.
Obtain context property in `DjangoFilterBackend.filter_queryset method`.

`context` property is supposed to be used to provide additional context data to the filterset.

Following #870