### PR TITLE
Customizable default lookup expression

### DIFF
--- a/django_filters/conf.py
+++ b/django_filters/conf.py
@@ -7,6 +7,8 @@ from .utils import deprecate
 DEFAULTS = {
     'DISABLE_HELP_TEXT': False,
 
+    'DEFAULT_LOOKUP_EXPR': 'exact',
+
     # empty/null choices
     'EMPTY_CHOICE_LABEL': '---------',
     'NULL_CHOICE_LABEL': None,

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -66,8 +66,10 @@ class Filter(object):
     creation_counter = 0
     field_class = forms.Field
 
-    def __init__(self, field_name=None, lookup_expr='exact', *, label=None,
+    def __init__(self, field_name=None, lookup_expr=None, *, label=None,
                  method=None, distinct=False, exclude=False, **kwargs):
+        if lookup_expr is None:
+            lookup_expr = settings.DEFAULT_LOOKUP_EXPR
         self.field_name = field_name
         self.lookup_expr = lookup_expr
         self.label = label
@@ -80,12 +82,6 @@ class Filter(object):
 
         self.creation_counter = Filter.creation_counter
         Filter.creation_counter += 1
-
-        # TODO: remove assertion in 2.1
-        assert not isinstance(self.lookup_expr, (type(None), list)), \
-            "The `lookup_expr` argument no longer accepts `None` or a list of " \
-            "expressions. Use the `LookupChoiceFilter` instead. See: " \
-            "https://django-filter.readthedocs.io/en/master/guide/migration.html"
 
     def get_method(self, qs):
         """Return filter method based on whether we're excluding
@@ -254,7 +250,7 @@ class MultipleChoiceFilter(Filter):
 
     def get_filter_predicate(self, v):
         name = self.field_name
-        if name and self.lookup_expr != 'exact':
+        if name and self.lookup_expr != settings.DEFAULT_LOOKUP_EXPR:
             name = LOOKUP_SEP.join([name, self.lookup_expr])
         try:
             return {name: getattr(v, self.field.to_field_name)}

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -294,7 +294,7 @@ class BaseFilterSet(object):
         # Remove excluded fields
         exclude = exclude or []
         if not isinstance(fields, dict):
-            fields = [(f, ['exact']) for f in fields if f not in exclude]
+            fields = [(f, [settings.DEFAULT_LOOKUP_EXPR]) for f in fields if f not in exclude]
         else:
             fields = [(f, lookups) for f, lookups in fields.items() if f not in exclude]
 
@@ -310,9 +310,9 @@ class BaseFilterSet(object):
         filter_name = LOOKUP_SEP.join([field_name, lookup_expr])
 
         # This also works with transformed exact lookups, such as 'date__exact'
-        _exact = LOOKUP_SEP + 'exact'
-        if filter_name.endswith(_exact):
-            filter_name = filter_name[:-len(_exact)]
+        _default_expr = LOOKUP_SEP + settings.DEFAULT_LOOKUP_EXPR
+        if filter_name.endswith(_default_expr):
+            filter_name = filter_name[:-len(_default_expr)]
 
         return filter_name
 
@@ -366,7 +366,9 @@ class BaseFilterSet(object):
         return filters
 
     @classmethod
-    def filter_for_field(cls, field, field_name, lookup_expr='exact'):
+    def filter_for_field(cls, field, field_name, lookup_expr=None):
+        if lookup_expr is None:
+            lookup_expr = settings.DEFAULT_LOOKUP_EXPR
         field, lookup_type = resolve_field(field, lookup_expr)
 
         default = {

--- a/docs/guide/usage.txt
+++ b/docs/guide/usage.txt
@@ -122,7 +122,8 @@ The above would generate 'price__lt', 'price__gt', 'release_date', and
 
     The filter lookup type 'exact' is an implicit default and therefore never
     added to a filter name. In the above example, the release date's exact
-    filter is 'release_date', not 'release_date__exact'.
+    filter is 'release_date', not 'release_date__exact'. This can be overridden
+    by the FILTERS_DEFAULT_LOOKUP_EXPR setting.
 
 Items in the ``fields`` sequence in the ``Meta`` class may include
 "relationship paths" using Django's ``__`` syntax to filter on fields on a

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -7,6 +7,14 @@ default values. All settings are prefixed with ``FILTERS_``, although this
 is a bit verbose it helps to make it easy to identify these settings.
 
 
+FILTERS_DEFAULT_LOOKUP_EXPR
+---------------------------
+
+Default: ``'exact'``
+
+Set the default lookup expression to be generated, when none is defined.
+
+
 FILTERS_EMPTY_CHOICE_LABEL
 --------------------------
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -11,6 +11,9 @@ class DefaultSettingsTests(TestCase):
         self.assertIsInstance(settings.VERBOSE_LOOKUPS, dict)
         self.assertIn('exact', settings.VERBOSE_LOOKUPS)
 
+    def test_default_lookup_expr(self):
+        self.assertEqual(settings.DEFAULT_LOOKUP_EXPR, 'exact')
+
     def test_disable_help_text(self):
         self.assertFalse(settings.DISABLE_HELP_TEXT)
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -94,19 +94,6 @@ class FilterTests(TestCase):
         field = f.field
         self.assertIsInstance(field, forms.Field)
 
-    def test_field_with_lookup_types_removal(self):
-        msg = (
-            "The `lookup_expr` argument no longer accepts `None` or a list of "
-            "expressions. Use the `LookupChoiceFilter` instead. See: "
-            "https://django-filter.readthedocs.io/en/master/guide/migration.html"
-        )
-
-        with self.assertRaisesMessage(AssertionError, msg):
-            Filter(lookup_expr=[])
-
-        with self.assertRaisesMessage(AssertionError, msg):
-            Filter(lookup_expr=None)
-
     def test_field_params(self):
         with mock.patch.object(Filter, 'field_class',
                                spec=['__call__']) as mocked:


### PR DESCRIPTION
When there are mosty string fields in an application, and one does not like the `__icontains` or `__iexact` suffixes in the URL params, then it would be beneficial to change the default lookup expression generated.