### PR TITLE
Add lookup_fields in REST Backend

### DIFF
--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -41,6 +41,7 @@ class DjangoFilterBackend(metaclass=RenameAttributes):
         """
         filterset_class = getattr(view, 'filterset_class', None)
         filterset_fields = getattr(view, 'filterset_fields', None)
+        lookup_fields = getattr(view, 'lookup_fields', None)
 
         # TODO: remove assertion in 2.1
         if filterset_class is None and hasattr(view, 'filter_class'):
@@ -69,6 +70,17 @@ class DjangoFilterBackend(metaclass=RenameAttributes):
 
         if filterset_fields and queryset is not None:
             MetaBase = getattr(self.filterset_base, 'Meta', object)
+
+            # Update lookup of specified fields in filterset_fields
+            if lookup_fields:
+                if not isinstance(filterset_fields, dict):
+                    filterset_fields = {f: ['exact'] for f in filterset_fields}
+                if isinstance(lookup_fields, dict):
+                    for k, v in lookup_fields.items():
+                        if isinstance(v, str):
+                            v = [v]
+                        if k in filterset_fields:
+                            filterset_fields[k] = v
 
             class AutoFilterSet(self.filterset_base):
                 class Meta(MetaBase):

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -102,6 +102,16 @@ class GetFilterClassTests(TestCase):
         filterset_class = backend.get_filterset_class(view, queryset)
         self.assertEqual(filterset_class._meta.fields, view.filterset_fields)
 
+    def test_lookup_fields(self):
+        backend = DjangoFilterBackend()
+        view = FilterableItemView()
+        view.filterset_fields = ['text', 'decimal', 'date']
+        view.lookup_fields = {'date': ['gt', 'lt']}
+        queryset = FilterableItem.objects.all()
+
+        filterset_class = backend.get_filterset_class(view, queryset)
+        self.assertEqual(filterset_class._meta.fields['date'], view.lookup_fields['date'])
+
     def test_filterset_fields_malformed(self):
         backend = DjangoFilterBackend()
         view = FilterableItemView()


### PR DESCRIPTION
This allows you to change the lookup of the fields defined in filterset_fields in the integration with Django Rest Framework.