### PR TITLE
Documentation fix: missing Meta.fields

### DIFF
--- a/docs/guide/tips.txt
+++ b/docs/guide/tips.txt
@@ -207,6 +207,7 @@ behavior as an ``isnull`` filter.
 
         class Meta:
             model = MyModel
+            fields = []
 
 
 Using ``initial`` values as defaults


### PR DESCRIPTION
This example doesn't work as is, since a `FilterSet` with `Meta.model` requires `Meta.fields` (or `meta.exclude`).