### PR TITLE
Add group validation & filtering

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -81,6 +81,10 @@ class Filter(object):
         self.creation_counter = Filter.creation_counter
         Filter.creation_counter += 1
 
+        # Set during parent FilterSet class creation
+        self.parent = None
+        self.model = None
+
         # TODO: remove assertion in 2.1
         assert not isinstance(self.lookup_expr, (type(None), list)), \
             "The `lookup_expr` argument no longer accepts `None` or a list of " \
@@ -117,7 +121,7 @@ class Filter(object):
 
     def label():
         def fget(self):
-            if self._label is None and hasattr(self, 'model'):
+            if self._label is None and self.model is not None:
                 self._label = label_for_filter(
                     self.model, self.field_name, self.lookup_expr, self.exclude
                 )
@@ -776,7 +780,7 @@ class FilterMethod(object):
             return instance.method
 
         # otherwise, method is the name of a method on the parent FilterSet.
-        assert hasattr(instance, 'parent'), \
+        assert instance.parent is not None, \
             "Filter '%s' must have a parent FilterSet to find '.%s()'" %  \
             (instance.field_name, instance.method)
 

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -56,6 +56,7 @@ class FilterSetOptions(object):
         self.model = getattr(options, 'model', None)
         self.fields = getattr(options, 'fields', None)
         self.exclude = getattr(options, 'exclude', None)
+        self.groups = getattr(options, 'groups', [])
 
         self.filter_overrides = getattr(options, 'filter_overrides', {})
 
@@ -193,11 +194,17 @@ class BaseFilterSet(object):
         self.form_prefix = prefix
 
         self.filters = copy.deepcopy(self.base_filters)
+        self.groups = copy.deepcopy(self._meta.groups)
 
         # propagate the model and filterset to the filters
         for filter_ in self.filters.values():
             filter_.model = model
             filter_.parent = self
+
+        # propagate the model and filterset to the groups
+        for group in self.groups:
+            group.model = model
+            group.parent = self
 
     def is_valid(self):
         """
@@ -220,11 +227,21 @@ class BaseFilterSet(object):
         This method should be overridden if additional filtering needs to be
         applied to the queryset before it is cached.
         """
-        for name, value in self.form.cleaned_data.items():
+        cleaned_data = self.form.cleaned_data.copy()
+
+        # Extract the grouped data from the rest of the `cleaned_data`. This
+        # ensures that the original filter methods aren't called in addition
+        # to the group filter methods.
+        for group in self.groups:
+            group_data, cleaned_data = group.extract_data(cleaned_data)
+            queryset = group.filter(queryset, **group_data)
+
+        for name, value in cleaned_data.items():
             queryset = self.filters[name].filter(queryset, value)
             assert isinstance(queryset, models.QuerySet), \
                 "Expected '%s.%s' to return a QuerySet, but got a %s instead." \
                 % (type(self).__name__, name, type(queryset).__name__)
+
         return queryset
 
     @property
@@ -245,12 +262,24 @@ class BaseFilterSet(object):
         This method should be overridden if the form class needs to be
         customized relative to the filterset instance.
         """
+        class FilterSetForm(forms.Form):
+            def clean(form):
+                cleaned_data = super().clean()
+
+                for group in self.groups:
+                    # Ignore the modified `cleaned_data`, as we only want to remove
+                    # data on error, which is accomplished through `form.add_error`.
+                    group_data, _ = group.extract_data(cleaned_data)
+                    group.validate(form, **group_data)
+
+                return cleaned_data
+
         fields = OrderedDict([
             (name, filter_.field)
             for name, filter_ in self.filters.items()])
 
         return type(str('%sForm' % self.__class__.__name__),
-                    (self._meta.form,), fields)
+                    (FilterSetForm, self._meta.form,), fields)
 
     @property
     def form(self):

--- a/django_filters/groups.py
+++ b/django_filters/groups.py
@@ -1,5 +1,6 @@
 import functools
 import operator
+from abc import abstractmethod
 
 from django.core.exceptions import ValidationError
 from django.db.models import Q
@@ -30,6 +31,7 @@ class BaseFilterGroup:
         self.parent = None
         self.model = None
 
+    @abstractmethod
     def validate(self, form, **data):
         """Validate the subset of cleaned data provided by the form.
 
@@ -42,6 +44,7 @@ class BaseFilterGroup:
         """
         raise NotImplementedError
 
+    @abstractmethod
     def filter(self, qs, **data):
         """Filter the result queryset with the subset of cleaned data.
 
@@ -49,6 +52,9 @@ class BaseFilterGroup:
             qs: The ``QuerySet`` instance to filter.
             **data: The subset of a form's ``cleaned_data`` for the filters in
                 the group.
+
+        Returns:
+            The filtered queryset instance.
         """
         raise NotImplementedError
 

--- a/django_filters/groups.py
+++ b/django_filters/groups.py
@@ -1,0 +1,283 @@
+import functools
+import operator
+
+from django.core.exceptions import ValidationError
+from django.db.models import Q
+from django.db.models.constants import LOOKUP_SEP
+from django.utils.translation import ugettext as _
+
+from .constants import EMPTY_VALUES
+
+__all__ = [
+    'BaseFilterGroup', 'ExclusiveGroup', 'RequiredGroup',
+    'CombinedGroup', 'CombinedRequiredGroup',
+]
+
+
+class BaseFilterGroup:
+    """Base class for validating & filtering query parameters as a group."""
+
+    def __init__(self, filters):
+        if not filters or len(filters) < 2:
+            msg = "A filter group must contain at least two members."
+            raise ValueError(msg)
+        if len(set(filters)) != len(filters):
+            msg = "A filter group must not contain duplicate members."
+            raise ValueError(msg)
+        self.filters = filters
+
+        # Set during parent FilterSet initialization
+        self.parent = None
+        self.model = None
+
+    def validate(self, form, **data):
+        """Validate the subset of cleaned data provided by the form.
+
+        Args:
+            form: The underlying ``Form`` instance used to validate the query
+                params. A ``FilterGroup`` should add errors to this form using
+                ``form.add_error(<field name>, <error message>)``.
+            **data: The subset of a form's ``cleaned_data`` for the filters in
+                the group.
+        """
+        raise NotImplementedError
+
+    def filter(self, qs, **data):
+        """Filter the result queryset with the subset of cleaned data.
+
+        Args:
+            qs: The ``QuerySet`` instance to filter.
+            **data: The subset of a form's ``cleaned_data`` for the filters in
+                the group.
+        """
+        raise NotImplementedError
+
+    def format_labels(self, filters):
+        """Return a formatted string of labels for the given filter names.
+
+        This inspects the filter labels from the ``self.parent`` FilterSet,
+        and combines them into a formatted string. This string can then be
+        used in validation error messages.
+
+        Args:
+            filters: A list of filter names.
+
+        Returns:
+            The formatted string of labels. For example, if filters 'a', 'b',
+            and 'c' have corresponding labels 'Filter A', 'Filter B', and
+            'Filter C', then...
+
+            >>> group.format_labels(['a', 'b'])
+            "'Filter A' and 'Filter B'"
+
+            >>> group.format_labels(['a', 'b', 'c'])
+            "'Filter A', 'Filter B', and 'Filter C'"
+        """
+        labels = [self.parent.filters[name].label for name in filters]
+
+        if len(labels) == 2:
+            return "'%s' and '%s'" % tuple(labels)
+
+        # e.g., joined = "'A', 'B', and 'C'"
+        joined = ', '.join("'%s'" % l for l in labels)
+        joined = ', and '.join(joined.rsplit(', ', 1))
+        return joined
+
+    def extract_data(self, cleaned_data):
+        """Extract the subset of cleaned data for the filters in the group.
+
+        Note that this is an internal method called by the ``FilterSet``.
+        Subclasses should not need to call or override this method.
+
+        Args:
+            cleaned_data: The underlying form's ``cleaned_data`` dict.
+
+        Returns:
+            A two-tuple containing the dict subset of data for the filters in
+            the group, and the remainder of the original ``cleaned_data`` dict.
+        """
+        # Create a copy so as to not modify the original data dict.
+        data = cleaned_data.copy()
+
+        return {
+            name: data.pop(name)
+            for name in self.filters
+            if name in data
+        }, data
+
+    def _filter_data(self, data):
+        # Helper for checking the extacted data.
+        # - Sanity check that correct data has been provided by the filterset.
+        # - Remove empty values that would normally be skipped by the
+        #     ``Filter.filter`` method.
+        assert set(data).issubset(set(self.filters)), (
+            "The `data` must be a subset of the group's `.filters`.")
+        return {k: v for k, v in data.items() if v not in EMPTY_VALUES}
+
+
+class ExclusiveGroup(BaseFilterGroup):
+    """A group of mutually exclusive filters.
+
+    If any filter in the group is included in the request data, then all other
+    filters in the group **must not** be present in the request data.
+
+    Attributes:
+        filters: The set of filter names to operate on.
+    """
+
+    def validate(self, form, **data):
+        data = self._filter_data(data)
+
+        if len(data) > 1:
+            err = ValidationError(
+                _('%(filters)s are mutually exclusive.'),
+                params={'filters': self.format_labels(self.filters)})
+
+            # The error message should include all filters (A, B, and C),
+            # but the error should only be raised for the given filters.
+            for param in data:
+                form.add_error(param, err)
+
+    def filter(self, qs, **data):
+        data = self._filter_data(data)
+        if not data:
+            return qs
+
+        assert len(data) <= 1, "The `data` should consist of only one element."
+
+        param, value = next(iter(data.items()))
+
+        return self.parent.filters[param].filter(qs, value)
+
+
+class RequiredGroup(BaseFilterGroup):
+    """A group of mutually required filters.
+
+    If any filter in the group is included in the request data, then all other
+    filters in the group **must** be present in the request data. Filtering is
+    still performed by the individual filters and is not combined via ``Q``
+    objects. To use ``Q`` objects instead (e.g., for OR-based filtering), use
+    the ``CombinedRequiredGroup``.
+
+    Attributes:
+        filters: The set of filter names to operate on.
+    """
+
+    def validate(self, form, **data):
+        data = self._filter_data(data)
+
+        if data and set(data) != set(self.filters):
+            err = ValidationError(
+                _('%(filters)s are mutually required.'),
+                params={'filters': self.format_labels(self.filters)})
+
+            # Unlike ``ExclusiveGroup``, the error should be raised for all
+            # filters since the missing filters are part of the error state.
+            for param in self.filters:
+                form.add_error(param, err)
+
+    def filter(self, qs, **data):
+        data = self._filter_data(data)
+
+        assert not data or len(data) == len(self.filters), (
+            "The `data` should contain all filters.")
+
+        # Filter by chaining the original filter method calls.
+        for param, value in data.items():
+            qs = self.parent.filters[param].filter(qs, value)
+
+        return qs
+
+
+class CombinedGroup(BaseFilterGroup):
+    """A group of filters that result in a combined query (a ``Q`` object).
+
+    This implementation combines ``Q`` objects *instead* of chaining
+    ``.filter()`` calls. The ``Q`` objects are generated from the filter's
+    ``field_name``, ``lookup_expr``, and ``exclude`` attributes, and the
+    resulting queryset will call ``.distinct()`` if set on any of the filters.
+
+    In short, instead of generating the following filter call:
+
+    .. code-block:: python
+
+        qs.filter(a=1).filter(b=2)
+
+    This group would generate a call like:
+
+    .. code-block:: python
+
+        qs.filter(Q(a=1) & Q(b=2))
+
+    This is useful for enabling OR filtering, as well as combining filters that
+    span multi-valued relationships (`more info`__).
+
+    __ https://docs.djangoproject.com/en/stable/topics/db/queries/#spanning-multi-valued-relationships
+
+    Attributes:
+        filters: The set of filter names to operate on.
+        combine: A function that combines two ``Q`` objects. Defaults to
+            ``operator.and_``. For OR operations, use ``operator.or_``.
+    """
+
+    def __init__(self, filters, combine=operator.and_):
+        super().__init__(filters)
+        self.combine = combine
+
+    def validate(self, form, **data):
+        # CombinedGroup has no specific validation rules.
+        self._filter_data(data)
+
+    def filter(self, qs, **data):
+        data = self._filter_data(data)
+
+        if not data:
+            return qs
+
+        # Filter by combining the set of constructed Q objects.
+        qs = qs.filter(functools.reduce(self.combine, [
+            self.build_q_object(param, value)
+            for param, value in data.items()]))
+
+        # If any filter is marked as distinct, the qs should also be distinct.
+        if any(self.parent.filters[param].distinct for param in data):
+            qs = qs.distinct()
+
+        return qs
+
+    def build_q_object(self, filter_name, value):
+        """Build a ``Q`` object for the given filter name and value.
+
+        The ``Q`` objects are generated from the filter's ``field_name``,
+        ``lookup_expr``, and ``exclude`` attributes.
+
+        Args:
+            filter_name: The name of the filter to base the ``Q`` object off of.
+            value: The value to filter within the ``Q`` object.
+
+        Returns:
+            A ``Q`` object that is reprentative of the filter and value.
+        """
+        f = self.parent.filters[filter_name]
+        q = Q(**{LOOKUP_SEP.join([f.field_name, f.lookup_expr]): value})
+        if f.exclude:
+            q = ~q
+
+        return q
+
+
+class CombinedRequiredGroup(CombinedGroup, RequiredGroup):
+    """A group of mutually required filters that result in a combined query.
+
+    This combines the validation logic of a ``RequiredGroup`` with the
+    filtering logic of a ``CombinedGroup``.
+
+    Attributes:
+        filters: The set of filter names to operate on.
+        combine: A function that combines two ``Q`` objects. Defaults to
+            ``operator.and_``. For OR operations, use ``operator.or_``.
+    """
+
+    def validate(self, form, **data):
+        # Use the validation provided by RequiredGroup
+        super(CombinedGroup, self).validate(form, **data)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,12 +11,13 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration -----------------------------------------------------
 
@@ -25,7 +26,10 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = []
+extensions = [
+  'sphinx.ext.autosummary',
+  'sphinx.ext.napoleon',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/guide/migration.txt
+++ b/docs/guide/migration.txt
@@ -72,9 +72,19 @@ FilterSet ``Meta.together`` option removed (`#791`__)
 -----------------------------------------------------
 __ https://github.com/carltongibson/django-filter/pull/791
 
-The ``Meta.together`` has been deprecated in favor of userland implementations
-that override the ``clean`` method of the ``Meta.form`` class. An example will
-be provided in a "recipes" section in future docs.
+The ``Meta.together`` has been deprecated, and has now been replaced by the
+``Meta.groups`` option, which provides a more generic and flexible interface.
+For more information, see the :doc:`group reference </ref/groups>`.
+
+.. code-block:: python
+
+    class ProductFilter(django_filters.FilterSet):
+        class Meta:
+            model = Product
+            fields = ['price', 'release_date', 'rating']
+            groups = [
+                RequiredGroup(['rating', 'price']),
+            ]
 
 
 FilterSet "strictness" handling moved to view (`#788`__)

--- a/docs/guide/usage.txt
+++ b/docs/guide/usage.txt
@@ -85,8 +85,8 @@ both transforms and a final lookup.
 .. _`lookup reference`: https://docs.djangoproject.com/en/stable/ref/models/lookups/#module-django.db.models.lookups
 
 
-Generating filters with Meta.fields
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Generating filters with ``Meta.fields``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The FilterSet Meta class provides a ``fields`` attribute that can be used for
 easily specifying multiple filters without significant code duplication. The
@@ -165,6 +165,26 @@ default filters for all the models fields of the same kind using
             }
 
 
+Process filters together with ``Meta.groups``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Filters can be added to a group, allowing them to be processed together. This
+overrides their validation and filtering behavior. In the example below,
+``first_name`` and ``last_name`` are mutually required. Filtering by one
+of the params requires that both are provided. For more information, see
+the :doc:`group reference </ref/groups>`.
+
+.. code-block:: python
+
+    class UserFilter(django_filters.FilterSet):
+        class Meta:
+            model = User
+            fields = ['username', 'first_name', 'last_name']
+            groups = [
+                RequiredGroup(['first_name', 'last_name']),
+            ]
+
+
 Request-based filtering
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -175,8 +195,8 @@ logged-in user or the ``Accepts-Languages`` header.
 
 .. note::
 
-    It is not guaranteed that a `request` will be provied to the `FilterSet`
-    instance. Any code depending on a request should handle the `None` case.
+    It is not guaranteed that a ``request`` will be provied to the ``FilterSet``
+    instance. Any code depending on a request should handle the ``None`` case.
 
 
 Filtering the primary ``.qs``

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -24,6 +24,7 @@ do this.
     ref/filterset
     ref/filters
     ref/fields
+    ref/groups
     ref/widgets
     ref/settings
 

--- a/docs/ref/filterset.txt
+++ b/docs/ref/filterset.txt
@@ -10,6 +10,7 @@ Meta options
 - :ref:`model <model>`
 - :ref:`fields <fields>`
 - :ref:`exclude <exclude>`
+- :ref:`groups <groups>`
 - :ref:`form <form>`
 - :ref:`filter_overrides <filter_overrides>`
 
@@ -87,6 +88,26 @@ declared directly  on the ``FilterSet``.
         class Meta:
             model = User
             exclude = ['password']
+
+
+.. _groups:
+
+Process filters together with ``groups``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``groups`` option accepts a list of ``BaseFilterGroup`` instances, enabling
+each group's filters to be validated and filtered together. For more information,
+see :doc:`group reference </ref/groups>`.
+
+.. code-block:: python
+
+    class UserFilter(django_filters.FilterSet):
+        class Meta:
+            model = User
+            fields = ['username', 'first_name', 'last_name']
+            groups = [
+                RequiredGroup(['first_name', 'last_name']),
+            ]
 
 
 .. _form:

--- a/docs/ref/groups.txt
+++ b/docs/ref/groups.txt
@@ -3,10 +3,9 @@ Group Reference
 ===============
 
 By default, a ``FilterSet`` validates and then filters its query parameters
-independently of each other, ultimately resulting in a sequence of chained
-``.filter()`` calls. Due to the nature of filter chaining, it's not trivial
-to, for example, make a group of filters mutually exclusive, or to OR them
-together into a single filter call.
+independently of each other, ultimately resulting in a chain of ``.filter()``
+calls. Due to the nature of filter chaining, it's not trivial to, for example,
+make a group of filters that are mutually exclusive to each other.
 
 Filter groups solve this limitation by processing subsets of parameters
 together, enabling higher level validation and filtering behavior.
@@ -15,9 +14,9 @@ Validation
 ==========
 
 A filter group only applies group-level validation. For example, a mutually
-exclusive group is only responsible for validating that one of its parameters
-is present. It is not responsible for individual value validation, which is
-still performed by the underlying filter instances.
+exclusive group is responsible for validating that *only* one of its parameters
+is present. It is not responsible for validating the individual values, which
+is still performed by the underlying filter instances.
 
 Filtering
 =========

--- a/docs/ref/groups.txt
+++ b/docs/ref/groups.txt
@@ -1,0 +1,65 @@
+===============
+Group Reference
+===============
+
+By default, a ``FilterSet`` validates and then filters its query parameters
+independently of each other, ultimately resulting in a sequence of chained
+``.filter()`` calls. Due to the nature of filter chaining, it's not trivial
+to, for example, make a group of filters mutually exclusive, or to OR them
+together into a single filter call.
+
+Filter groups solve this limitation by processing subsets of parameters
+together, enabling higher level validation and filtering behavior.
+
+Validation
+==========
+
+A filter group only applies group-level validation. For example, a mutually
+exclusive group is only responsible for validating that one of its parameters
+is present. It is not responsible for individual value validation, which is
+still performed by the underlying filter instances.
+
+Filtering
+=========
+
+In contrast to validation, a filter group overrides its filtering behavior.
+Internally, a group may use the ``.filter()`` methods of its filters, but it
+might also override it completely. For example, the ``RequiredGroup`` delegates
+filtering to each of its underlying filters, while ``CombinedRequiredGroup``
+constructs a ``Q`` object.
+
+Builtin Groups:
+===============
+
+.. module:: django_filters.groups
+
+.. autosummary::
+    BaseFilterGroup
+    ExclusiveGroup
+    RequiredGroup
+    CombinedGroup
+    CombinedRequiredGroup
+
+BaseFilterGroup
+---------------
+.. autoclass:: BaseFilterGroup
+
+    .. automethod:: validate
+    .. automethod:: filter
+    .. automethod:: format_labels
+
+ExclusiveGroup
+--------------
+.. autoclass:: ExclusiveGroup
+
+RequiredGroup
+-------------
+.. autoclass:: RequiredGroup
+
+CombinedGroup
+-------------
+.. autoclass:: CombinedGroup
+
+CombinedRequiredGroup
+---------------------
+.. autoclass:: CombinedRequiredGroup

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,15 @@
 [metadata]
 license-file = LICENSE
 
+[coverage:run]
+branch = true
+
+[coverage:report]
+show_missing = true
+exclude_lines =
+    pragma: no cover
+    raise NotImplementedError
+
 [isort]
 skip=.tox
 atomic=true

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -51,13 +51,8 @@ from tests.models import Book, User
 
 
 class ModuleImportTests(TestCase):
-    def is_filter(self, name, value):
-        return (
-            isinstance(value, type) and issubclass(value, Filter)
-        )
 
     def test_imports(self):
-        # msg = "Expected `filters.%s` to be imported in `filters.__all__`"
         filter_classes = [
             key for key, value
             in inspect.getmembers(filters)
@@ -68,8 +63,8 @@ class ModuleImportTests(TestCase):
         self.assertIn('Filter', filter_classes)
         self.assertIn('BooleanFilter', filter_classes)
 
-        for f in filter_classes:
-            self.assertIn(f, filters.__all__)
+        # Ensure all filter subclasses are included in filters.__all__
+        self.assertSetEqual(set(filter_classes), set(filters.__all__))
 
 
 class FilterTests(TestCase):

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -781,12 +781,10 @@ class FilterMethodTests(TestCase):
 
     def test_parent_unresolvable(self):
         f = Filter(method='filter_f')
-        with self.assertRaises(AssertionError) as w:
-            f.filter(User.objects.all(), 0)
 
-        self.assertIn("'None'", str(w.exception))
-        self.assertIn('parent', str(w.exception))
-        self.assertIn('filter_f', str(w.exception))
+        msg = "Filter 'None' must have a parent FilterSet to find '.filter_f()'"
+        with self.assertRaisesMessage(AssertionError, msg):
+            f.filter(User.objects.all(), 0)
 
     def test_method_self_is_parent(self):
         # Ensure the method isn't 're-parented' on the `FilterMethod` helper class.

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -20,6 +20,7 @@ from django_filters.filters import (
     UUIDFilter
 )
 from django_filters.filterset import FILTER_FOR_DBFIELD_DEFAULTS, FilterSet
+from django_filters.groups import RequiredGroup
 from django_filters.widgets import BooleanWidget
 
 from .models import (
@@ -625,7 +626,8 @@ class FilterSetInstantiationTests(TestCase):
     class F(FilterSet):
         class Meta:
             model = User
-            fields = ['username']
+            fields = ['username', 'first_name', 'last_name']
+            groups = [RequiredGroup(['first_name', 'last_name'])]
 
     def test_creating_instance(self):
         f = self.F()
@@ -651,6 +653,18 @@ class FilterSetInstantiationTests(TestCase):
         m = mock.Mock()
         f = self.F(request=m)
         self.assertEqual(f.request, m)
+
+    def test_filter_parent_and_model_set(self):
+        filterset = self.F({})
+        f = filterset.filters['username']
+        self.assertIs(f.parent, filterset)
+        self.assertIs(f.model, User)
+
+    def test_group_parent_and_model_set(self):
+        filterset = self.F({})
+        g = filterset.groups[0]
+        self.assertIs(g.parent, filterset)
+        self.assertIs(g.model, User)
 
 
 class FilterSetQuerysetTests(TestCase):

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -1,0 +1,415 @@
+import inspect
+from unittest import mock
+
+from django.db.models import Q
+from django.test import TestCase
+
+from django_filters import FilterSet, filters, groups
+from django_filters.groups import BaseFilterGroup
+
+
+class ModuleImportTests(TestCase):
+
+    def test_imports(self):
+        group_classes = [
+            key for key, value
+            in inspect.getmembers(groups)
+            if isinstance(value, type) and issubclass(value, BaseFilterGroup)
+        ]
+
+        # sanity check
+        self.assertIn('BaseFilterGroup', group_classes)
+        self.assertIn('ExclusiveGroup', group_classes)
+
+        # Ensure all group subclasses are included in groups.__all__
+        self.assertSetEqual(set(group_classes), set(groups.__all__))
+
+
+class FilterGroupInitTests(TestCase):
+
+    def test_valid(self):
+        group = BaseFilterGroup(['foo', 'bar'])
+        self.assertEqual(group.filters, ['foo', 'bar'])
+
+    def test_invalid_member_count(self):
+        invalid = [
+            ['foo'],
+            [],
+            None,
+        ]
+
+        msg = "A filter group must contain at least two members."
+        for names in invalid:
+            with self.subTest(filters=names):
+                with self.assertRaisesMessage(ValueError, msg):
+                    BaseFilterGroup(names)
+
+    def test_duplicate_members(self):
+        invalid = [
+            ['foo', 'foo'],
+            ['foo', 'bar', 'foo'],
+        ]
+
+        msg = "A filter group must not contain duplicate members."
+        for names in invalid:
+            with self.subTest(filters=names):
+                with self.assertRaisesMessage(ValueError, msg):
+                    BaseFilterGroup(names)
+
+
+class FilterGroupExtractDataTests(TestCase):
+
+    def test_original_data_unaltered(self):
+        # The cleaned_data dict should be unaltered
+        group = BaseFilterGroup(['foo', 'bar'])
+        cleaned_data = {'foo': 1, 'bar': 2, 'baz': 3}
+
+        # discard result - we're testing that input is unaltered
+        group.extract_data(cleaned_data)
+        self.assertEqual(cleaned_data, {'foo': 1, 'bar': 2, 'baz': 3})
+
+    def test_combined_result_matches_original(self):
+        group = BaseFilterGroup(['foo', 'bar'])
+        cleaned_data = {'foo': 1, 'bar': 2, 'baz': 3}
+
+        extract, rest = group.extract_data(cleaned_data)
+        self.assertEqual({**extract, **rest}, {'foo': 1, 'bar': 2, 'baz': 3})
+
+    def test_extract_not_in_rest(self):
+        group = BaseFilterGroup(['foo', 'bar'])
+        cleaned_data = {'foo': 1, 'bar': 2, 'baz': 3}
+
+        extract, rest = group.extract_data(cleaned_data)
+        self.assertEqual(set(extract) & set(rest), set())
+        self.assertEqual(set(extract) ^ set(rest), set(cleaned_data))
+
+    def test_missing_data(self):
+        group = BaseFilterGroup(['foo', 'bar'])
+        cleaned_data = {'foo': 1}
+
+        extract, _ = group.extract_data(cleaned_data)
+        self.assertEqual(extract, {'foo': 1})
+
+
+class FilterGroupFormatLabelsTests(TestCase):
+
+    def setUp(self):
+        class F(FilterSet):
+            foo = filters.CharFilter(label='who foo')
+            bar = filters.CharFilter(label='What bar')
+            baz = filters.CharFilter(label='When Baz')
+            qux = filters.CharFilter(label='Where QUX')
+
+        self.group = BaseFilterGroup(['foo', 'bar'])
+        self.group.parent = F(data={}, queryset=mock.Mock())
+
+    def test_format_labels(self):
+        # (names, expected)
+        cases = [
+            (['foo'], "'who foo'"),
+            (['foo', 'bar'], "'who foo' and 'What bar'"),
+            (['bar', 'foo'], "'What bar' and 'who foo'"),
+            (['foo', 'bar', 'baz'],
+                "'who foo', 'What bar', and 'When Baz'"),
+            (['foo', 'bar', 'baz', 'qux'],
+                "'who foo', 'What bar', 'When Baz', and 'Where QUX'"),
+        ]
+
+        for names, expected in cases:
+            with self.subTest(names=names):
+                self.assertEqual(self.group.format_labels(names), expected)
+
+
+class ConcreteFilterGroupSanityChecks:
+    group_class = None
+
+    class F(FilterSet):
+        foo = filters.CharFilter(label='foo')
+        bar = filters.CharFilter(label='bar')
+        baz = filters.CharFilter(label='baz')
+
+        ungrouped = filters.CharFilter(label='ungrouped')
+        distinct = filters.CharFilter(label='distinct', distinct=True)
+        negated = filters.CharFilter(label='negated', exclude=True)
+
+    def setUp(self):
+        self.group = self.group_class(['foo', 'bar', 'baz'])
+        self.group.parent = self.F(data={}, queryset=mock.Mock())
+
+    def test_validate_invalid_data(self):
+        msg = "The `data` must be a subset of the group's `.filters`."
+        with self.assertRaisesMessage(AssertionError, msg):
+            self.group.validate(None, invalid='param')
+
+        # 'ungrouped' filter not a member of the group
+        with self.assertRaisesMessage(AssertionError, msg):
+            self.group.validate(None, ungrouped='param')
+
+    def test_filter_invalid_data(self):
+        msg = "The `data` must be a subset of the group's `.filters`."
+        with self.assertRaisesMessage(AssertionError, msg):
+            self.group.filter(None, invalid='param')
+
+        # 'ungrouped' filter not a member of the group
+        with self.assertRaisesMessage(AssertionError, msg):
+            self.group.filter(None, ungrouped='param')
+
+
+class ExclusiveGroupTests(ConcreteFilterGroupSanityChecks, TestCase):
+    group_class = groups.ExclusiveGroup
+
+    def test_validation_error(self):
+        form = mock.Mock()
+
+        self.group.validate(form, foo='1', bar='2')
+
+        # get ValidationError
+        args, kwargs = form.add_error.call_args
+        exc = args[1]
+        msg = "'foo', 'bar', and 'baz' are mutually exclusive."
+
+        self.assertEqual(exc.messages, [msg])
+
+    def test_validate_none(self):
+        form = mock.Mock()
+
+        self.group.validate(form)
+
+        form.add_error.assert_not_called()
+
+    def test_validate_empty(self):
+        form = mock.Mock()
+
+        self.group.validate(form, foo='', bar='', baz='')
+
+        form.add_error.assert_not_called()
+
+    def test_validate_single(self):
+        form = mock.Mock()
+
+        self.group.validate(form, foo='1')
+        self.group.validate(form, bar='1')
+
+        form.add_error.assert_not_called()
+
+    def test_validate_multiple_partial(self):
+        # test if a partial set of filters are validated
+        form = mock.Mock()
+
+        self.group.validate(form, foo='1', bar='2')
+
+        form.add_error.assert_has_calls([
+            mock.call('foo', mock.ANY),
+            mock.call('bar', mock.ANY),
+        ], any_order=True)
+        self.assertEqual(form.add_error.call_count, 2)
+
+    def test_validate_multiple_all(self):
+        # test if the entire set of filters are validated
+        form = mock.Mock()
+
+        # sanity check to ensure there are 3 members
+        self.assertEqual(len(self.group.filters), 3)
+
+        self.group.validate(form, foo='1', bar='2', baz='3')
+
+        form.add_error.assert_has_calls([
+            mock.call('foo', mock.ANY),
+            mock.call('bar', mock.ANY),
+            mock.call('baz', mock.ANY),
+        ], any_order=True)
+        self.assertEqual(form.add_error.call_count, 3)
+
+    def test_filter_none(self):
+        qs = mock.Mock()
+
+        self.group.filter(qs)
+
+        qs.filter.assert_not_called()
+
+    def test_filter_single(self):
+        qs = mock.Mock()
+
+        self.group.filter(qs, foo='1')
+
+        qs.filter.assert_called_once_with(foo__exact='1')
+
+    def test_filter_multiple_partial(self):
+        msg = "The `data` should consist of only one element."
+        with self.assertRaisesMessage(AssertionError, msg):
+            self.group.filter(None, foo='1', bar='2')
+
+    def test_filter_multiple_all(self):
+        msg = "The `data` should consist of only one element."
+        with self.assertRaisesMessage(AssertionError, msg):
+            self.group.filter(None, foo='1', bar='2', baz='3')
+
+
+class RequiredGroupTests(ConcreteFilterGroupSanityChecks, TestCase):
+    group_class = groups.RequiredGroup
+
+    def test_validation_error(self):
+        form = mock.Mock()
+
+        self.group.validate(form, foo='1', bar='2')
+
+        # get ValidationError
+        args, kwargs = form.add_error.call_args
+        exc = args[1]
+        msg = "'foo', 'bar', and 'baz' are mutually required."
+
+        self.assertEqual(exc.messages, [msg])
+
+    def test_validate_none(self):
+        form = mock.Mock()
+
+        self.group.validate(form)
+
+        form.add_error.assert_not_called()
+
+    def test_validate_empty(self):
+        form = mock.Mock()
+
+        self.group.validate(form, foo='', bar='', baz='')
+
+        form.add_error.assert_not_called()
+
+    def test_validate_single(self):
+        form = mock.Mock()
+
+        self.group.validate(form, foo='1')
+
+        form.add_error.assert_has_calls([
+            mock.call('foo', mock.ANY),
+            mock.call('bar', mock.ANY),
+            mock.call('baz', mock.ANY),
+        ], any_order=True)
+        self.assertEqual(form.add_error.call_count, 3)
+
+    def test_validate_multiple_partial(self):
+        # test if a partial set of filters are validated
+        form = mock.Mock()
+
+        self.group.validate(form, foo='1', bar='2')
+
+        form.add_error.assert_has_calls([
+            mock.call('foo', mock.ANY),
+            mock.call('bar', mock.ANY),
+            mock.call('baz', mock.ANY),
+        ], any_order=True)
+        self.assertEqual(form.add_error.call_count, 3)
+
+    def test_validate_multiple_all(self):
+        # test if the entire set of filters are validated
+        form = mock.Mock()
+
+        # sanity check to ensure there are 3 members
+        self.assertEqual(len(self.group.filters), 3)
+
+        self.group.validate(form, foo='1', bar='2', baz='3')
+
+        form.add_error.assert_not_called()
+
+    def test_filter_none(self):
+        qs = mock.Mock()
+
+        self.group.filter(qs)
+
+        qs.filter.assert_not_called()
+
+    def test_filter_single(self):
+        msg = "The `data` should contain all filters."
+        with self.assertRaisesMessage(AssertionError, msg):
+            self.group.filter(None, foo='1')
+
+    def test_filter_multiple_partial(self):
+        msg = "The `data` should contain all filters."
+        with self.assertRaisesMessage(AssertionError, msg):
+            self.group.filter(None, foo='1', bar='2')
+
+    def test_filter_multiple_all(self):
+        qs = mock.Mock()
+
+        self.group.filter(qs, foo='1', bar='2', baz='3')
+
+        # need to sort calls since call order not guaranteed
+        self.assertEqual(sorted(qs.filter.mock_calls), [
+            mock.call(foo__exact='1'),
+            mock.call().filter(bar__exact='2'),
+            mock.call().filter().filter(baz__exact='3'),
+        ])
+
+
+class CombinedGroupTests(ConcreteFilterGroupSanityChecks, TestCase):
+    group_class = groups.CombinedGroup
+
+    def test_filter_none(self):
+        qs = mock.Mock()
+
+        self.group.filter(qs)
+
+        qs.filter.assert_not_called()
+
+    def test_filter_single(self):
+        qs = mock.Mock()
+
+        self.group.filter(qs, foo='1')
+
+        qs.filter.assert_called_once_with(Q(foo__exact='1'))
+
+    def test_filter_multiple(self):
+        qs = mock.Mock()
+
+        self.group.filter(qs, foo='1', bar='2', baz='3')
+
+        # Unpack Q object from filter call args
+        args, _ = qs.filter.call_args
+        q_obj, = args  # note that `,` unpacks the list
+
+        self.assertEqual(q_obj.connector, 'AND')
+        self.assertEqual(sorted(q_obj.children), [
+            ('bar__exact', '2'),
+            ('baz__exact', '3'),
+            ('foo__exact', '1'),
+        ])
+
+    def test_filter_distinct(self):
+        qs = mock.Mock()
+        group = self.group_class(['foo', 'distinct'])
+        group.parent = self.F(data={}, queryset=mock.Mock())
+
+        group.filter(qs, foo='1', distinct='2')
+
+        # Unpack Q object from filter call args
+        args, _ = qs.filter.call_args
+        q_obj, = args  # note that `,` unpacks the list
+
+        # need to sort calls since call order not guaranteed
+        self.assertEqual(q_obj.connector, 'AND')
+        self.assertEqual(sorted(q_obj.children), [
+            ('distinct__exact', '2'),
+            ('foo__exact', '1'),
+        ])
+
+        qs.filter().distinct.assert_called_once()
+
+    def test_filter_negation(self):
+        q_obj = self.group.build_q_object('negated', '1')
+        self.assertEqual(q_obj, ~Q(negated__exact='1'))
+
+
+class CombinedRequiredGroupTests(ConcreteFilterGroupSanityChecks, TestCase):
+    group_class = groups.CombinedRequiredGroup
+
+    test_validation_error = RequiredGroupTests.test_validation_error
+    test_validate_none = RequiredGroupTests.test_validate_none
+    test_validate_empty = RequiredGroupTests.test_validate_empty
+    test_validate_single = RequiredGroupTests.test_validate_single
+    test_validate_multiple_partial = RequiredGroupTests.test_validate_multiple_partial
+    test_validate_multiple_all = RequiredGroupTests.test_validate_multiple_all
+
+    test_filter_none = CombinedGroupTests.test_filter_none
+    test_filter_single = CombinedGroupTests.test_filter_single
+    test_filter_multiple = CombinedGroupTests.test_filter_multiple
+    test_filter_distinct = CombinedGroupTests.test_filter_distinct
+    test_filter_negation = CombinedGroupTests.test_filter_negation


### PR DESCRIPTION
This PR introduces a `Meta.groups` option to the `FilterSet`, which allows users to define groups of `Filter`s that override the validation and filtering behavior for the filters in that group. Example:

```python
class UserFilter(django_filters.FilterSet):
    class Meta:
        model = User
        fields = ['username', 'first_name', 'last_name']
        groups = [
            RequiredGroup(['first_name', 'last_name']),
        ]
```

In the above, both `first_name` and `last_name` are mutually required, so if one of the filter params is provided, then both must be provided. 

This PR should resolve #1020 and is an alternative to #1164 (cc @jonathan-golorry, any thoughts on this PR as an alternative to yours?).

**Context:**

Users periodically request how to validate and filter against multiple parameters. The goto advice has been to implement something based on `MultiWidget`, however there are three main deficiencies in my mind:

- It's verbose, users will typically need to subclass `MultiWidget`, `MultiValueField`, and `Filter`.
- It's difficult to implement. For new Django users, the `MultiWidget`/`MultiValueField` API is somewhat confusing (maybe I just didn't grok it for some reason, but I remember struggling with it in the past)
- As mentioned elsewhere, validation errors don't account for sub-widgets and are raised under the unsuffixed parameter name. This is acceptable for forms usage, where all sub widgets and errors are rendered together, but this mismatch doesn't work in an API context. You might have query params `foo_min` and `foo_max`, but the errors are reported as `foo`.

I think this ultimately stems from a mismatch in expectations. Filters are generally designed to operate on a single query parameter, while `MultiWidget` is not. Aside from the difficulties in implementing, there are other limitations elsewhere (e.g., lack of schema support).

**Proposal:**

In contrast to a `MultiWidget`-based approach, `Meta.groups` are specially handled by the filterset and provided its entire set of filter params. Groups must implement both validation and filtering, however they are slightly different. 

- Group validation is only intended to validate the qualities of the group. For example, an `ExclusiveGroup` would validate that only one of its mutually exclusive parameters is provided. Validation of the individual filter parameters is still performed by the filter's underlying form field.
- In contrast, group filtering completely overrides how filtering is performed for that set of filters. Internally, a group may still delegate to the underlying `Filter.filter` methods, however this is up to the group's implementation. For example, `RequiredGroup` calls the `filter` methods of its individual filters, while `CombinedRequiredGroup` constructs Q objects that are combined via `&` or `|` (or some other function). 

In total, this PR implements four groups:

Name | Description
-- | --
ExclusiveGroup(filters) | A group of mutually exclusive filters.
RequiredGroup(filters) | A group of mutually required filters.
CombinedGroup(filters[, combine]) | A group of filters that result in a combined query (a Q object).
CombinedRequiredGroup(filters[, combine]) | A group of mutually required filters that result in a combined query.

**Notes:**
- `RequiredGroup` effectively provides an alternative for the old `Meta.together` option.
- Rendered docs can be found at https://rpkilby.github.io/django-filter/ref/groups.html
- One objective of the PR was to merge docstrings into the actual site docs. The idea being that this reduces potential duplication. The docs page provides some structure/prose, and class/method docstrings are inserted where appropriate. If this style is 👍, then I'd want to eventually want to look into overhauling the rest of the reference docs in a similar manner.
- Code changes/additions are actually fairly minimal. Most of the lines are docs/docstrings/tests.

**TODO:**
- [ ] How is the clarity of the docs? What parts don't make sense?
- [ ] Are better code examples needed?