### PR TITLE
Feature: Add custom BooleanWidget choices

### DIFF
--- a/django_filters/widgets.py
+++ b/django_filters/widgets.py
@@ -156,10 +156,11 @@ class BooleanWidget(forms.Select):
     This can be used for AJAX queries that pass true/false from JavaScript's
     internal types through.
     """
-    def __init__(self, attrs=None):
-        choices = (('', _('Unknown')),
-                   ('true', _('Yes')),
-                   ('false', _('No')))
+    def __init__(self, attrs=None, choices=None):
+        if not choices:
+            choices = (('', _('Unknown')),
+                       ('true', _('Yes')),
+                       ('false', _('No')))
         super().__init__(attrs, choices)
 
     def render(self, name, value, attrs=None, renderer=None):

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -249,6 +249,18 @@ class BooleanWidgetTests(TestCase):
                 <option value="false">No</option>
             </select>""")
 
+    def test_widget_render_with_custom_choices(self):
+        choices = (('', 'Both'),
+                   ('true', 'True'),
+                   ('false', 'False'))
+        w = BooleanWidget(choices=choices)
+        self.assertHTMLEqual(w.render('price', ''), """
+            <select name="price">
+                <option selected="selected" value="">Both</option>
+                <option value="true">True</option>
+                <option value="false">False</option>
+            </select>""")
+
     def test_widget_value_from_datadict(self):
         """
         """


### PR DESCRIPTION
I've been using django-filter for about half a year so far and today was the first time I needed the boolean filter with custom choices. In my case "Unknown" doesn't sound correct and I believe it would be useful if we can apply custom choices. I considered adding an empty_label configuration or separate configs for true, false and empty but this looks like the cleanest solution. I'm open to suggestions.