### PR TITLE
Prevent aliasing of fields

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -344,8 +344,6 @@ class BaseFilterSet(object):
                 if field is not None:
                     filters[filter_name] = cls.filter_for_field(field, field_name, lookup_expr)
 
-        # filter out declared filters
-        undefined = [f for f in undefined if f not in cls.declared_filters]
         if undefined:
             raise TypeError(
                 "'Meta.fields' contains fields that are not defined on this FilterSet: "


### PR DESCRIPTION
Currently redefining / aliasing of model fields is being allowed as stated in #1013

```python
class Book(models.Model):
    name = models.CharField(max_length=100)

class BookFilter(django_filter.FilterSet):
    title = models.CharFilter(field_name='name')
    class Meta:
        model = Book
        fields = {
        "title": ["contains",]
        }
````