### PR TITLE
WIP: Add schema type extra param to OpenAPI generation

### DIFF
--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -156,7 +156,7 @@ class DjangoFilterBackend(metaclass=RenameAttributes):
                 'in': 'query',
                 'description': field.label if field.label is not None else field_name,
                 'schema': {
-                    'type': 'string',
+                    'type': field.extra.get('schema_type', 'string'),
                 },
             }) for field_name, field in filterset_class.base_filters.items()
         ]


### PR DESCRIPTION
This would allow for user defined schema type, which is currently hard coded as `'string'`.

Related issue #1104 