### PR TITLE
Removed empty action from a form.

### DIFF
--- a/docs/guide/usage.txt
+++ b/docs/guide/usage.txt
@@ -280,7 +280,7 @@ And lastly we need a template::
     {% extends "base.html" %}
 
     {% block content %}
-        <form action="" method="get">
+        <form method="get">
             {{ filter.form.as_p }}
             <input type="submit" />
         </form>


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-action

>The action and formaction content attributes, if specified, must have a value that is a valid non-empty URL potentially surrounded by spaces.