### PR TITLE
Fix indentation in docs/ref/filters.txt

### DIFF
--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -496,13 +496,13 @@ Example of using the ``DateField`` field::
     # Max-Only: Comments added before 2016-02-01
     f = F({'date_before': '2016-02-01'})
 
-    .. note::
-        When filtering ranges that occurs on DST transition dates ``DateFromToRangeFilter`` will use the first valid hour of the day for start datetime and the last valid hour of the day for end datetime.
-        This is OK for most applications, but if you want to customize this behavior you must extend ``DateFromToRangeFilter`` and make a custom field for it.
+.. note::
+    When filtering ranges that occurs on DST transition dates ``DateFromToRangeFilter`` will use the first valid hour of the day for start datetime and the last valid hour of the day for end datetime.
+    This is OK for most applications, but if you want to customize this behavior you must extend ``DateFromToRangeFilter`` and make a custom field for it.
 
-    .. warning::
-        If you're using Django prior to 1.9 you may hit ``AmbiguousTimeError`` or ``NonExistentTimeError`` when start/end date matches DST start/end respectively.
-        This occurs because versions before 1.9 don't allow to change the DST behavior for making a datetime aware.
+.. warning::
+    If you're using Django prior to 1.9 you may hit ``AmbiguousTimeError`` or ``NonExistentTimeError`` when start/end date matches DST start/end respectively.
+    This occurs because versions before 1.9 don't allow to change the DST behavior for making a datetime aware.
 
 Example of using the ``DateTimeField`` field::
 


### PR DESCRIPTION
https://django-filter.readthedocs.io/en/master/ref/filters.html#datefromtorangefilter

note/warning after code block was not properly indented