### PR TITLE
Fixed import of FieldDoesNotExist.

### DIFF
--- a/django_filters/utils.py
+++ b/django_filters/utils.py
@@ -3,11 +3,10 @@ from collections import OrderedDict
 
 import django
 from django.conf import settings
-from django.core.exceptions import FieldError
+from django.core.exceptions import FieldDoesNotExist, FieldError
 from django.db import models
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.expressions import Expression
-from django.db.models.fields import FieldDoesNotExist
 from django.db.models.fields.related import ForeignObjectRel, RelatedField
 from django.utils import timezone
 from django.utils.encoding import force_str


### PR DESCRIPTION
`FieldDoesNotExist` was moved to `django.core.exceptions` in https://github.com/django/django/commit/8958170755b37ce346ae5257c1000bd936faa3b0 and removed from `django.db.models.fields` in https://github.com/django/django/commit/129583a0d3cf69b08d058cd751d777588801b7ad.