### PR TITLE
Fix passing choices to ChoiceFilter in BaseFilterSet.filter_for_lookup

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -394,7 +394,7 @@ class BaseFilterSet(object):
 
         # perform lookup specific checks
         if lookup_type == 'exact' and getattr(field, 'choices', None):
-            return ChoiceFilter, {'choices': field.choices}
+            return ChoiceFilter, {'choices': field.get_choices(include_blank=False)}
 
         if lookup_type == 'isnull':
             data = try_dbfield(DEFAULTS.get, models.BooleanField)


### PR DESCRIPTION
Each django.db.models.fields.Field has a [get_choices()](https://github.com/django/django/blob/52e9c753659ffeab67149fcf26b95c10cf137c40/django/db/models/fields/__init__.py\#L810) method which is being used when displaying \<select choices\> for this field.

get_choices() is being used heavily, especially in [django admin filters](https://github.com/django/django/blob/52e9c753659ffeab67149fcf26b95c10cf137c40/django/contrib/admin/filters.py\#L196).

Other apps eg. [django-enumfields](https://github.com/hzdg/django-enumfields) also [rely on it](https://github.com/hzdg/django-enumfields/blob/70a2f2cd76a05ac528c35fd099ea5cf595fa0e61/enumfields/fields.py\#L110).

Actually while using django-enumfields I noticed this issue, it was not possible to use django-enumfields and django-filter together because the choices dict keys were enums.

Update: fixed markdown formatting