### PR TITLE
Add support for setting up Form widgets in the FilterSet Meta.

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -60,7 +60,7 @@ class FilterSetOptions(object):
         self.filter_overrides = getattr(options, 'filter_overrides', {})
 
         self.form = getattr(options, 'form', forms.Form)
-        self.widgets = getattr(options, 'widgets', None)
+        self.widgets = getattr(options, 'widgets', {})
 
 
 class FilterSetMetaclass(type):

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -60,6 +60,7 @@ class FilterSetOptions(object):
         self.filter_overrides = getattr(options, 'filter_overrides', {})
 
         self.form = getattr(options, 'form', forms.Form)
+        self.widgets = getattr(options, 'widgets', None)
 
 
 class FilterSetMetaclass(type):
@@ -245,9 +246,13 @@ class BaseFilterSet(object):
         This method should be overridden if the form class needs to be
         customized relative to the filterset instance.
         """
-        fields = OrderedDict([
-            (name, filter_.field)
-            for name, filter_ in self.filters.items()])
+        fields = OrderedDict()
+
+        for name, filter_ in self.filters.items():
+            widget = self._meta.widgets.get(name, None)
+            if widget:
+                filter_.field.widget = widget
+            fields[name] = filter_.field
 
         return type(str('%sForm' % self.__class__.__name__),
                     (self._meta.form,), fields)


### PR DESCRIPTION
Set up a "widgets" attribute in the FilterSet Meta to customize the form's widgets.

Example:
```
widgets = {
    'field_1': Widget1(),
    'field_2': Widget2(),
}
```

This was useful to me when I had to automatically generate my filters with the factory method pattern and I didn't want to manually create the related customized form.