### PR TITLE
Add lookup_expr to MultipleChoiceFilter

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -253,10 +253,13 @@ class MultipleChoiceFilter(Filter):
         return qs.distinct() if self.distinct else qs
 
     def get_filter_predicate(self, v):
+        name = self.field_name
+        if name and self.lookup_expr != 'exact':
+            name = LOOKUP_SEP.join([name, self.lookup_expr])
         try:
-            return {self.field_name: getattr(v, self.field.to_field_name)}
+            return {name: getattr(v, self.field.to_field_name)}
         except (AttributeError, TypeError):
-            return {self.field_name: v}
+            return {name: v}
 
 
 class TypedMultipleChoiceFilter(MultipleChoiceFilter):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -419,6 +419,21 @@ class MultipleChoiceFilterTests(TestCase):
             qs.exclude.assert_called_once_with(mockQ1.__ior__.return_value)
             qs.exclude.return_value.distinct.assert_called_once_with()
 
+    def test_filtering_with_lookup_expr(self):
+        qs = mock.Mock(spec=['filter'])
+        f = MultipleChoiceFilter(field_name='somefield', lookup_expr='icontains')
+        with mock.patch('django_filters.filters.Q') as mockQclass:
+            mockQ1, mockQ2 = mock.MagicMock(), mock.MagicMock()
+            mockQclass.side_effect = [mockQ1, mockQ2]
+
+            f.filter(qs, ['value'])
+
+            self.assertEqual(mockQclass.call_args_list,
+                             [mock.call(), mock.call(somefield__icontains='value')])
+            mockQ1.__ior__.assert_called_once_with(mockQ2)
+            qs.filter.assert_called_once_with(mockQ1.__ior__.return_value)
+            qs.filter.return_value.distinct.assert_called_once_with()
+
     def test_filtering_on_required_skipped_when_len_of_value_is_len_of_field_choices(self):
         qs = mock.Mock(spec=[])
         f = MultipleChoiceFilter(field_name='somefield', required=True)


### PR DESCRIPTION
This was requested in #49 (back when lookup_expr was called
lookup_type). This is a minor change, with the added advantage of making
``MultipleChoiceFilter`` perform more like other Filter classes, down to
the explicit ``__exact`` filter.

As the documentation only mentions ``lookup_expr`` to be available on
Filter classes in general, and doesn't mention ``MultipleChoiceFilter``
to be different, no documentation change is necessary.