### PR TITLE
Drop Django 2.1 and below

### DIFF
--- a/django_filters/utils.py
+++ b/django_filters/utils.py
@@ -1,7 +1,6 @@
 import warnings
 from collections import OrderedDict
 
-import django
 from django.conf import settings
 from django.core.exceptions import FieldDoesNotExist, FieldError
 from django.db import models
@@ -196,9 +195,6 @@ def resolve_field(model_field, lookup_expr):
         while lookups:
             name = lookups[0]
             args = (lhs, name)
-            if django.VERSION < (2, 0):
-                # rest_of_lookups was removed in Django 2.0
-                args += (lookups,)
             # If there is just one part left, try first get_lookup() so
             # that if the lhs supports both transform and lookup for the
             # name, then lookup will be picked.

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,5 @@
 [tox]
 envlist =
-       {py35,py36}-django111,
-       {py35,py36}-django20,
-       {py35,py36,py37}-django21,
        {py35,py36,py37}-django22,
        {py36,py37,py38}-django30,
        {py36,py37,py38}-latest,
@@ -21,11 +18,8 @@ ignore_outcome =
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
-    django111: django==1.11.*
-    django20: django==2.0.*
-    django21: django==2.1.*
     django22: django==2.2.*
-    django30: django>=3.0,<3.1
+    django30: django>=3.0.*
     djangorestframework==3.10.*
     latest: {[latest]deps}
     -rrequirements/test-ci.txt

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ setenv =
 deps =
     django22: django==2.2.*
     django30: django>=3.0.*
-    djangorestframework==3.10.*
+    djangorestframework==3.11.*
     latest: {[latest]deps}
     -rrequirements/test-ci.txt
 


### PR DESCRIPTION
In addition to dropping Django 1.11, I also drop 2.0 and 2.1 since they're no longer supported.