### PR TITLE
Fix filterset multiple inheritance bug

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -98,11 +98,11 @@ class FilterSetMetaclass(type):
         # merge declared filters from base classes
         for base in reversed(bases):
             if hasattr(base, 'declared_filters'):
-                filters = [
+                filters = filters + [
                     (name, f) for name, f
                     in base.declared_filters.items()
                     if name not in attrs
-                ] + filters
+                ]
 
         return OrderedDict(filters)
 

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -95,16 +95,22 @@ class FilterSetMetaclass(type):
 
         filters.sort(key=lambda x: x[1].creation_counter)
 
-        # merge declared filters from base classes
-        for base in reversed(bases):
-            if hasattr(base, 'declared_filters'):
-                filters = filters + [
-                    (name, f) for name, f
-                    in base.declared_filters.items()
-                    if name not in attrs
-                ]
+        # Ensures a base class field doesn't override cls attrs, and maintains
+        # field precedence when inheriting multiple parents. e.g. if there is a
+        # class C(A, B), and A and B both define 'field', use 'field' from A.
+        known = set(attrs)
 
-        return OrderedDict(filters)
+        def visit(name):
+            known.add(name)
+            return name
+
+        base_filters = [
+            (visit(name), f)
+            for base in bases if hasattr(base, 'declared_filters')
+            for name, f in base.declared_filters.items() if name not in known
+        ]
+
+        return OrderedDict(base_filters + filters)
 
 
 FILTER_FOR_DBFIELD_DEFAULTS = {

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -632,6 +632,35 @@ class FilterSetClassCreationTests(TestCase):
         filters = {name: type(f) for name, f in F.declared_filters.items()}
         self.assertEqual(filters, {'f': CharFilter})
 
+    def test_declared_filter_multiple_inheritance_field_ordering(self):
+        class Base(FilterSet):
+            f1 = CharFilter()
+            f2 = CharFilter()
+
+        class A(Base):
+            f3 = NumberFilter()
+
+        class B(FilterSet):
+            f3 = CharFilter()
+            f4 = CharFilter()
+
+        class F(A, B):
+            f2 = NumberFilter()
+            f5 = CharFilter()
+
+        fields = {name: type(f) for name, f in F.declared_filters.items()}
+
+        # `NumberFilter`s should be the 'winners' in filter name conflicts
+        # - `F.f2` should override `Base.F2`
+        # - `A.f3` should override `B.f3`
+        assert fields == {
+            'f1': CharFilter,
+            'f2': NumberFilter,
+            'f3': NumberFilter,
+            'f4': CharFilter,
+            'f5': CharFilter,
+        }
+
 
 class FilterSetInstantiationTests(TestCase):
 

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -619,6 +619,19 @@ class FilterSetClassCreationTests(TestCase):
         self.assertEqual(len(Child.base_filters), 1)
         self.assertEqual(len(Grandchild.base_filters), 1)
 
+    def test_declared_filter_multiple_inheritance(self):
+        class A(FilterSet):
+            f = CharFilter()
+
+        class B(FilterSet):
+            f = NumberFilter()
+
+        class F(A, B):
+            pass
+
+        filters = {name: type(f) for name, f in F.declared_filters.items()}
+        self.assertEqual(filters, {'f': CharFilter})
+
 
 class FilterSetInstantiationTests(TestCase):
 


### PR DESCRIPTION
Declared filter resolution was mostly copied from DRF. This fixes a multiple inheritance bug described in https://github.com/encode/django-rest-framework/pull/6980