### PR TITLE
Add filter instance to `Filter.method` signature

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -765,6 +765,7 @@ class FilterMethod(object):
     This helper is used to override Filter.filter() when a 'method' argument
     is passed. It proxies the call to the actual method on the filter's parent.
     """
+
     def __init__(self, filter_instance):
         self.f = filter_instance
 
@@ -772,7 +773,7 @@ class FilterMethod(object):
         if value in EMPTY_VALUES:
             return qs
 
-        return self.method(qs, self.f.field_name, value)
+        return self.method(self.f, qs, value)
 
     @property
     def method(self):

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -87,6 +87,16 @@ class Filter(object):
             "expressions. Use the `LookupChoiceFilter` instead. See: " \
             "https://django-filter.readthedocs.io/en/master/guide/migration.html"
 
+    def bind(self, attr, parent):
+        """Bind the filter to its parent filterset.
+
+        Provides both the filter's attribute name on the filterset and the
+        parent filterset instance. Called when the parent is initialized.
+        """
+        self.attr = attr
+        self.parent = parent
+        self.model = parent.queryset.model
+
     def get_method(self, qs):
         """Return filter method based on whether we're excluding
            or simply filtering.

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -777,7 +777,7 @@ class FilterMethod(object):
 
         # otherwise, method is the name of a method on the parent FilterSet.
         assert hasattr(instance, 'parent'), \
-            "Filter '%s' must have a parent FilterSet to find '.%s()'" %  \
+            "Filter '%s' must have a parent FilterSet to find '.%s()'." %  \
             (instance.field_name, instance.method)
 
         parent = instance.parent

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -184,7 +184,6 @@ class BaseFilterSet(object):
     def __init__(self, data=None, queryset=None, *, request=None, prefix=None):
         if queryset is None:
             queryset = self._meta.model._default_manager.all()
-        model = queryset.model
 
         self.is_bound = data is not None
         self.data = data or {}
@@ -194,10 +193,8 @@ class BaseFilterSet(object):
 
         self.filters = copy.deepcopy(self.base_filters)
 
-        # propagate the model and filterset to the filters
-        for filter_ in self.filters.values():
-            filter_.model = model
-            filter_.parent = self
+        for filter_name, f in self.filters.items():
+            f.bind(filter_name, self)
 
     def is_valid(self):
         """

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1095,8 +1095,8 @@ class FilterMethodTests(TestCase):
                 model = User
                 fields = ['username']
 
-            def filter_username(self, queryset, name, value):
-                return queryset.filter(**{name: value})
+            def filter_username(self, f, qs, value):
+                return qs.filter(**{f.field_name: value})
 
         self.assertEqual(list(F().qs), list(User.objects.all()))
         self.assertEqual(list(F({'username': 'alex'}).qs),
@@ -1105,8 +1105,8 @@ class FilterMethodTests(TestCase):
                          list())
 
     def test_filtering_callable(self):
-        def filter_username(queryset, name, value):
-            return queryset.filter(**{name: value})
+        def filter_username(f, qs, value):
+            return qs.filter(**{f.field_name: value})
 
         class F(FilterSet):
             username = CharFilter(method=filter_username)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -176,7 +176,7 @@ class FilterTests(TestCase):
         f = Filter(method=method)
         f.bind('name', mock.Mock())
         result = f.filter(qs, 'value')
-        method.assert_called_once_with(qs, None, 'value')
+        method.assert_called_once_with(f, qs, 'value')
         self.assertNotEqual(qs, result)
 
     def test_filtering_uses_distinct(self):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -174,6 +174,7 @@ class FilterTests(TestCase):
         qs = mock.NonCallableMock(spec=[])
         method = mock.Mock()
         f = Filter(method=method)
+        f.bind('name', mock.Mock())
         result = f.filter(qs, 'value')
         method.assert_called_once_with(qs, None, 'value')
         self.assertNotEqual(qs, result)

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -784,9 +784,8 @@ class FilterMethodTests(TestCase):
         with self.assertRaises(AssertionError) as w:
             f.filter(User.objects.all(), 0)
 
-        self.assertIn("'None'", str(w.exception))
-        self.assertIn('parent', str(w.exception))
-        self.assertIn('filter_f', str(w.exception))
+        msg = "Filter 'None' must have a parent FilterSet to find '.filter_f()'."
+        self.assertEqual(str(w.exception), msg)
 
     def test_method_self_is_parent(self):
         # Ensure the method isn't 're-parented' on the `FilterMethod` helper class.
@@ -816,8 +815,9 @@ class FilterMethodTests(TestCase):
         with self.assertRaises(AssertionError) as w:
             f.filters['f'].filter(User.objects.all(), 0)
 
-        self.assertIn('%s.%s' % (F.__module__, F.__name__), str(w.exception))
-        self.assertIn('.filter_f()', str(w.exception))
+        msg = ("Expected parent FilterSet 'tests.test_filterset.F' to have "
+               "a '.filter_f()' method.")
+        self.assertEqual(str(w.exception), msg)
 
     def test_method_uncallable(self):
         class F(FilterSet):
@@ -829,8 +829,9 @@ class FilterMethodTests(TestCase):
         with self.assertRaises(AssertionError) as w:
             f.filters['f'].filter(User.objects.all(), 0)
 
-        self.assertIn('%s.%s' % (F.__module__, F.__name__), str(w.exception))
-        self.assertIn('.filter_f()', str(w.exception))
+        msg = ("Expected parent FilterSet 'tests.test_filterset.F' to have "
+               "a '.filter_f()' method.")
+        self.assertEqual(str(w.exception), msg)
 
     def test_method_set_unset(self):
         # use a mock to bypass bound/unbound method equality

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -732,7 +732,7 @@ class FilterMethodTests(TestCase):
         class F(FilterSet):
             f = Filter(method='filter_f')
 
-            def filter_f(self, qs, name, value):
+            def filter_f(self, f, qs, value):
                 pass
 
         f = F({}, queryset=User.objects.all())
@@ -741,7 +741,7 @@ class FilterMethodTests(TestCase):
         self.assertIsInstance(f.filters['f'].filter, FilterMethod)
 
     def test_method_callable(self):
-        def filter_f(qs, name, value):
+        def filter_f(f, qs, value):
             pass
 
         class F(FilterSet):
@@ -756,7 +756,7 @@ class FilterMethodTests(TestCase):
         class F(FilterSet):
             f = Filter(method='filter_f')
 
-            def filter_f(self, qs, name, value):
+            def filter_f(self, f, qs, value):
                 # call mock request object to prove self.request can be accessed
                 self.request()
 
@@ -772,7 +772,7 @@ class FilterMethodTests(TestCase):
         class F(FilterSet):
             f = DateRangeFilter(method='filter_f')
 
-            def filter_f(self, qs, name, value):
+            def filter_f(self, f, qs, value):
                 pass
 
         f = F({}, queryset=User.objects.all())
@@ -799,7 +799,7 @@ class FilterMethodTests(TestCase):
                 model = User
                 fields = []
 
-            def filter_f(inner_self, qs, name, value):
+            def filter_f(inner_self, f, qs, value):
                 self.assertIsInstance(inner_self, F)
                 self.assertIs(inner_self.request, request)
                 return qs


### PR DESCRIPTION
`Filter.method` enables ad hoc filtering behavior, however the current implementation does not sufficiently support writing more generic methods, as you cannot easily access the associated filter instance or its properties. With the filter instance, the method could alter its behavior, like whether it should `exclude` or use a specific `lookup_expr`. This PR proposes changing the method callback signature to provide the filter instance in lieu of the model field name.

**Context:**
Let's work with the following example:

```python
class MyFilter(FilterSet):
    date = IsoDateFilter(field_name='f', lookup_expr='exact', method='date_filter')
    not_date = IsoDateFilter(field_name='f', lookup_expr='exact', exclude=True, method='date_filter')
    date_before = IsoDateFilter(field_name='f', lookup_expr='lte', method='date_filter')

    def date_filter(self, qs, field_name, value):
        ...
```

With the current implementation, it's not possible for `date_filter` to differentiate between the three filters, as only the `field_name` is provided as context, and all three filters reference the same field.

Current workarounds involve either abusing the `field_name` to provide both the attr/field names (e.g., `field_name="<attr name>-<field name>"`) or to use `functools.partialmethod`. e.g., 

```python
class MyFilter(FilterSet):
    date = IsoDateFilter(field_name='f', lookup_expr='exact', method='date_filter')
    not_date = IsoDateFilter(field_name='f', lookup_expr='exact', exclude=True, method='not_date_filter')

    def generic_date_filter(self, qs, field_name, value, attr):
        f = self.filters[attr]
    
    date_filter = partialmethod(generic_date_filter, attr='date')
    not_date_filter = partialmethod(generic_date_filter, attr='not_date')
``` 

**Proposal:**
Change the signature to include the filter instance instead of the `field_name`. e.g., 

```python
    def filter_method(self, f, qs, value):
        ...

def filter_func(f, qs, value):
    ...
```

Because the first positional argument has changed from the `QuerySet` to a `Filter` instance, this should raise a loud, but easy to fix `AttributeError`. There might be a possible deprecation path here (check for `AttributeError` and object type, then retry with old signature call), or at a minimum, we can catch all `AttributeError`s and reraise with an explanatory message.

**TODO:**
- [ ] Try to implement deprecation path
- [ ] Documentation updates
- [ ] Migration entry