### PR TITLE
adding additional check for presence of field in filter

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -221,10 +221,11 @@ class BaseFilterSet(object):
         applied to the queryset before it is cached.
         """
         for name, value in self.form.cleaned_data.items():
-            queryset = self.filters[name].filter(queryset, value)
-            assert isinstance(queryset, models.QuerySet), \
-                "Expected '%s.%s' to return a QuerySet, but got a %s instead." \
-                % (type(self).__name__, name, type(queryset).__name__)
+            if name in self.filters:
+                queryset = self.filters[name].filter(queryset, value)
+                assert isinstance(queryset, models.QuerySet), \
+                    "Expected '%s.%s' to return a QuerySet, but got a %s instead." \
+                    % (type(self).__name__, name, type(queryset).__name__)
         return queryset
 
     @property


### PR DESCRIPTION
issue https://github.com/carltongibson/django-filter/issues/1151

test was failing with 

```
Traceback (most recent call last):
  File "/Desktop/django-filter/tests/rest_framework/test_filterset.py", line 81, in test_filter_queyset_with_extra_form_fields
    e.filter_queryset(queryset=queryset)
  File "/Desktop/django-filter/django_filters/filterset.py", line 225, in filter_queryset
    queryset = self.filters[name].filter(queryset, value)
KeyError: 'extra_field'
```