### PR TITLE
Feature: Override keyword arguments passed to the form

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 
-dist: xenial
+dist: bionic
 language: python
 python:
   - "3.5"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+Unreleased
+----------
+
+* Added ``FilterSet.get_form_kwargs()``, which allow to override keyword arguments
+  passed to the resulting form.
+
+
 Version 2.2 (2019-7-16)
 -----------------------
 

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -252,14 +252,21 @@ class BaseFilterSet(object):
         return type(str('%sForm' % self.__class__.__name__),
                     (self._meta.form,), fields)
 
+    def get_form_kwargs(self):
+        """
+        Return the keyword arguments for instantiating the form.
+        """
+        return {'prefix': self.form_prefix}
+
     @property
     def form(self):
         if not hasattr(self, '_form'):
             Form = self.get_form_class()
+            form_kwargs = self.get_form_kwargs()
             if self.is_bound:
-                self._form = Form(self.data, prefix=self.form_prefix)
+                self._form = Form(self.data, **form_kwargs)
             else:
-                self._form = Form(prefix=self.form_prefix)
+                self._form = Form(**form_kwargs)
         return self._form
 
     @classmethod

--- a/requirements/test-ci.txt
+++ b/requirements/test-ci.txt
@@ -1,4 +1,4 @@
-markdown==2.6.4
+markdown
 coreapi
 django-crispy-forms
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -51,6 +51,20 @@ class FilterSetFormTests(TestCase):
         f = F(prefix='prefix').form
         self.assertEqual(f.prefix, 'prefix')
 
+    def test_form_extra_kwargs(self):
+        class F(FilterSet):
+            class Meta:
+                model = Book
+                fields = ('title',)
+
+            def get_form_kwargs(self):
+                kwargs = super().get_form_kwargs()
+                kwargs.update(label_suffix='')
+                return kwargs
+
+        f = F().form
+        self.assertEqual(f.label_suffix, '')
+
     def test_form_fields(self):
         class F(FilterSet):
             class Meta:


### PR DESCRIPTION

- Added ``FilterSet.get_form_kwargs()``, which allow to override keyword arguments passed to the resulting form.
- Do not pin markdown version, latest DRF version expects a newer version.

```
======================================================================
ERROR: test_html_rendering (tests.rest_framework.test_integration.IntegrationTestFiltering)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/hsmett/Workspace/django-filter/tests/rest_framework/test_integration.py", line 287, in test_html_rendering
    response = view(request).render()
  File "/home/hsmett/.virtualenvs/django-filter/lib/python3.7/site-packages/django/template/response.py", line 105, in render
    self.content = self.rendered_content
  File "/home/hsmett/.virtualenvs/django-filter/lib/python3.7/site-packages/rest_framework/response.py", line 70, in rendered_content
    ret = renderer.render(self.data, accepted_media_type, context)
  File "/home/hsmett/.virtualenvs/django-filter/lib/python3.7/site-packages/rest_framework/renderers.py", line 724, in render
    context = self.get_context(data, accepted_media_type, renderer_context)
  File "/home/hsmett/.virtualenvs/django-filter/lib/python3.7/site-packages/rest_framework/renderers.py", line 686, in get_context
    'description': self.get_description(view, response.status_code),
  File "/home/hsmett/.virtualenvs/django-filter/lib/python3.7/site-packages/rest_framework/renderers.py", line 601, in get_description
    return view.get_view_description(html=True)
  File "/home/hsmett/.virtualenvs/django-filter/lib/python3.7/site-packages/rest_framework/views.py", line 245, in get_view_description
    return func(self, html)
  File "/home/hsmett/.virtualenvs/django-filter/lib/python3.7/site-packages/rest_framework/views.py", line 61, in get_view_description
    return formatting.markup_description(description)
  File "/home/hsmett/.virtualenvs/django-filter/lib/python3.7/site-packages/rest_framework/utils/formatting.py", line 63, in markup_description
    description = apply_markdown(description)
  File "/home/hsmett/.virtualenvs/django-filter/lib/python3.7/site-packages/rest_framework/compat.py", line 156, in apply_markdown
    md_filter_add_syntax_highlight(md)
  File "/home/hsmett/.virtualenvs/django-filter/lib/python3.7/site-packages/rest_framework/compat.py", line 213, in md_filter_add_syntax_highlight
    md.preprocessors.register(CodeBlockPreprocessor(), 'highlight', 40)
AttributeError: 'OrderedDict' object has no attribute 'register'
```