### PR TITLE
Prevent declared field to have additional lookups

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -22,6 +22,7 @@ from .filters import (
     DateTimeFilter,
     DurationFilter,
     Filter,
+    LookupChoiceFilter,
     ModelChoiceFilter,
     ModelMultipleChoiceFilter,
     NumberFilter,
@@ -344,8 +345,11 @@ class BaseFilterSet(object):
                 if field is not None:
                     filters[filter_name] = cls.filter_for_field(field, field_name, lookup_expr)
 
-        # filter out declared filters
-        undefined = [f for f in undefined if f not in cls.declared_filters]
+        # filter out declared filters where expressions are same as those in declared fields
+        undefined = [f for f in undefined
+                     if f not in cls.declared_filters or
+                     ((type(cls.declared_filters[f]) != LookupChoiceFilter) and
+                     fields[f] != [cls.declared_filters[f].lookup_expr])] # noqa
         if undefined:
             raise TypeError(
                 "'Meta.fields' contains fields that are not defined on this FilterSet: "

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -348,7 +348,7 @@ class BaseFilterSet(object):
         # filter out declared filters where expressions are same as those in declared fields
         undefined = [f for f in undefined
                      if f not in cls.declared_filters or
-                     ((type(cls.declared_filters[f]) != LookupChoiceFilter) and
+                     (not isinstance(cls.declared_filters[f], LookupChoiceFilter) and
                      fields[f] != [cls.declared_filters[f].lookup_expr])] # noqa
         if undefined:
             raise TypeError(

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1961,3 +1961,21 @@ class MiscFilterSetTests(TestCase):
         f = F({'status': '2'}, queryset=qs)
         self.assertEqual(len(f.qs), 2)
         self.assertEqual(f.qs.count(), 2)
+
+    def test_declared_field_additional_lookup_invalid(self):
+        msg = "'Meta.fields' contains fields that are not defined on this FilterSet: account"
+        with self.assertRaises(TypeError) as excinfo:
+            class F(FilterSet):
+                account = CharFilter(field_name='username')
+
+                class Meta:
+                    model = User
+                    fields = {
+                        'account': ['exact', 'contains'],
+                    }
+            F()
+
+        self.assertEqual(
+            str(excinfo.exception),
+            msg
+        )


### PR DESCRIPTION
 I've included an extra check for all fields other than the LookupChoiceFilter to check that if a field which is specified in Meta.fields also exists in declared fields, then make sure that the lookup expressions match; ie declaration of fields in both Meta.fields and the declare fields agree on the same lookup expressions for that field.

I'm not sure if this covers all possible cases as I'm not entirely familiar with the codebase yet. Any feedback would be greatly appreciated! #1013 