### PR TITLE
FilterView strict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 build/
 dist/
 docs/_build
+.idea/
+venv/
 .python-version
 .tox
 .coverage

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@
 build/
 dist/
 docs/_build
-.idea/
-venv/
 .python-version
 .tox
 .coverage

--- a/docs/guide/usage.txt
+++ b/docs/guide/usage.txt
@@ -314,6 +314,13 @@ You must provide either a ``model`` or ``filterset_class`` argument, similar to
 If you provide a ``model`` optionally you can set ``filterset_fields`` to specify a list or a tuple of
 the fields that you want to include for the automatic construction of the filterset class.
 
+
+.. note::
+
+    The current class behavior implies strict filtering. If you want to get the original queryset
+    with no filters, use ``strict = False``.
+
+
 You must provide a template at ``<app>/<model>_filter.html`` which gets the
 context parameter ``filter``.  Additionally, the context will contain
 ``object_list`` which holds the filtered queryset.


### PR DESCRIPTION
- Add `strict` references to docs when using FilterView

Unfortunately, after #788 there is no mention of this feature in the documentation.