### PR TITLE
Use verbose name of the model field in generated filter fields

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -359,6 +359,7 @@ class BaseFilterSet(object):
 
     @classmethod
     def filter_for_field(cls, field, field_name, lookup_expr='exact'):
+        model = field.model
         field, lookup_type = resolve_field(field, lookup_expr)
 
         default = {
@@ -376,7 +377,9 @@ class BaseFilterSet(object):
             "#customise-filter-generation-with-filter-overrides"
         ) % (cls.__name__, field_name, lookup_expr, field.__class__.__name__)
 
-        return filter_class(**default)
+        f = filter_class(**default)
+        f.model = model
+        return f
 
     @classmethod
     def filter_for_lookup(cls, field, lookup_type):

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -260,7 +260,7 @@ class GetSchemaOperationParametersTests(TestCase):
                 'name': 'category',
                 'required': False,
                 'in': 'query',
-                'description': 'category',
+                'description': 'Category',
                 'schema': {
                     'type': 'string',
                     'enum': ['home', 'office']

--- a/tests/rest_framework/test_filterset.py
+++ b/tests/rest_framework/test_filterset.py
@@ -25,6 +25,11 @@ class FilterSetFilterForFieldTests(TestCase):
         self.assertIsInstance(result, filters.IsoDateTimeFilter)
         self.assertEqual(result.field_name, 'published')
 
+    def test_filter_label(self):
+        field = Article._meta.get_field('name')
+        result = FilterSet.filter_for_field(field, 'name')
+        self.assertEqual(result.label, 'Title')
+
     def test_booleanfilter_widget(self):
         field = User._meta.get_field('is_active')
         result = FilterSet.filter_for_field(field, 'is_active')


### PR DESCRIPTION
Currently if you have model:
```
class MyModel(models.Model):
  weight = models.IntegerField('weight of the model', null=True)
```
And you have filter:
```
class MyModelFilterSet(django_filters.FilterSet):
    class Meta:
        model = MyModel
        fields = ['weight']
```
Then if you generate schema for view that uses the above filter set, it will use 'weight' as description for `weight` field instead of the expected 'Weight of the model' text.

I was not sure if I should fix the issue in `get_filters` where it would look bit cleaner or in `filter_for_field` where it was easier to test.