### PR TITLE
Added filters that filter multiple values at once using multiwidgets and multivaluefields

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -15,6 +15,7 @@ from django_filters.fields import (
     IsoDateTimeRangeField,
     Lookup,
     LookupChoiceField,
+    MultiWidgetField,
     RangeField,
     TimeRangeField
 )
@@ -40,6 +41,22 @@ class LookupTests(TestCase):
     def test_empty_lookup_expr(self):
         with self.assertRaisesMessage(ValueError, ''):
             Lookup('Value', '')
+
+
+class MultiWidgetFieldTests(TestCase):
+
+    def test_field(self):
+        f = MultiWidgetField(fields=[forms.CharField(), forms.DecimalField()])
+        self.assertEqual(len(f.fields), 2)
+        self.assertEqual(len(f.widget.widgets), 2)
+
+    def test_clean(self):
+        f = MultiWidgetField(fields=[forms.CharField(required=False), forms.DecimalField(required=False)], require_all_fields=False, required=False)
+
+        self.assertEqual(
+            f.clean(['abcd', '12.34']),
+            ['abcd', to_d(12.34)])
+        self.assertIsNone(f.clean([None, None]))
 
 
 class RangeFieldTests(TestCase):

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -9,6 +9,7 @@ from django_filters.widgets import (
     LookupChoiceWidget,
     QueryArrayWidget,
     RangeWidget,
+    RelatedMultiWidget,
     SuffixedMultiWidget
 )
 
@@ -211,7 +212,34 @@ class SuffixedMultiWidgetTests(TestCase):
             suffixes = ['']
 
         a = A(widgets=[None])
-        self.assertEqual(a.decompress(None), [None, None])
+        self.assertEqual(a.decompress(None), [None])
+
+        class A(SuffixedMultiWidget):
+            suffixes = ['', 'a', 'b']
+
+        a = A(widgets=[None]*3)
+        self.assertEqual(a.decompress(None), [None]*3)
+
+    def test_passed_suffix(self):
+        a = SuffixedMultiWidget(suffixes=["a"], widgets=[None])
+        self.assertEqual(a.suffixes, ["a"])
+
+        class A(SuffixedMultiWidget):
+            suffixes = ["b"]
+
+        a = A(widgets=[None])
+        self.assertEqual(a.suffixes, ["b"])
+
+        a = A(suffixes=["a"], widgets=[None])
+        self.assertEqual(a.suffixes, ["a"])
+
+
+class RelatedWidgetTests(TestCase):
+
+    def test_suffixed(self):
+        a = RelatedMultiWidget(suffixes=[''], widgets=[None])
+        self.assertEqual(a.suffixed("a", ""), "a")
+        self.assertEqual(a.suffixed("a", "b"), "a__b")
 
 
 class RangeWidgetTests(TestCase):


### PR DESCRIPTION
This is a pretty basic implementation, but it can do a few fancy things like efficiently filtering to customers with at least one completed, unreturned purchase:
```
class CustomerFilter(filters.FilterSet):
    purchases = filters.RelatedMultiFilter(
        related_names=["completed", "returned"], distinct=True
    )
    class Meta:
        model = Customer
        fields = {}
```
```
Customer.objects.filter(purchases__complete=True, purchases__returned=False).distinct()
```
```
SELECT DISTINCT "customers"."id"
FROM "customers"
INNER JOIN "purchases" ON ("customers"."id" = "purchases"."customer_id")
WHERE ("purchases"."completed" = True and "purchases"."returned" = False);
```

Currently django-filter with two separate separate filters would return all customers with a completed purchase *and* an unreturned purchase (with no guarantee that they are the same purchase). See #745 and #1077 :
```
class CustomerFilter(filters.FilterSet):
    class Meta:
        model = Customer
        fields = {
            "purchases__completed": ["exact"],
            "purchases__returned": ["exact"],
        }
```
```
Customer.objects.filter(purchases__complete=True.filter(purchases__returned=False).distinct()
```
```
SELECT DISTINCT "customers"."id"
FROM "customers"
INNER JOIN "purchases" ON ("customers"."id" = "purchases"."customer_id")
INNER JOIN "purchases" T3 ON ("customers"."id" = T3."customer_id")
WHERE ("purchases"."completed" = True and T3."returned" = False);
```

This is similar to `RelatedFilter` in philipn/django-rest-framework-filters/pull/199, but without the use of subqueries which can be extremely slow for this sort of lookup.
```
class CustomerFilter(filters.FilterSet):
    purchases = filters.RelatedFilter(
        "PurchaseFilter", queryset=Purchase.objects.all(), lookups=["completed", "returned"]
    )
    class Meta:
        model = Product
```
```
subquery = Purchase.objects.filter(completed=True).filter(returned=False).values('pk')
Customer.objects.filter(purchases__in=subquery).distinct()
```
```
SELECT DISTINCT "customers"."id"
FROM "customers"
INNER JOIN "purchases" ON ("customers"."id" = "purchases"."customer_id")
WHERE "purchases"."id" IN (
    SELECT U0."id"
    FROM "purchases" U0
    WHERE (U0."completed" = True AND U0."returned" = False)
);
```

Having done all this, I'm not sure a `MultiWidget` is a good way to group filters. The main issue is that validation errors are always described at the `MultiWidget` level instead of the subwidget level (see https://stackoverflow.com/questions/12245887/how-to-render-validation-errors-in-a-multivaluefield-multiwidget-per-field). This makes validation error messages largely useless. Unfortunately this is a fairly core issue in django and not easily fixable.

The [django-rest-framework-filters](https://github.com/philipn/django-rest-framework-filters) approach of having a separate form for each `RelatedFilter` might be better.

If people really like this `MultiWidget` approach, the remaining work is:

* Handle related_names that result in a `ModelChoiceField` (currently errors due to no queryset)
* Change the `SuffixedMultiWidget` template to show suffixes to the user
* Rewrite `MultiValueField.clean` to raise more useful validation errors. The best approach is probably to to make [errors](https://github.com/django/django/blob/stable/3.0.x/django/forms/fields.py#L1006) a dictionary, but I'm not sure how to set the keys or how `Form` will interpret a dictionary.
* Write tests for fields.

I use django-rest-framework, so I don't have much experience with widgets, fields, and forms. 