### PR TITLE
Split REST FilterSet into mixin and final class

### DIFF
--- a/django_filters/rest_framework/filterset.py
+++ b/django_filters/rest_framework/filterset.py
@@ -15,7 +15,7 @@ FILTER_FOR_DBFIELD_DEFAULTS.update({
 })
 
 
-class FilterSet(filterset.FilterSet):
+class FilterSetMixin(object):
     FILTER_DEFAULTS = FILTER_FOR_DBFIELD_DEFAULTS
 
     @property
@@ -37,3 +37,7 @@ class FilterSet(filterset.FilterSet):
             form.helper = helper
 
         return form
+    
+    
+class FilterSet(FilterSetMixin, filterset.FilterSet):
+    pass


### PR DESCRIPTION
This will help when users just want to use REST FilterSet behavior without have to inherit from `rest_framework.FilterSet`.
This absolutely doesn't change the code's behavior. Just helps to play with multiple inheritance.