### PR TITLE
Fix Empty Queryset for Unbound Filter Form

### DIFF
--- a/django_filters/views.py
+++ b/django_filters/views.py
@@ -79,6 +79,8 @@ class BaseFilterView(FilterMixin, MultipleObjectMixin, View):
 
         if self.filterset.is_valid() or not self.get_strict():
             self.object_list = self.filterset.qs
+        elif not self.filterset.is_bound:
+            self.object_list = self.get_queryset()
         else:
             self.object_list = self.filterset.queryset.none()
 

--- a/tests/templates/tests/book_filter.html
+++ b/tests/templates/tests/book_filter.html
@@ -1,5 +1,5 @@
 {{ filter.form }}
 
-{% for obj in filter.qs %}
+{% for obj in object_list %}
     {{ obj }}
 {% endfor %}

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -126,13 +126,15 @@ class GenericClassBasedViewTests(GenericViewTestCase):
     def test_view_with_unbound_filter_form_returns_initial_queryset(self):
         factory = RequestFactory()
         request = factory.get(self.base_url)
+
         queryset = Book.objects.filter(title='Snowcrash')
         view = FilterView.as_view(model=Book, queryset=queryset)
+
         response = view(request)
         titles = [o.title for o in response.context_data['object_list']]
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(titles, ['Snowcrash'], )
+        self.assertEqual(titles, ['Snowcrash'])
 
 
 class GenericFunctionalViewTests(GenericViewTestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -40,7 +40,7 @@ class GenericClassBasedViewTests(GenericViewTestCase):
         factory = RequestFactory()
         request = factory.get(self.base_url)
         filterset = filterset_factory(Book)
-        view = FilterView.as_view(filterset_class=filterset)
+        view = FilterView.as_view(filterset_class=filterset, queryset=Book.objects.all())
         response = view(request)
         self.assertEqual(response.status_code, 200)
         for b in ['Ender&#39;s Game', 'Rainbow Six', 'Snowcrash']:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -123,6 +123,17 @@ class GenericClassBasedViewTests(GenericViewTestCase):
         self.assertEqual(message, expected)
         self.assertEqual(len(recorded), 0)
 
+    def test_view_with_unbound_filter_form_returns_initial_queryset(self):
+        factory = RequestFactory()
+        request = factory.get(self.base_url)
+        queryset = Book.objects.filter(title='Snowcrash')
+        view = FilterView.as_view(model=Book, queryset=queryset)
+        response = view(request)
+        titles = [o.title for o in response.context_data['object_list']]
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(titles, ['Snowcrash'], )
+
 
 class GenericFunctionalViewTests(GenericViewTestCase):
     base_url = '/books-legacy/'


### PR DESCRIPTION
Fix for #930 

### Changes
1. If the filter form is not bound. return what the list view would return by default.
2. Fix the values of a test that were incorrect but passing.