### PR TITLE
Update docs

### DIFF
--- a/docs/guide/rest_framework.txt
+++ b/docs/guide/rest_framework.txt
@@ -30,7 +30,7 @@ Your view class will also need to add ``DjangoFilterBackend`` to the ``filter_ba
         queryset = Product.objects.all()
         serializer_class = ProductSerializer
         filter_backends = (filters.DjangoFilterBackend,)
-        filter_fields = ('category', 'in_stock')
+        filterset_fields = ('category', 'in_stock')
 
 If you want to use the django-filter backend by default, add it to the ``DEFAULT_FILTER_BACKENDS`` setting.
 
@@ -51,10 +51,10 @@ If you want to use the django-filter backend by default, add it to the ``DEFAULT
     }
 
 
-Adding a FilterSet with ``filter_class``
-----------------------------------------
+Adding a FilterSet with ``filterset_class``
+-------------------------------------------
 
-To enable filtering with a ``FilterSet``, add it to the ``filter_class`` parameter on your view class.
+To enable filtering with a ``FilterSet``, add it to the ``filterset_class`` parameter on your view class.
 
 .. code-block:: python
 
@@ -76,13 +76,13 @@ To enable filtering with a ``FilterSet``, add it to the ``filter_class`` paramet
         queryset = Product.objects.all()
         serializer_class = ProductSerializer
         filter_backends = (filters.DjangoFilterBackend,)
-        filter_class = ProductFilter
+        filterset_class = ProductFilter
 
 
-Using the ``filter_fields`` shortcut
-------------------------------------
+Using the ``filterset_fields`` shortcut
+---------------------------------------
 
-You may bypass creating a ``FilterSet`` by instead adding ``filter_fields`` to your view class. This is equivalent to creating a FilterSet with just :ref:`Meta.fields <fields>`.
+You may bypass creating a ``FilterSet`` by instead adding ``filterset_fields`` to your view class. This is equivalent to creating a FilterSet with just :ref:`Meta.fields <fields>`.
 
 
 .. code-block:: python
@@ -95,7 +95,7 @@ You may bypass creating a ``FilterSet`` by instead adding ``filter_fields`` to y
     class ProductList(generics.ListAPIView):
         queryset = Product.objects.all()
         filter_backends = (filters.DjangoFilterBackend,)
-        filter_fields = ('category', 'in_stock')
+        filterset_fields = ('category', 'in_stock')
 
 
     # Equivalent FilterSet:
@@ -105,7 +105,7 @@ You may bypass creating a ``FilterSet`` by instead adding ``filter_fields`` to y
             fields = ('category', 'in_stock')
 
 
-Note that using ``filter_fields`` and ``filter_class`` together is not
+Note that using ``filterset_fields`` and ``filterset_class`` together is not
 supported.
 
 
@@ -141,7 +141,7 @@ You can override these methods on a case-by-case basis for each view, creating u
 
     class BookViewSet(viewsets.ModelViewSet):
         filter_backends = [MyFilterBackend]
-        filter_class = BookFilter
+        filterset_class = BookFilter
 
         def get_filteset_kwargs(self):
             return {

--- a/docs/guide/rest_framework.txt
+++ b/docs/guide/rest_framework.txt
@@ -228,5 +228,4 @@ The following features are specific to the rest framework FilterSet:
 
 - ``BooleanFilter``'s use the API-friendly ``BooleanWidget``, which accepts lowercase ``true``/``false``.
 - Filter generation uses ``IsoDateTimeFilter`` for datetime model fields.
-- Raised ``ValidationError``'s are reraised as their DRF equivalent. This behavior is useful when setting FilterSet
-  strictness to ``STRICTNESS.RAISE_VALIDATION_ERROR``.
+- Raised ``ValidationError``'s are reraised as their DRF equivalent.

--- a/docs/guide/tips.txt
+++ b/docs/guide/tips.txt
@@ -10,11 +10,11 @@ recommended that you read this as it provides a more complete understanding of
 how filters work.
 
 
-Filter ``name`` and ``lookup_expr`` not configured
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Filter ``field_name`` and ``lookup_expr`` not configured
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-While ``name`` and ``lookup_expr`` are optional, it is recommended that you specify
-them. By default, if ``name`` is not specified, the filter's name on the
+While ``field_name`` and ``lookup_expr`` are optional, it is recommended that you specify
+them. By default, if ``field_name`` is not specified, the filter's name on the
 filterset class will be used. Additionally, ``lookup_expr`` defaults to
 ``exact``. The following is an example of a misconfigured price filter:
 
@@ -36,7 +36,7 @@ would be:
 .. code-block:: python
 
     class ProductFilter(django_filters.FilterSet):
-        price__gt = django_filters.NumberFilter(name='price', lookup_expr='gt')
+        price__gt = django_filters.NumberFilter(field_name='price', lookup_expr='gt')
 
 
 Missing ``lookup_expr`` for text search filters
@@ -68,7 +68,7 @@ for uncategorized products. The following is an incorrectly configured
 .. code-block:: python
 
     class ProductFilter(django_filters.FilterSet):
-        uncategorized = django_filters.NumberFilter(name='category', lookup_expr='isnull')
+        uncategorized = django_filters.NumberFilter(field_name='category', lookup_expr='isnull')
 
 So what's the issue? While the underlying column type for ``category`` is an
 integer, ``isnull`` lookups expect a boolean value. A ``NumberFilter`` however
@@ -84,8 +84,8 @@ uncategorized products and products for a set of categories:
         pass
 
     class ProductFilter(django_filters.FilterSet):
-        categories = NumberInFilter(name='category', lookup_expr='in')
-        uncategorized = django_filters.BooleanFilter(name='category', lookup_expr='isnull')
+        categories = NumberInFilter(field_name='category', lookup_expr='in')
+        uncategorized = django_filters.BooleanFilter(field_name='category', lookup_expr='isnull')
 
 More info on constructing ``in`` and ``range`` csv :ref:`filters <base-in-filter>`.
 
@@ -112,7 +112,7 @@ the FilterSet's automatic filter generation. To do this manually, simply add:
 .. code-block:: python
 
     class ProductFilter(django_filters.FilterSet):
-        uncategorized = django_filters.BooleanFilter(name='category', lookup_expr='isnull')
+        uncategorized = django_filters.BooleanFilter(field_name='category', lookup_expr='isnull')
 
 .. note::
 
@@ -124,7 +124,7 @@ You may also reverse the logic with the ``exclude`` parameter.
 .. code-block:: python
 
     class ProductFilter(django_filters.FilterSet):
-        has_category = django_filters.BooleanFilter(name='category', lookup_expr='isnull', exclude=True)
+        has_category = django_filters.BooleanFilter(field_name='category', lookup_expr='isnull', exclude=True)
 
 Solution 2: Using ``ChoiceFilter``'s null choice
 """"""""""""""""""""""""""""""""""""""""""""""""
@@ -137,7 +137,7 @@ the ``null_label`` parameter. More details in the ``ChoiceFilter`` reference
 
     class ProductFilter(django_filters.FilterSet):
         category = django_filters.ModelChoiceFilter(
-            name='category', lookup_expr='isnull',
+            field_name='category', lookup_expr='isnull',
             null_label='Uncategorized',
             queryset=Category.objects.all(),
         )
@@ -203,7 +203,7 @@ behavior as an ``isnull`` filter.
 
 
     class MyFilterSet(filters.FilterSet):
-        myfield__isempty = EmptyStringFilter(name='myfield')
+        myfield__isempty = EmptyStringFilter(field_name='myfield')
 
         class Meta:
             model = MyModel

--- a/docs/guide/usage.txt
+++ b/docs/guide/usage.txt
@@ -311,7 +311,7 @@ You must provide either a ``model`` or ``filterset_class`` argument, similar to
         url(r'^list/$', FilterView.as_view(model=Product)),
     ]
 
-If you provide a ``model`` optionally you can set ``filter_fields`` to specify a list or a tuple of
+If you provide a ``model`` optionally you can set ``filterset_fields`` to specify a list or a tuple of
 the fields that you want to include for the automatic construction of the filterset class.
 
 You must provide a template at ``<app>/<model>_filter.html`` which gets the

--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -19,6 +19,21 @@ provided it automatically becomes the filter's name on the ``FilterSet``.
 You can traverse "relationship paths" using Django's ``__`` syntax to filter
 fields on a related model. eg, ``manufacturer__name``.
 
+``lookup_expr``
+~~~~~~~~~~~~~~~
+
+The lookup expression that should be performed using `Django's ORM`_.
+
+.. _`Django's ORM`: https://docs.djangoproject.com/en/dev/ref/models/querysets/#field-lookups
+
+.. _keyword-only-arguments:
+
+Keyword-only Arguments:
+-----------------------
+
+The following are optional arguments that can be used to modify the behavior of
+all filters.
+
 ``label``
 ~~~~~~~~~
 
@@ -91,46 +106,6 @@ so raw value transformation and empty value checking should be unnecessary.
         class Meta:
             model = Book
             fields = ['published']
-
-``lookup_expr``
-~~~~~~~~~~~~~~~
-
-The lookup expression that should be performed using `Django's ORM`_.
-
-.. _`Django's ORM`: https://docs.djangoproject.com/en/dev/ref/models/querysets/#field-lookups
-
-A ``list`` or ``tuple`` of lookup types is also accepted, allowing the user to
-select the lookup from a dropdown. The list of lookup types are filtered against
-``filters.LOOKUP_TYPES``. If `lookup_expr=None` is passed, then a list of all lookup
-types will be generated::
-
-    class ProductFilter(django_filters.FilterSet):
-        name = django_filters.CharFilter(lookup_expr=['exact', 'iexact'])
-
-You can enable custom lookups by adding them to ``LOOKUP_TYPES``::
-
-    from django_filters import filters
-
-    filters.LOOKUP_TYPES = ['gt', 'gte', 'lt', 'lte', 'custom_lookup_type']
-
-Additionally, you can provide human-friendly help text by overriding ``LOOKUP_TYPES``::
-
-    # filters.py
-    from django_filters import filters
-
-    filters.LOOKUP_TYPES = [
-        ('', '---------'),
-        ('exact', 'Is equal to'),
-        ('not_exact', 'Is not equal to'),
-        ('lt', 'Lesser than'),
-        ('gt', 'Greater than'),
-        ('gte', 'Greater than or equal to'),
-        ('lte', 'Lesser than or equal to'),
-        ('startswith', 'Starts with'),
-        ('endswith', 'Ends with'),
-        ('contains', 'Contains'),
-        ('not_contains', 'Does not contain'),
-    ]
 
 
 ``distinct``

--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -46,7 +46,7 @@ all filters.
 
 The label as it will apear in the HTML, analogous to a form field's label
 argument. If a label is not provided, a verbose label will be generated based
-on the field ``name`` and the parts of the ``lookup_expr``
+on the field ``field_name`` and the parts of the ``lookup_expr``
 (see: :ref:`verbose-lookups-setting`).
 
 .. _filter-method:
@@ -66,7 +66,7 @@ transformation and empty value checking should be unnecessary.
 
     class F(FilterSet):
         """Filter for Books by if books are published or not"""
-        published = BooleanFilter(name='published_on', method='filter_published')
+        published = BooleanFilter(field_name='published_on', method='filter_published')
 
         def filter_published(self, queryset, name, value):
             # construct the full lookup expression.
@@ -88,7 +88,7 @@ transformation and empty value checking should be unnecessary.
 
     class F(FilterSet):
         """Filter for Books by if books are published or not"""
-        published = BooleanFilter(name='published_on', method=filter_not_empty)
+        published = BooleanFilter(field_name='published_on', method=filter_not_empty)
 
         class Meta:
             model = Book
@@ -373,7 +373,7 @@ To use a custom field name for the lookup, you can use ``to_field_name``::
 
     class FooFilter(BaseFilterSet):
         foo = django_filters.filters.ModelMultipleChoiceFilter(
-            name='attr__uuid',
+            field_name='attr__uuid',
             to_field_name='uuid',
             queryset=Foo.objects.all(),
         )
@@ -649,7 +649,7 @@ Example::
         pass
 
     class F(FilterSet):
-        id__in = NumberInFilter(name='id', lookup_expr='in')
+        id__in = NumberInFilter(field_name='id', lookup_expr='in')
 
         class Meta:
             model = User
@@ -676,7 +676,7 @@ Example::
         pass
 
     class F(FilterSet):
-        id__range = NumberRangeFilter(name='id', lookup_expr='range')
+        id__range = NumberRangeFilter(field_name='id', lookup_expr='range')
 
         class Meta:
             model = User
@@ -714,8 +714,8 @@ two additional arguments that are used to build the ordering choices.
 .. code-block:: python
 
     class UserFilter(FilterSet):
-        account = CharFilter(name='username')
-        status = NumberFilter(name='status')
+        account = CharFilter(field_name='username')
+        status = NumberFilter(field_name='status')
 
         o = OrderingFilter(
             # tuple-mapping retains order
@@ -752,8 +752,8 @@ want to disable descending sort options.
 .. code-block:: python
 
     class UserFilter(FilterSet):
-        account = CharFilter(name='username')
-        status = NumberFilter(name='status')
+        account = CharFilter(field_name='username')
+        status = NumberFilter(field_name='status')
 
         o = OrderingFilter(
             choices=(

--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -46,8 +46,8 @@ all filters.
 
 The label as it will apear in the HTML, analogous to a form field's label
 argument. If a label is not provided, a verbose label will be generated based
-on the field ``name`` and the parts of the ``lookup_expr``.
-(See: :ref:`verbose-lookups-setting`).
+on the field ``name`` and the parts of the ``lookup_expr``
+(see: :ref:`verbose-lookups-setting`).
 
 .. _filter-method:
 
@@ -56,12 +56,11 @@ on the field ``name`` and the parts of the ``lookup_expr``.
 
 An optional argument that tells the filter how to handle the queryset. It can
 accept either a callable or the name of a method on the ``FilterSet``. The
-method receives a ``QuerySet``, the name of the model field to filter on, and
-the value to filter with. It should return a ``Queryset`` that is filtered
-appropriately.
+callable receives a ``QuerySet``, the name of the model field to filter on, and
+the value to filter with. It should return a filtered ``Queryset``.
 
-The passed in value is validated and cleaned by the filter's ``field_class``,
-so raw value transformation and empty value checking should be unnecessary.
+Note that the value is validated by the ``Filter.field``, so raw value
+transformation and empty value checking should be unnecessary.
 
 .. code-block:: python
 
@@ -99,14 +98,15 @@ so raw value transformation and empty value checking should be unnecessary.
 ``distinct``
 ~~~~~~~~~~~~
 
-A boolean value that specifies whether the Filter will use distinct on the
-queryset. This option can be used to eliminate duplicate results when using filters that span related models. Defaults to ``False``.
+A boolean that specifies whether the Filter will use distinct on the queryset.
+This option can be used to eliminate duplicate results when using filters that
+span relationships. Defaults to ``False``.
 
 ``exclude``
 ~~~~~~~~~~~
 
-A boolean value that specifies whether the Filter should use ``filter`` or ``exclude`` on the queryset.
-Defaults to ``False``.
+A boolean that specifies whether the Filter should use ``filter`` or ``exclude``
+on the queryset. Defaults to ``False``.
 
 
 ``**kwargs``

--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -49,25 +49,6 @@ argument. If a label is not provided, a verbose label will be generated based
 on the field ``name`` and the parts of the ``lookup_expr``.
 (See: :ref:`verbose-lookups-setting`).
 
-``widget``
-~~~~~~~~~~
-
-The django.form Widget class which will represent the ``Filter``.  In addition
-to the widgets that are included with Django that you can use there are
-additional ones that django-filter provides which may be useful:
-
-    * :ref:`LinkWidget <link-widget>` -- this displays the options in a manner
-      similar to the way the Django Admin does, as a series of links. The link
-      for the selected option will have ``class="selected"``.
-    * :ref:`BooleanWidget <boolean-widget>` -- this widget converts its input
-      into Python's True/False values. It will convert all case variations of
-      ``True`` and ``False`` into the internal Python values.
-    * :ref:`CSVWidget <csv-widget>` -- this widget expects a comma separated
-      value and converts it into a list of string values. It is expected that
-      the field class handle a list of values as well as type conversion.
-    * :ref:`RangeWidget <range-widget>` -- this widget is used with ``RangeFilter``
-      to generate two form input elements using a single field.
-
 .. _filter-method:
 
 ``method``
@@ -131,7 +112,28 @@ Defaults to ``False``.
 ``**kwargs``
 ~~~~~~~~~~~~
 
-Any additional keyword arguments are stored as the ``extra`` parameter on the filter. They are provided to the accompanying form Field and can be used to provide arguments like ``choices``.
+Any additional keyword arguments are stored as the ``extra`` parameter on the
+filter. They are provided to the accompanying form ``Field`` and can be used to
+provide arguments like ``choices``. Some field-related arguments:
+
+``widget``
+""""""""""
+
+The django.form Widget class which will represent the ``Filter``.  In addition
+to the widgets that are included with Django that you can use there are
+additional ones that django-filter provides which may be useful:
+
+    * :ref:`LinkWidget <link-widget>` -- this displays the options in a manner
+      similar to the way the Django Admin does, as a series of links. The link
+      for the selected option will have ``class="selected"``.
+    * :ref:`BooleanWidget <boolean-widget>` -- this widget converts its input
+      into Python's True/False values. It will convert all case variations of
+      ``True`` and ``False`` into the internal Python values.
+    * :ref:`CSVWidget <csv-widget>` -- this widget expects a comma separated
+      value and converts it into a list of string values. It is expected that
+      the field class handle a list of values as well as type conversion.
+    * :ref:`RangeWidget <range-widget>` -- this widget is used with ``RangeFilter``
+      to generate two form input elements using a single field.
 
 
 ModelChoiceFilter and ModelMultipleChoiceFilter arguments

--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -9,22 +9,29 @@ This is a reference document with a list of the filters and their arguments.
 Core Arguments
 --------------
 
-The following are the core arguments that apply to all filters.
+The following are the core arguments that apply to all filters. Note that they
+are joined to construct the complete `lookup expression`_ that is the left hand
+side of the ORM ``.filter()`` call.
+
+.. _`lookup expression`: https://docs.djangoproject.com/en/dev/ref/models/lookups/#module-django.db.models.lookups
 
 ``field_name``
 ~~~~~~~~~~~~~~
 
-The name of the field this filter is supposed to filter on, if this is not
-provided it automatically becomes the filter's name on the ``FilterSet``.
-You can traverse "relationship paths" using Django's ``__`` syntax to filter
-fields on a related model. eg, ``manufacturer__name``.
+The name of the model field that is filtered against. If this argument is not
+provided, it defaults the filter's attribute name on the ``FilterSet`` class.
+Field names can traverse relationships by joining the related parts with the ORM
+lookup separator (``__``). e.g., a product's ``manufacturer__name``.
 
 ``lookup_expr``
 ~~~~~~~~~~~~~~~
 
-The lookup expression that should be performed using `Django's ORM`_.
+The `field lookup`_ that should be performed in the filter call. Defaults to
+``exact``. The ``lookup_expr`` can contain transforms if the expression parts
+are joined by the ORM lookup separator (``__``). e.g., filter a datetime by its
+year part ``year__gt``.
 
-.. _`Django's ORM`: https://docs.djangoproject.com/en/dev/ref/models/querysets/#field-lookups
+.. _`Field lookup`: https://docs.djangoproject.com/en/dev/ref/models/querysets/#field-lookups
 
 .. _keyword-only-arguments:
 


### PR DESCRIPTION
Alright, this should cover the renamed arguments. I also did some minor restructuring of the `Filter` arguments, to more correctly reflect the signature in `2.x`. Note that the `widget` and other field-related arguments are nested under `**kwargs`/`extra`.

preview: [here](http://rpkilby.github.io/django-filter).