### PR TITLE
Improve exception message for invalid filter result

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -179,6 +179,9 @@ class BaseFilterSet(object):
         """
         for name, value in self.form.cleaned_data.items():
             queryset = self.filters[name].filter(queryset, value)
+            assert isinstance(queryset, models.QuerySet), \
+                "Expected '%s.%s' to return a QuerySet, but got a %s instead." \
+                % (type(self).__name__, name, type(queryset).__name__)
         return queryset
 
     @property

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -42,6 +42,7 @@ from .models import (
     SpacewalkRecord,
     User
 )
+from .utils import MockQuerySet
 
 
 class CharFilterTests(TestCase):
@@ -1869,10 +1870,8 @@ class MiscFilterSetTests(TestCase):
                 model = User
                 fields = ['account']
 
-        qs = mock.NonCallableMagicMock()
-        f = F({'account': 'jdoe'}, queryset=qs)
-        result = f.qs
-        self.assertNotEqual(qs, result)
+        qs = MockQuerySet()
+        F({'account': 'jdoe'}, queryset=qs).qs
         qs.all.return_value.filter.assert_called_with(username__exact='jdoe')
 
     def test_filtering_without_meta(self):

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -40,6 +40,7 @@ from .models import (
     UUIDTestModel,
     Worker
 )
+from .utils import MockQuerySet
 
 
 def checkItemsEqual(L1, L2):
@@ -641,7 +642,7 @@ class FilterSetQuerysetTests(TestCase):
             fields = ['username', 'invalid']
 
     def test_filter_queryset_called_once(self):
-        m = mock.Mock()
+        m = MockQuerySet()
         f = self.F({'username': 'bob'}, queryset=m)
 
         with mock.patch.object(f, 'filter_queryset',
@@ -674,7 +675,7 @@ class FilterSetQuerysetTests(TestCase):
         self.assertIs(f.form, f.form)
 
     def test_qs_triggers_form_validation(self):
-        m = mock.Mock()
+        m = MockQuerySet()
         f = self.F({'username': 'bob'}, queryset=m)
 
         with mock.patch.object(f.form, 'full_clean',
@@ -684,7 +685,7 @@ class FilterSetQuerysetTests(TestCase):
             fn.assert_called()
 
     def test_filters_must_return_queryset(self):
-        m = mock.Mock()
+        m = MockQuerySet()
         f = self.F({'invalid': 'result'}, queryset=m)
 
         msg = "Expected 'F.invalid' to return a QuerySet, but got a NoneType instead."
@@ -769,7 +770,7 @@ class FilterMethodTests(TestCase):
     def test_method_self_is_parent(self):
         # Ensure the method isn't 're-parented' on the `FilterMethod` helper class.
         # Filter methods should have access to the filterset's properties.
-        request = mock.Mock()
+        request = MockQuerySet()
 
         class F(FilterSet):
             f = CharFilter(method='filter_f')
@@ -781,6 +782,7 @@ class FilterMethodTests(TestCase):
             def filter_f(inner_self, qs, name, value):
                 self.assertIsInstance(inner_self, F)
                 self.assertIs(inner_self.request, request)
+                return qs
 
         F({'f': 'foo'}, request=request, queryset=User.objects.all()).qs
 

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -634,9 +634,11 @@ class FilterSetInstantiationTests(TestCase):
 class FilterSetQuerysetTests(TestCase):
 
     class F(FilterSet):
+        invalid = CharFilter(method=lambda *args: None)
+
         class Meta:
             model = User
-            fields = ['username']
+            fields = ['username', 'invalid']
 
     def test_filter_queryset_called_once(self):
         m = mock.Mock()
@@ -680,6 +682,14 @@ class FilterSetQuerysetTests(TestCase):
             fn.assert_not_called()
             f.qs
             fn.assert_called()
+
+    def test_filters_must_return_queryset(self):
+        m = mock.Mock()
+        f = self.F({'invalid': 'result'}, queryset=m)
+
+        msg = "Expected 'F.invalid' to return a QuerySet, but got a NoneType instead."
+        with self.assertRaisesMessage(AssertionError, msg):
+            f.qs
 
 
 # test filter.method here, as it depends on its parent FilterSet

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,15 @@
+from unittest import mock
+
+from django.db import models
+
+
+class MockQuerySet:
+    """
+    Generate a mock that is suitably similar to a QuerySet
+    """
+
+    def __new__(self):
+        m = mock.Mock(spec_set=models.QuerySet())
+        m.filter.return_value = m
+        m.all.return_value = m
+        return m


### PR DESCRIPTION
As mentioned in #938, the exception for an invalid filter result isn't that helpful. e.g., if a custom filter method unintentionally returns a `None` value, you end up with `NoneType has no attribute filter`, which lacks any context about the offending `FilterSet` and `Filter` instance.

@jpic - would this exception have been helpful the first time around? e.g.
```
Expected 'F.invalid' to return a QuerySet, but got a NoneType instead.
```