### PR TITLE
Add base_ordering to OrderingFilter

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1461,6 +1461,24 @@ class OrderingFilterTests(TestCase):
         result = f.filter(qs, None)
         self.assertEqual(qs, result)
 
+    def test_base_ordering(self):
+        qs = mock.Mock(spec=['order_by'])
+        f = OrderingFilter(base_ordering=['b'])
+        f.filter(qs, ['a'])
+        qs.order_by.assert_called_once_with('a', 'b')
+
+    def test_base_ordering_no_duplicate(self):
+        qs = mock.Mock(spec=['order_by'])
+        f = OrderingFilter(base_ordering=['b'])
+        f.filter(qs, ['a', 'b'])
+        qs.order_by.assert_called_once_with('a', 'b')
+
+    def test_base_ordering_no_duplicate_descending(self):
+        qs = mock.Mock(spec=['order_by'])
+        f = OrderingFilter(base_ordering=['b'])
+        f.filter(qs, ['a', '-b'])
+        qs.order_by.assert_called_once_with('a', '-b')
+
     def test_choices_unaltered(self):
         # provided 'choices' should not be altered when 'fields' is present
         f = OrderingFilter(


### PR DESCRIPTION
``base_ordering`` is an optional argument that allows you to specify a set of fields that will be given to ``order_by()`` after any provided ordering options. This is useful if you filter by a non-unique field but want an unique field to serve as a base. Django guarantees a consistent order only for querysets with at least one unique ordering field. Consistent ordering is important for things like pagination.