### PR TITLE
Prevent having queryset=None

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -178,7 +178,9 @@ class BaseFilterSet(object):
         applied to the queryset before it is cached.
         """
         for name, value in self.form.cleaned_data.items():
-            queryset = self.filters[name].filter(queryset, value)
+            result = self.filters[name].filter(queryset, value)
+            if result is not None:
+                queryset = result
         return queryset
 
     @property


### PR DESCRIPTION
This will forgive user errors where their filter() implementation
returns None, ie. in the case of a choice filter where they don't handle
the case where no choice was selected.

Otherwise, we could raise a clear Exception, because currently in this case users would get "NoneType has no attribute filter" which might not help the user understand how they should fix their issue. 

TYIA for comments