### PR TITLE
Formalize filter binding to parent

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -83,6 +83,16 @@ class Filter(object):
         self.creation_counter = Filter.creation_counter
         Filter.creation_counter += 1
 
+    def bind(self, attr, parent):
+        """Bind the filter to its parent filterset.
+
+        Provides both the filter's attribute name on the filterset and the
+        parent filterset instance. Called when the parent is initialized.
+        """
+        self.attr = attr
+        self.parent = parent
+        self.model = parent.queryset.model
+
     def get_method(self, qs):
         """Return filter method based on whether we're excluding
            or simply filtering.

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -190,7 +190,6 @@ class BaseFilterSet(object):
     def __init__(self, data=None, queryset=None, *, request=None, prefix=None):
         if queryset is None:
             queryset = self._meta.model._default_manager.all()
-        model = queryset.model
 
         self.is_bound = data is not None
         self.data = data or {}
@@ -200,10 +199,8 @@ class BaseFilterSet(object):
 
         self.filters = copy.deepcopy(self.base_filters)
 
-        # propagate the model and filterset to the filters
-        for filter_ in self.filters.values():
-            filter_.model = model
-            filter_.parent = self
+        for filter_name, f in self.filters.items():
+            f.bind(filter_name, self)
 
     def is_valid(self):
         """

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1271,15 +1271,10 @@ class AllValuesFilterTests(TestCase):
             f.field
 
     def test_default_field_with_assigning_model(self):
-        mocked = mock.Mock()
-        chained_call = '.'.join(['_default_manager', 'distinct.return_value',
-                                 'order_by.return_value',
-                                 'values_list.return_value'])
-        mocked.configure_mock(**{chained_call: iter([])})
-        f = AllValuesFilter()
-        f.model = mocked
-        field = f.field
-        self.assertIsInstance(field, forms.ChoiceField)
+        f = AllValuesFilter(field_name='username')
+        f.bind('name', mock.Mock(queryset=User.objects.all()))
+
+        self.assertIsInstance(f.field, forms.ChoiceField)
 
     def test_empty_value_in_choices(self):
         f = AllValuesFilter(field_name='username')


### PR DESCRIPTION
Pulled this out of #1150, since it's relatively straightforward to review on its own. 

In short, this does two things:
- The filterset now calls a `bind` method, instead of setting attributes directly on the filter.
- The filter's param/filterset attribute name is also provided. This isn't 
