### PR TITLE
docs: Fix simple typo, ususal -> usual

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1577,6 +1577,6 @@ class OrderingFilterTests(TestCase):
             ])
 
     def test_help_text(self):
-        # regression test for #756 - the ususal CSV help_text is not relevant to ordering filters.
+        # regression test for #756 - the usual CSV help_text is not relevant to ordering filters.
         self.assertEqual(OrderingFilter().field.help_text, '')
         self.assertEqual(OrderingFilter(help_text='a').field.help_text, 'a')


### PR DESCRIPTION
There is a small typo in tests/test_filters.py.

Should read `usual` rather than `ususal`.

