### PR TITLE
Rewrite filtering based on Q objects

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -382,7 +382,7 @@ class NumberFilter(Filter):
 class NumericRangeFilter(Filter):
     field_class = RangeField
 
-    def filter(self, qs, value):
+    def get_q_objects(self, value):
         if value:
             if value.start is not None and value.stop is not None:
                 value = (value.start, value.stop)
@@ -393,13 +393,13 @@ class NumericRangeFilter(Filter):
                 self.lookup_expr = 'endswith'
                 value = value.stop
 
-        return super().filter(qs, value)
+        return super().get_q_objects(value)
 
 
 class RangeFilter(Filter):
     field_class = RangeField
 
-    def filter(self, qs, value):
+    def get_q_objects(self, value):
         if value:
             if value.start is not None and value.stop is not None:
                 self.lookup_expr = 'range'
@@ -411,7 +411,7 @@ class RangeFilter(Filter):
                 self.lookup_expr = 'lte'
                 value = value.stop
 
-        return super().filter(qs, value)
+        return super().get_q_objects(value)
 
 
 def _truncate(dt):
@@ -664,12 +664,12 @@ class LookupChoiceFilter(Filter):
 
         return self._field
 
-    def filter(self, qs, lookup):
+    def get_q_objects(self, lookup):
         if not lookup:
-            return super(LookupChoiceFilter, self).filter(qs, None)
+            return super(LookupChoiceFilter, self).get_q_objects(None)
 
         self.lookup_expr = lookup.lookup_expr
-        return super(LookupChoiceFilter, self).filter(qs, lookup.value)
+        return super(LookupChoiceFilter, self).get_q_objects(lookup.value)
 
 
 class OrderingFilter(BaseCSVFilter, ChoiceFilter):
@@ -725,6 +725,9 @@ class OrderingFilter(BaseCSVFilter, ChoiceFilter):
         field_name = self.param_map.get(param, param)
 
         return "-%s" % field_name if descending else field_name
+
+    def get_q_objects(self, value):
+        return super().get_q_objects(None)
 
     def filter(self, qs, value):
         if value in EMPTY_VALUES:

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -5,6 +5,7 @@ import unittest
 from operator import attrgetter
 
 from django import forms
+from django.db import models
 from django.http import QueryDict
 from django.test import TestCase, override_settings
 from django.utils import timezone
@@ -1926,7 +1927,7 @@ class MiscFilterSetTests(TestCase):
 
         qs = MockQuerySet()
         F({'account': 'jdoe'}, queryset=qs).qs
-        qs.all.return_value.filter.assert_called_with(username__exact='jdoe')
+        qs.all.return_value.filter.assert_called_with(models.Q(username__exact='jdoe'))
 
     def test_filtering_without_meta(self):
         class F(FilterSet):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1048,7 +1048,8 @@ class DateRangeFilterTests(TestCase):
                 mock_td.call_args_list,
                 [mock.call(days=7), mock.call(days=1)]
             )
-            qs.filter.assert_called_once_with(models.Q(None__gte=mock_d1) & models.Q(None__lt=mock_d2) )
+            qs.filter.assert_called_once_with(
+                models.Q(None__gte=mock_d1) & models.Q(None__lt=mock_d2))
 
     def test_filtering_for_today(self):
         qs = mock.Mock(spec=['filter'])


### PR DESCRIPTION
This PR rewrites the filters to use Q objects instead of subsequent `filter()` calls. The goal is to provide a way to support arbitraty logic for combining filters in filtersets. The idea is that the `filter_queryset()` function would receive a list of **Q** objects, and by default it calls `filter` with each. If overridden, any custom logic could be supported.

Related to #1167. Groups could be implemented based on this new interface as well, but some discussion is needed there.

Problems to work on:
- Distinct calls are sometimes made before, sometimes after the filtering. What is the reason behind it?

@carltongibson What do you think of this PR? Does it worth finishing? Could you help me sort out the distinct calls?

Still left:
- [ ] Filterset filtering rewrite
- [ ] Doc update