### PR TITLE
Update CI

### DIFF
--- a/.azure_pipelines/azure-pipelines.yml
+++ b/.azure_pipelines/azure-pipelines.yml
@@ -32,7 +32,7 @@ steps:
   displayName: Ensure latest setuptools
 
 - script: |
-    pip install coverage tox tox-venv unittest-xml-reporting
+    pip install coverage tox unittest-xml-reporting
   displayName: Install deps
 
 - script: |

--- a/.azure_pipelines/azure-pipelines.yml
+++ b/.azure_pipelines/azure-pipelines.yml
@@ -6,13 +6,16 @@ strategy:
   matrix:
     PY35:
       PYTHON_VERSION: '3.5'
-      TOXENV: django111, django20, django21
+      TOXFACTOR: py35
     PY36:
       PYTHON_VERSION: '3.6'
+      TOXFACTOR: py36
     PY37:
       PYTHON_VERSION: '3.7'
+      TOXFACTOR: py37
     PY38:
       PYTHON_VERSION: '3.8'
+      TOXFACTOR: py38
 
     PY38_isort:
       PYTHON_VERSION: '3.8'
@@ -32,12 +35,13 @@ steps:
   displayName: Ensure latest setuptools
 
 - script: |
-    pip install coverage tox unittest-xml-reporting
+    pip install coverage tox tox-factor unittest-xml-reporting
   displayName: Install deps
 
 - script: |
     pip --version
-    tox --skip-missing-interpreters true
+    tox --version
+    tox
   displayName: Run tox
 
 - script: |

--- a/.azure_pipelines/azure-pipelines.yml
+++ b/.azure_pipelines/azure-pipelines.yml
@@ -4,22 +4,22 @@
 
 strategy:
   matrix:
-    # For some reason, Python 3.4 tries to install Django 2.0 - disabling for now
-    # PY34:
-    #   PYTHON_VERSION: '3.4'
     PY35:
       PYTHON_VERSION: '3.5'
       TOXENV: django111, django20, django21
     PY36:
       PYTHON_VERSION: '3.6'
-    PY36_isort:
-      PYTHON_VERSION: '3.6'
-      TOXENV: isort,lint,docs
-    PY36_warnings:
-      PYTHON_VERSION: '3.6'
-      TOXENV: warnings
     PY37:
       PYTHON_VERSION: '3.7'
+    PY38:
+      PYTHON_VERSION: '3.8'
+
+    PY38_isort:
+      PYTHON_VERSION: '3.8'
+      TOXENV: isort,lint,docs
+    PY38_warnings:
+      PYTHON_VERSION: '3.8'
+      TOXENV: warnings
 
 steps:
 - task: UsePythonVersion@0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
-sudo: false
-
-dist: xenial
+os: linux
+dist: bionic
 language: python
 python:
   - "3.5"
@@ -17,7 +16,7 @@ script:
   - coverage erase
   - tox
 
-matrix:
+jobs:
   fast_finish: true
   include:
     - python: "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
 cache: pip
 
 install:
-  - pip install coverage tox tox-travis tox-venv
+  - pip install coverage tox tox-travis
 
 script:
   - coverage erase

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
 os: linux
 dist: bionic
 language: python
-python:
-  - "3.5"
-  - "3.6"
-  - "3.7"
-  - "3.8"
 
 cache: pip
 
 install:
-  - pip install coverage tox tox-travis
+  - pip install coverage tox tox-factor
 
 script:
   - coverage erase
@@ -19,6 +14,11 @@ script:
 jobs:
   fast_finish: true
   include:
+    - { python: "3.5", env: TOXFACTOR=py35 }
+    - { python: "3.6", env: TOXFACTOR=py36 }
+    - { python: "3.7", env: TOXFACTOR=py37 }
+    - { python: "3.8", env: TOXFACTOR=py38 }
+
     - python: "3.8"
       env: TOXENV=isort,lint,docs
     - python: "3.8"

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ envlist =
        {py35,py36}-django20,
        {py35,py36,py37}-django21,
        {py35,py36,py37}-django22,
-       {py36,py37,38}-django30,
-       {py36,py37,38}-latest,
+       {py36,py37,py38}-django30,
+       {py36,py37,py38}-latest,
        isort,lint,docs,warnings,
 
 


### PR DESCRIPTION
Azure containers(?) seem to provide multiple versions of Python, so some of the jobs seemingly run the entire tox test suite, taking ~15 minutes to complete instead of ~2 ([example](https://dev.azure.com/noumenal/Django%20Filter/_build/results?buildId=252&view=results)).

This PR uses [tox-factor](https://github.com/rpkilby/tox-factor) (disclaimer, I wrote this plugin) to select Python-specific tox envs. Note that it works similarly to tox-travis, however factors are provided explicitly (e.g., `tox -f py38` or `TOXFACTOR=py38 tox`) instead of relying on the Travis environment to match tox envs. 

A few other changes:
- Virtualenv has undergone a rewrite, so `tox-venv` is no longer necessary.
- Various updates to the travis config (e.g., `sudo` no longer required, `matrix` => `jobs`).
- Add Python 3.8 to Azure, remove commented out Python 3.4, since no longer supported.