### PR TITLE
Add 'python_requires' check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         'Framework :: Django',
     ],
     zip_safe=False,
+    python_requires='>=3.4',
     install_requires=[
         'Django>=1.11',
     ],


### PR DESCRIPTION
This should help ensure users don't unintentionally install django-filter 2.x with Python 2. 

This could be released as a post-release (2.0.0.post1), since it doesn't include code changes. I don't think it's necessary, but I'm not sure if the original 2.0 release needs to be deleted in order to prevent pip from falling back to it during installation. 