### PR TITLE
Backend - improve schema generation

### DIFF
--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -150,7 +150,7 @@ class DjangoFilterBackend(metaclass=RenameAttributes):
         ]
 
     def get_queryset_for_schema_generation(self, view):
-        """Get query set from view from schema generation"""
+        """Get query set from view for schema generation"""
         try:
             queryset = view.get_queryset()
         except Exception:

--- a/tests/rest_framework/models.py
+++ b/tests/rest_framework/models.py
@@ -1,4 +1,4 @@
-
+from django.conf import settings
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
@@ -21,7 +21,6 @@ class FilterableItem(BaseFilterableItem):
 
 
 class FilterableItemWithOwner(FilterableItem):
-    from django.conf import settings
     owner = models.ForeignKey(
         settings.AUTH_USER_MODEL, on_delete=models.CASCADE
     )

--- a/tests/rest_framework/models.py
+++ b/tests/rest_framework/models.py
@@ -20,6 +20,13 @@ class FilterableItem(BaseFilterableItem):
     date = models.DateField()
 
 
+class FilterableItemWithOwner(FilterableItem):
+    from django.conf import settings
+    owner = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.CASCADE
+    )
+
+
 class DjangoFilterOrderingModel(models.Model):
     date = models.DateField()
     text = models.CharField(max_length=10)

--- a/tests/rest_framework/models.py
+++ b/tests/rest_framework/models.py
@@ -1,6 +1,7 @@
-from django.conf import settings
 from django.db import models
 from django.utils.translation import gettext_lazy as _
+
+from tests.models import User
 
 
 class BasicModel(models.Model):
@@ -22,7 +23,7 @@ class FilterableItem(BaseFilterableItem):
 
 class FilterableItemWithOwner(FilterableItem):
     owner = models.ForeignKey(
-        settings.AUTH_USER_MODEL, on_delete=models.CASCADE
+        User, on_delete=models.CASCADE
     )
 
 


### PR DESCRIPTION
Improved retrieval of view's `queryset` in `get_schema_fields` and `get_schema_operation_parameters`.
Now we first try to get `queryset` via `get_queryset` method, and if this one fails, we use `queryset` attribute.

Why?
For example in #551, you don't need to add extra workaround like in [docs (Schema Generation with Core API)](http://rpkilby.github.io/django-filter/rest_framework). Since later in this methods we only use model attr from `queryset`, there is no difference between `queryset` and `get_queryset`.