### PR TITLE
Keep coverage reports files off version control.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docs/_build
 .python-version
 .tox
 .coverage
+.coverage.*


### PR DESCRIPTION
Running tox created a load of coverage reports in the form `.coverage.hostname.number.number`.

This PR will tell git to ignore any dot-coverage-dot file.