### PR TITLE
Pin TIME_ZONE setting to UTC

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -25,6 +25,8 @@ ROOT_URLCONF = 'tests.urls'
 
 USE_TZ = True
 
+TIME_ZONE = 'UTC'
+
 SECRET_KEY = 'foobar'
 
 TEMPLATES = [{


### PR DESCRIPTION
I think #1050 is actually due to mishandling of datetime creation w/ pytz timezones.

Per the [pytz docs](http://pytz.sourceforge.net/):

> Unfortunately using the tzinfo argument of the standard datetime constructors ‘’does not work’’ with pytz for many timezones.

> It is safe for timezones without daylight saving transitions though, such as UTC:

When running the referenced test, the four datetimes resulted in the following (which is not correct):
```
2016-01-01 15:51:00+00:00
2016-01-02 18:36:00+00:00
2016-01-04 00:06:00+00:00
2016-01-04 01:21:00+00:00
```

We can either pin the `TIME_ZONE` setting to UTC, or we need to properly localize the UTC datetimes to the current timezone. 
