### PR TITLE
Require tests to pass on `latest`.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,6 @@ deps =
 
 [testenv]
 commands = coverage run --parallel-mode --source django_filters ./runtests.py --testrunner xmlrunner.extra.djangotestrunner.XMLTestRunner {posargs}
-ignore_outcome =
-    latest: True
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =


### PR DESCRIPTION
What happens if we do this? 