### PR TITLE
improved get_schema_fields in DjangoFilterBackend

### DIFF
--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -3,7 +3,7 @@ import warnings
 from django.template import loader
 
 from . import filters, filterset
-from .. import compat, utils, fields
+from .. import compat, fields, utils
 
 
 class DjangoFilterBackend(object):

--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -3,7 +3,7 @@ import warnings
 from django.template import loader
 
 from . import filters, filterset
-from .. import compat, utils
+from .. import compat, utils, fields
 
 
 class DjangoFilterBackend(object):
@@ -79,12 +79,8 @@ class DjangoFilterBackend(object):
         )
 
     def get_schema_fields(self, view):
-        # This is not compatible with widgets where the query param differs from the
-        # filter's attribute name. Notably, this includes `MultiWidget`, where query
-        # params will be of the format `<name>_0`, `<name>_1`, etc...
         assert compat.coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
         assert compat.coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
-
         try:
             queryset = view.get_queryset()
         except Exception:
@@ -94,12 +90,26 @@ class DjangoFilterBackend(object):
             )
 
         filter_class = self.get_filter_class(view, queryset)
+        schema_fields = []
+        if filter_class:
+            for filter_name, filter in filter_class.base_filters.items():
+                schema_fields += self.filter_to_coreapi_fields(filter_name, filter)
+        return schema_fields
 
-        return [] if not filter_class else [
-            compat.coreapi.Field(
-                name=field_name,
-                required=field.extra['required'],
-                location='query',
-                schema=self.get_coreschema_field(field)
-            ) for field_name, field in filter_class.base_filters.items()
-        ]
+    def filter_to_coreapi_fields(self, filter_name, filter):
+        coreapi_fields = []
+        if issubclass(filter.field_class, fields.RangeField) or \
+           filter.lookup_expr is None or \
+           isinstance(filter.lookup_expr, (list, tuple)):
+            field_names = [filter_name + '_0',
+                           filter_name + '_1']
+        else:
+            field_names = [filter_name]
+
+        for field_name in field_names:
+            coreapi_fields.append(
+                compat.coreapi.Field(name=field_name,
+                                     required=filter.extra['required'],
+                                     location='query',
+                                     schema=self.get_coreschema_field(filter)))
+        return coreapi_fields

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -206,6 +206,23 @@ class GetSchemaFieldsTests(TestCase):
         self.assertFalse(required[2])
         self.assertTrue(required[3])
 
+    def test_fields_complex(self):
+        class ComplexFieldsFilter(FilterSet):
+            decimal = filters.NumericRangeFilter()
+            text = filters.CharFilter(lookup_expr=None)
+            class Meta:
+                model = FilterableItem
+                fields = ['decimal']
+
+        class FilterClassWithComplexFieldsView(FilterClassRootView):
+            filter_class = ComplexFieldsFilter
+
+        backend = DjangoFilterBackend()
+        fields = backend.get_schema_fields(FilterClassWithComplexFieldsView())
+        fields = [f.name for f in fields]
+        self.assertEqual(fields, ['decimal_0', 'decimal_1', 'text_0', 'text_1'])
+
+
     def tests_field_with_request_callable(self):
         def qs(request):
             # users expect a valid request object to be provided which cannot


### PR DESCRIPTION
Hello everyone. 
I encountered problem with get_schema_fields that is not generating correct coreapi schema for complex fields like RangeField or CharField with lookup_expr=None or tuple/list (this fields are resulting to two url paramters : name_0, name_1). The problem is also described in comment for this method in current version here: https://github.com/dmippolitov/django-filter/blob/2b554a50d227999db9e537568af63c64a550f786/django_filters/rest_framework/backends.py#L82 
```
        # This is not compatible with widgets where the query param differs from the
        # filter's attribute name. Notably, this includes `MultiWidget`, where query
        # params will be of the format `<name>_0`, `<name>_1`, etc...
```
Made a little patch + tests for this place, so it will be possible to have correct schema in this cases.