### PR TITLE
Fix tox deps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,9 +18,9 @@ ignore_outcome =
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
-    django22: django==2.2.*
-    django30: django~=3.0
-    djangorestframework==3.11.*
+    django22: django~=2.2.0
+    django30: django~=3.0.0
+    djangorestframework~=3.11.0
     latest: {[latest]deps}
     -rrequirements/test-ci.txt
 


### PR DESCRIPTION
Minor correction to #1218. `django~=3.0` is compatible with all versions of Django  3.x, we'd need to  pin against `django~=3.0.0`