### PR TITLE
Replaces ugettext(_lazy) with gettext(_lazy), force_text with force_str.

### DIFF
--- a/django_filters/conf.py
+++ b/django_filters/conf.py
@@ -1,6 +1,6 @@
 from django.conf import settings as dj_settings
 from django.core.signals import setting_changed
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .utils import deprecate
 

--- a/django_filters/fields.py
+++ b/django_filters/fields.py
@@ -4,7 +4,7 @@ from datetime import datetime, time
 from django import forms
 from django.utils.dateparse import parse_datetime
 from django.utils.encoding import force_str
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .conf import settings
 from .constants import EMPTY_VALUES

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -7,7 +7,7 @@ from django.db.models.constants import LOOKUP_SEP
 from django.forms.utils import pretty_name
 from django.utils.itercompat import is_iterable
 from django.utils.timezone import now
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .conf import settings
 from .constants import EMPTY_VALUES

--- a/django_filters/rest_framework/filterset.py
+++ b/django_filters/rest_framework/filterset.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django_filters import filterset
 

--- a/django_filters/utils.py
+++ b/django_filters/utils.py
@@ -10,9 +10,9 @@ from django.db.models.expressions import Expression
 from django.db.models.fields import FieldDoesNotExist
 from django.db.models.fields.related import ForeignObjectRel, RelatedField
 from django.utils import timezone
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.text import capfirst
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from .exceptions import FieldLookupError
 
@@ -253,7 +253,7 @@ def verbose_field_name(model, field_name):
             else:
                 return '[invalid name]'
         else:
-            names.append(force_text(part.verbose_name))
+            names.append(force_str(part.verbose_name))
 
     return ' '.join(names)
 
@@ -278,7 +278,7 @@ def verbose_lookup_expr(lookup_expr):
 
     VERBOSE_LOOKUPS = app_settings.VERBOSE_LOOKUPS or {}
     lookups = [
-        force_text(VERBOSE_LOOKUPS.get(lookup, _(lookup)))
+        force_str(VERBOSE_LOOKUPS.get(lookup, _(lookup)))
         for lookup in lookup_expr.split(LOOKUP_SEP)
     ]
 
@@ -302,7 +302,7 @@ def label_for_filter(model, field_name, lookup_expr, exclude=False):
     if isinstance(lookup_expr, str):
         verbose_expression += [verbose_lookup_expr(lookup_expr)]
 
-    verbose_expression = [force_text(part) for part in verbose_expression if part]
+    verbose_expression = [force_str(part) for part in verbose_expression if part]
     verbose_expression = capfirst(' '.join(verbose_expression))
 
     return verbose_expression

--- a/django_filters/widgets.py
+++ b/django_filters/widgets.py
@@ -6,10 +6,10 @@ from django import forms
 from django.db.models.fields import BLANK_CHOICE_DASH
 from django.forms.utils import flatatt
 from django.utils.datastructures import MultiValueDict
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 
 class LinkWidget(forms.Widget):
@@ -37,7 +37,7 @@ class LinkWidget(forms.Widget):
         return mark_safe('\n'.join(output))
 
     def render_options(self, choices, selected_choices, name):
-        selected_choices = set(force_text(v) for v in selected_choices)
+        selected_choices = set(force_str(v) for v in selected_choices)
         output = []
         for option_value, option_label in chain(self.choices, choices):
             if isinstance(option_label, (list, tuple)):
@@ -52,7 +52,7 @@ class LinkWidget(forms.Widget):
 
     def render_option(self, name, selected_choices,
                       option_value, option_label):
-        option_value = force_text(option_value)
+        option_value = force_str(option_value)
         if option_label == BLANK_CHOICE_DASH[0][1]:
             option_label = _("All")
         data = self.data.copy()
@@ -65,7 +65,7 @@ class LinkWidget(forms.Widget):
         return self.option_string() % {
             'attrs': selected and ' class="selected"' or '',
             'query_string': url,
-            'label': force_text(option_label)
+            'label': force_str(option_label)
         }
 
     def option_string(self):
@@ -213,7 +213,7 @@ class BaseCSVWidget(forms.Widget):
         # if we have multiple values, we need to force render as a text input
         # (otherwise, the additional values are lost)
         surrogate = forms.TextInput()
-        value = [force_text(surrogate.format_value(v)) for v in value]
+        value = [force_str(surrogate.format_value(v)) for v in value]
         value = ','.join(list(value))
 
         return surrogate.render(name, value, attrs, renderer=renderer)

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 REGULAR = 0
 MANAGER = 1

--- a/tests/rest_framework/models.py
+++ b/tests/rest_framework/models.py
@@ -1,6 +1,6 @@
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class BasicModel(models.Model):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import inspect
 import mock
 from collections import OrderedDict
@@ -7,7 +6,7 @@ from datetime import date, datetime, time, timedelta
 from django import forms
 from django.test import TestCase, override_settings
 from django.utils import translation
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from django_filters import filters, widgets
 from django_filters.fields import (


### PR DESCRIPTION
Fixes
- `RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().`
- `RemovedInDjango40Warning: force_text() is deprecated in favor of force_str().`