### PR TITLE
add get_schema_operation_parameters() for Open API 3 generateschema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Version 2.x (unreleased)
 ------------------------
 
-* Added ``DjangoFilterBackend.get_schema_operation_parameters()`` for DRF 3.9+ ``generateschema``.
+* Added ``DjangoFilterBackend.get_schema_operation_parameters()`` for DRF 3.10+ OpenAPI schema generation.
 
 Version 2.1 (2019-1-20)
 -----------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+Version 2.x (unreleased)
+------------------------
+
+* Added ``DjangoFilterBackend.get_schema_operation_parameters()`` for DRF 3.9+ ``generateschema``.
+
 Version 2.1 (2019-1-20)
 -----------------------
 

--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -140,4 +140,23 @@ class DjangoFilterBackend(metaclass=RenameAttributes):
         ]
 
     def get_schema_operation_parameters(self, view):
-        return []
+        try:
+            queryset = view.get_queryset()
+        except Exception:
+            queryset = None
+            warnings.warn(
+                "{} is not compatible with schema generation".format(view.__class__)
+            )
+
+        filterset_class = self.get_filterset_class(view, queryset)
+        return [] if not filterset_class else [
+            ({
+                'name': field_name,
+                'required': field.extra['required'],
+                'in': 'query',
+                'description': field.label if field.label is not None else field_name,
+                'schema': {
+                    'type': 'string',
+                },
+            }) for field_name, field in filterset_class.base_filters.items()
+        ]

--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -138,3 +138,6 @@ class DjangoFilterBackend(metaclass=RenameAttributes):
                 schema=self.get_coreschema_field(field)
             ) for field_name, field in filterset_class.base_filters.items()
         ]
+
+    def get_schema_operation_parameters(self, view):
+        return []

--- a/docs/guide/rest_framework.txt
+++ b/docs/guide/rest_framework.txt
@@ -148,10 +148,10 @@ You can override these methods on a case-by-case basis for each view, creating u
                 'author': self.get_author(),
             }
 
-Schema Generation with Core API
--------------------------------
+Schema Generation with Core API and Open API
+--------------------------------------------
 
-The backend class integrates with DRF's schema generation by implementing ``get_schema_fields()``. This is automatically enabled when Core API is installed. Schema generation usually functions seamlessly, however the implementation does expect to invoke the view's ``get_queryset()`` method. There is a caveat in that views are artificially constructed during schema generation, so the ``args`` and ``kwargs`` attributes will be empty. If you depend on arguments parsed from the URL, you will need to handle their absence in ``get_queryset()``.
+The backend class integrates with DRF's schema generation by implementing ``get_schema_fields()`` and ``get_schema_operation_parameters()``. ``get_schema_fields()`` is automatically enabled when Core API is installed. ``get_schema_operation_parameters()`` is always enabled for Open API (new since DRF 3.9). Schema generation usually functions seamlessly, however the implementation does expect to invoke the view's ``get_queryset()`` method. There is a caveat in that views are artificially constructed during schema generation, so the ``args`` and ``kwargs`` attributes will be empty. If you depend on arguments parsed from the URL, you will need to handle their absence in ``get_queryset()``.
 
 For example, your get queryset method may look like this:
 

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -233,9 +233,9 @@ class GetSchemaOperationParametersTests(TestCase):
     def test_get_operation_parameters_with_filterset_fields_list(self):
         backend = DjangoFilterBackend()
         fields = backend.get_schema_operation_parameters(FilterFieldsRootView())
-        fields = [f.name for f in fields]
+        fields = [f['name'] for f in fields]
 
-        self.assertEqual(fields, [])
+        self.assertEqual(fields, ['decimal', 'date'])
 
 
 class TemplateTests(TestCase):

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -229,6 +229,15 @@ class GetSchemaFieldsTests(TestCase):
         self.assertEqual(fields, ['text', 'decimal', 'date', 'f'])
 
 
+class GetSchemaOperationParametersTests(TestCase):
+    def test_get_operation_parameters_with_filterset_fields_list(self):
+        backend = DjangoFilterBackend()
+        fields = backend.get_schema_operation_parameters(FilterFieldsRootView())
+        fields = [f.name for f in fields]
+
+        self.assertEqual(fields, [])
+
+
 class TemplateTests(TestCase):
     def test_backend_output(self):
         """


### PR DESCRIPTION
Fixes #1083 

Implements Open API 3 (formerly known as Swagger) schema generation by upstream DRF 3.9+ `generateschema` management command.
