### PR TITLE
Fix declared filters + Meta.fields dict

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -344,12 +344,14 @@ class BaseFilterSet(object):
                 if field is not None:
                     filters[filter_name] = cls.filter_for_field(field, field_name, lookup_expr)
 
-        # filter out declared filters
-        undefined = [f for f in undefined if f not in cls.declared_filters]
+        # Allow Meta.fields to contain declared filters *only* when a list/tuple
+        if isinstance(cls._meta.fields, (list, tuple)):
+            undefined = [f for f in undefined if f not in cls.declared_filters]
+
         if undefined:
             raise TypeError(
-                "'Meta.fields' contains fields that are not defined on this FilterSet: "
-                "%s" % ', '.join(undefined)
+                "'Meta.fields' must not contain non-model field names: %s"
+                % ', '.join(undefined)
             )
 
         # Add in declared filters. This is necessary since we don't enforce adding

--- a/docs/ref/filterset.txt
+++ b/docs/ref/filterset.txt
@@ -71,6 +71,25 @@ include both transforms and lookups, as detailed in the `lookup reference`__.
 
 __ https://docs.djangoproject.com/en/stable/ref/models/lookups/#module-django.db.models.lookups
 
+Note that it is **not** necessary to included declared filters in a ``fields``
+list - doing so will have no effect - and including declarative aliases in a
+``fields`` dict will raise an error.
+
+.. code-block:: python
+
+    class UserFilter(django_filters.FilterSet):
+        username = filters.CharFilter()
+        login_timestamp = filters.IsoDateTimeFilter(field_name='last_login')
+
+        class Meta:
+            model = User
+            fields = {
+                'username': ['exact', 'contains'],
+                'login_timestamp': ['exact'],
+            }
+
+    TypeError("'Meta.fields' contains fields that are not defined on this FilterSet: login_timestamp")
+
 
 .. _exclude:
 

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -121,7 +121,7 @@ class GetFilterClassTests(TestCase):
         view.filterset_fields = ['non_existent']
         queryset = FilterableItem.objects.all()
 
-        msg = "'Meta.fields' contains fields that are not defined on this FilterSet: non_existent"
+        msg = "'Meta.fields' must not contain non-model field names: non_existent"
         with self.assertRaisesMessage(TypeError, msg):
             backend.get_filterset_class(view, queryset)
 
@@ -173,7 +173,7 @@ class GetSchemaFieldsTests(TestCase):
 
         backend = DjangoFilterBackend()
 
-        msg = "'Meta.fields' contains fields that are not defined on this FilterSet: non_existent"
+        msg = "'Meta.fields' must not contain non-model field names: non_existent"
         with self.assertRaisesMessage(TypeError, msg):
             backend.get_schema_fields(View())
 


### PR DESCRIPTION
This fixes #1013. Also, I've based this off of #1060, and can rebase once that's resolved.

**Context:**
Whether a user should include declared filters in `Meta.fields` is something that's never really been clarified. DRF serializers generally expect that declared fields are included in their `Meta.fields`, and it's common to see users add declared fields to a model form's `Meta.fields`. Users might expect the same for `FilterSet`s, however, it isn't necessary and has no effect. e.g., the following are all equivalent:

```python
class F(FilterSet):
    username = CharFilter()

class F(FilterSet):
    username = CharFilter()
    class Meta:
        model = User
        fields = []

class F(FilterSet):
    username = CharFilter()
    class Meta:
        model = User
        fields = ['username']
```

**Problem:**
While the above is fine for `Meta.fields` lists, this breaks down for dicts. Given the below, a user might expect that additional fields are generated from the aliased filter.

```python
class F(FilterSet):
    name = CharFilter(field_name='username')
    class Meta:
        model = User
        fields = {'name': ['exact', 'contains']}
```

Currently, only the declared `name` filter is created, and no `name__contains` filter is generated. No warning is given to the user that nothing happened.

**Proposal:**

`Meta.fields` dict usage should disallow non-model fields, since the usage is non-sensical. It's not possible to generate per-lookup filters for a non-model field. However, non-model fields are still acceptable in list usage, since the declared filter would preempt the filter generation. 

```python
# raise error
class F(FilterSet):
    name = CharFilter(field_name='username')
    class Meta:
        model = User
        fields = {'name': ['exact']}

# acceptable
class F(FilterSet):
    name = CharFilter(field_name='username')
    class Meta:
        model = User
        fields = ['name']
```