### PR TITLE
Fix descending choices building for OrderingFilter

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -737,14 +737,22 @@ class OrderingFilter(BaseCSVFilter, ChoiceFilter):
         ])
 
     def build_choices(self, fields, labels):
-        fields = {param: field for field, param in fields.items()}
         ascending = [
             (param, labels.get(field, _(pretty_name(param))))
-            for param, field in fields.items()
+            for field, param in fields.items()
+        ]
+
+        # Descending labels are more complicated:
+        # - Generated from parameter name
+        # - Generated from ascending label
+        # - Provided a descending label
+        descending = [
+            (field, param, self.descending_fmt % labels.get(field, _(pretty_name(param))))
+            for field, param in fields.items()
         ]
         descending = [
-            ('-%s' % param, labels.get('-%s' % fields[param], self.descending_fmt % label))
-            for param, label in ascending
+            ('-%s' % param, labels.get('-%s' % field, default_label))
+            for field, param, default_label in descending
         ]
 
         # interleave the ascending and descending choices

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -737,12 +737,13 @@ class OrderingFilter(BaseCSVFilter, ChoiceFilter):
         ])
 
     def build_choices(self, fields, labels):
+        fields = {param: field for field, param in fields.items()}
         ascending = [
             (param, labels.get(field, _(pretty_name(param))))
-            for field, param in fields.items()
+            for param, field in fields.items()
         ]
         descending = [
-            ('-%s' % param, labels.get('-%s' % param, self.descending_fmt % label))
+            ('-%s' % param, labels.get('-%s' % fields[param], self.descending_fmt % label))
             for param, label in ascending
         ]
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1508,17 +1508,19 @@ class OrderingFilterTests(TestCase):
 
     def test_field_labels_descending(self):
         f = OrderingFilter(
-            fields=['username'],
+            fields=(('a', 'c'), ('b', 'd')),
             field_labels={
-                'username': 'BLABLA',
-                '-username': 'XYZXYZ',
+                '-a': 'BLABLA',
+                '-b': 'XYZXYZ',
             }
         )
 
         self.assertEqual(list(f.field.choices), [
             ('', '---------'),
-            ('username', 'BLABLA'),
-            ('-username', 'XYZXYZ'),
+            ('c', 'C'),
+            ('-c', 'BLABLA'),
+            ('d', 'D'),
+            ('-d', 'XYZXYZ'),
         ])
 
     def test_normalize_fields(self):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1508,19 +1508,28 @@ class OrderingFilterTests(TestCase):
 
     def test_field_labels_descending(self):
         f = OrderingFilter(
-            fields=(('a', 'c'), ('b', 'd')),
+            fields=(('a', 'b'), ('c', 'd'), ('e', 'f')),
             field_labels={
-                '-a': 'BLABLA',
-                '-b': 'XYZXYZ',
+                'c': 'BLABLA',
+                'e': 'BLABLA',
+                '-e': 'XYZXYZ',
             }
         )
 
         self.assertEqual(list(f.field.choices), [
             ('', '---------'),
-            ('c', 'C'),
-            ('-c', 'BLABLA'),
-            ('d', 'D'),
-            ('-d', 'XYZXYZ'),
+
+            # Generates from prettified asc param name
+            ('b', 'B'),
+            ('-b', 'B (descending)'),
+
+            # Generates from provided asc label
+            ('d', 'BLABLA'),
+            ('-d', 'BLABLA (descending)'),
+
+            # Given desc label supersedes generated label
+            ('f', 'BLABLA'),
+            ('-f', 'XYZXYZ'),
         ])
 
     def test_normalize_fields(self):


### PR DESCRIPTION
Alternate to #1176, fixes #1175. 

It's a little more verbose, but I think a little more straightforward to understand, as #1176 inverts the field<>param dict, which is somewhat confusing.

Note that this might be made moot by #1118, although a similar test case should be incorporated.