### PR TITLE
Fix class name in code sample

### DIFF
--- a/docs/guide/rest_framework.txt
+++ b/docs/guide/rest_framework.txt
@@ -133,7 +133,7 @@ You can override these methods on a case-by-case basis for each view, creating u
             return kwargs
 
 
-    class BooksFilter(filters.FilterSet):
+    class BookFilter(filters.FilterSet):
         def __init__(self, *args, author=None, **kwargs):
             super().__init__(*args, **kwargs)
             # do something w/ author


### PR DESCRIPTION
Change FilterSet subclass name so that it matches the filterset_class later in the sample:

https://github.com/carltongibson/django-filter/blob/c98e52d80d8deb626fe5f4826cf2872e79a86459/docs/guide/rest_framework.txt#L144