### PR TITLE
Inclusion of the possibility of logic fields in django-filter

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -221,10 +221,11 @@ class BaseFilterSet(object):
         applied to the queryset before it is cached.
         """
         for name, value in self.form.cleaned_data.items():
-            queryset = self.filters[name].filter(queryset, value)
-            assert isinstance(queryset, models.QuerySet), \
-                "Expected '%s.%s' to return a QuerySet, but got a %s instead." \
-                % (type(self).__name__, name, type(queryset).__name__)
+            if not hasattr(self.Meta, 'logic_fields') or name not in self.Meta.logic_fields:
+                queryset = self.filters[name].filter(queryset, value)
+                assert isinstance(queryset, models.QuerySet), \
+                    "Expected '%s.%s' to return a QuerySet, but got a %s instead." \
+                    % (type(self).__name__, name, type(queryset).__name__)
         return queryset
 
     @property

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -220,8 +220,11 @@ class BaseFilterSet(object):
         This method should be overridden if additional filtering needs to be
         applied to the queryset before it is cached.
         """
+        meta = getattr(self, 'Meta', None)
+        logic_fields = getattr(meta, 'logic_fields', [])
+
         for name, value in self.form.cleaned_data.items():
-            if not hasattr(self.Meta, 'logic_fields') or name not in self.Meta.logic_fields:
+            if name not in logic_fields:
                 queryset = self.filters[name].filter(queryset, value)
                 assert isinstance(queryset, models.QuerySet), \
                     "Expected '%s.%s' to return a QuerySet, but got a %s instead." \

--- a/docs/guide/usage.txt
+++ b/docs/guide/usage.txt
@@ -45,6 +45,25 @@ As you can see this uses a very similar API to Django's ``ModelForm``.  Just
 like with a ``ModelForm`` we can also override filters, or add new ones using a
 declarative syntax.
 
+The logic filds
+----------
+
+When we have fields that are for logical use we can declare it as follows:
+
+    import django_filters
+
+    class ProductFilter(django_filters.FilterSet):
+        name = django_filters.CharFilter(lookup_expr='iexact')
+        show_more_details = django_filters.BooleanFilter()
+
+        class Meta:
+            model = Product
+            fields = ['price', 'release_date', 'show_more_details']
+            logic_fields = ['show_more_details']
+
+
+This logic field can be used for example in the ``get_context_data``.
+
 Declaring filters
 ~~~~~~~~~~~~~~~~~
 

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -861,3 +861,18 @@ class MiscFilterSetTests(TestCase):
         # The FilterSet should not proxy .qs methods - just access .qs directly
         self.assertFalse(hasattr(FilterSet, '__len__'))
         self.assertFalse(hasattr(FilterSet, '__iter__'))
+
+
+class LogicFieldsFilterSetTests(TestCase):
+    class F(FilterSet):
+        invalid = CharFilter(method=lambda *args: None)
+
+        class Meta:
+            model = User
+            fields = ['username', 'invalid']
+            logic_fields = ['invalid']
+
+    def test_logic_field(self):
+        request = MockQuerySet()
+
+        self.F({'f': 'foo'}, request=request, queryset=User.objects.all()).qs


### PR DESCRIPTION
When we have fields that are for logical use we can declare it as follows:
```
    import django_filters

    class ProductFilter(django_filters.FilterSet):
        name = django_filters.CharFilter(lookup_expr='iexact')
        show_more_details = django_filters.BooleanFilter()

        class Meta:
            model = Product
            fields = ['price', 'release_date', 'show_more_details']
            logic_fields = ['show_more_details']
```

This logic field can be used for example in the ``get_context_data``.