### PR TITLE
Django 2.1 compatibility.

### DIFF
--- a/django_filters/compat.py
+++ b/django_filters/compat.py
@@ -1,5 +1,16 @@
 from django.conf import settings
 
+try:
+    from django.db.models.sql.constants import QUERY_TERMS
+except ImportError:
+    # Django 2.1+ does not have QUERY_TERMS anymore
+    QUERY_TERMS = {
+        'contains', 'day', 'endswith', 'exact', 'gt', 'gte', 'hour',
+        'icontains', 'iendswith', 'iexact', 'in', 'iregex', 'isnull',
+        'istartswith', 'lt', 'lte', 'minute', 'month', 'range', 'regex',
+        'search', 'second', 'startswith', 'week_day', 'year',
+    }
+
 # django-crispy-forms is optional
 try:
     import crispy_forms

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -4,12 +4,12 @@ from datetime import timedelta
 from django import forms
 from django.db.models import Q
 from django.db.models.constants import LOOKUP_SEP
-from django.db.models.sql.constants import QUERY_TERMS
 from django.forms.utils import pretty_name
 from django.utils.itercompat import is_iterable
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
 
+from .compat import QUERY_TERMS
 from .conf import settings
 from .constants import EMPTY_VALUES
 from .fields import (

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -747,6 +747,7 @@ class ModelChoiceFilterTests(TestCase):
 
     def test_default_field_with_queryset(self):
         qs = mock.NonCallableMock(spec=[])
+        qs.all = mock.Mock(return_value=qs)  # For django 2.1+
         f = ModelChoiceFilter(queryset=qs)
         field = f.field
         self.assertIsInstance(field, forms.ModelChoiceField)
@@ -755,6 +756,7 @@ class ModelChoiceFilterTests(TestCase):
     def test_callable_queryset(self):
         request = mock.NonCallableMock(spec=[])
         qs = mock.NonCallableMock(spec=[])
+        qs.all = mock.Mock(return_value=qs)  # For django 2.1+
 
         qs_callable = mock.Mock(return_value=qs)
 
@@ -768,6 +770,7 @@ class ModelChoiceFilterTests(TestCase):
     def test_get_queryset_override(self):
         request = mock.NonCallableMock(spec=[])
         qs = mock.NonCallableMock(spec=[])
+        qs.all = mock.Mock(return_value=qs)  # For django 2.1+
 
         class F(ModelChoiceFilter):
             get_queryset = mock.create_autospec(ModelChoiceFilter.get_queryset, return_value=qs)
@@ -798,6 +801,7 @@ class ModelMultipleChoiceFilterTests(TestCase):
 
     def test_default_field_with_queryset(self):
         qs = mock.NonCallableMock(spec=[])
+        qs.all = mock.Mock(return_value=qs)  # For django 2.1+
         f = ModelMultipleChoiceFilter(queryset=qs)
         field = f.field
         self.assertIsInstance(field, forms.ModelMultipleChoiceField)
@@ -821,6 +825,7 @@ class ModelMultipleChoiceFilterTests(TestCase):
     def test_callable_queryset(self):
         request = mock.NonCallableMock(spec=[])
         qs = mock.NonCallableMock(spec=[])
+        qs.all = mock.Mock(return_value=qs)  # For django 2.1+
 
         qs_callable = mock.Mock(return_value=qs)
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
        {py27,py34,py35,py36}-django111,
        {py34,py35,py36}-django20,
+       {py35,py36}-django21,
        {py35,py36}-latest,
        isort, warnings,
 
@@ -19,6 +20,7 @@ setenv =
 deps =
     django111: django>=1.11.0,<2.0
     django20: django>=2.0,<2.1
+    django21: django>=2.1a1
     djangorestframework>=3.7,<3.8
     latest: {[latest]deps}
     -rrequirements/test-ci.txt


### PR DESCRIPTION
Django 2.1 introduces custom lookups. In doing so, it gets rid of the hardcoded list of query terms. This PR makes sure `django-filter` keeps working on Django 2.1.

It does not introduce support for custom lookups, though, as this seems to be a bigger task; the lookups are registered against model fields, not form fields, so it's hard to pull them out.