### PR TITLE
Adjust tox dependencies. 

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -623,7 +623,7 @@ class LookupChoiceFilter(Filter):
             field = get_model_field(self.model, self.field_name)
             lookups = field.get_lookups()
 
-        return [self.normalize_lookup(l) for l in lookups]
+        return [self.normalize_lookup(lookup) for lookup in lookups]
 
     @property
     def field(self):

--- a/requirements/test-ci.txt
+++ b/requirements/test-ci.txt
@@ -1,4 +1,4 @@
-markdown==2.6.4
+markdown
 coreapi
 django-crispy-forms
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
     django22: django==2.2.*
-    django30: django>=3.0.*
+    django30: django~=3.0
     djangorestframework==3.11.*
     latest: {[latest]deps}
     -rrequirements/test-ci.txt


### PR DESCRIPTION
Curious CI failure after eca2c1fe45fbb84c198971b7ecc2d98e690c09e1. 

Experimenting, it doesn't seem markdown needs pinning any more. 