### PR TITLE
Fix filter label serialization for OpenAPI

### DIFF
--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -2,6 +2,7 @@ import warnings
 
 from django.template import loader
 from django.utils.deprecation import RenameMethodsBase
+from django.utils.encoding import force_str
 
 from .. import compat, utils
 from . import filters, filterset
@@ -159,7 +160,7 @@ class DjangoFilterBackend(metaclass=RenameAttributes):
                 'name': field_name,
                 'required': field.extra['required'],
                 'in': 'query',
-                'description': field.label if field.label is not None else field_name,
+                'description': force_str(field.label) if field.label is not None else field_name,
                 'schema': {
                     'type': 'string',
                 },

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -4,6 +4,7 @@ from unittest import mock, skipIf
 from django.db.models import BooleanField
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.utils.translation import gettext_lazy as _
 from rest_framework import generics, serializers
 from rest_framework.test import APIRequestFactory
 
@@ -268,6 +269,17 @@ class GetSchemaOperationParametersTests(TestCase):
 
             }]
         )
+
+    def test_get_operation_parameters_with_lazy_text_as_label(self):
+        class LazyTextFilterSet(FilterSet):
+            text = filters.CharFilter(label=_('Text'))
+
+        class FilterableCategoryItemView(CategoryItemView):
+            filterset_class = LazyTextFilterSet
+
+        backend = DjangoFilterBackend()
+        fields = backend.get_schema_operation_parameters(FilterableCategoryItemView())
+        self.assertEqual(fields[0]['description'], 'Text')
 
 
 class TemplateTests(TestCase):


### PR DESCRIPTION
Consider the following case:

```
from django.utils.translation import ugettext_lazy as _

class NameFilterSet(django_filters.FilterSet):
    name = django_filters.CharFilter(label=_('Name'))
```

In OpenAPI it is rendered as 
```
      - name: name
        required: false
        in: query
        description: !!python/object/apply:django.utils.functional._lazy_proxy_unpickle
        - !!python/name:django.utils.translation.gettext ''
        - !!python/tuple
          - Name
        - {}
        - !!python/name:builtins.str ''
        schema:
          type: string
```

It happens because lazy string is not converted to Python string.