### PR TITLE
Filter field schema operation parameters

### DIFF
--- a/django_filters/rest_framework/filters.py
+++ b/django_filters/rest_framework/filters.py
@@ -11,3 +11,27 @@ class BooleanFilter(filters.BooleanFilter):
         kwargs.setdefault('widget', BooleanWidget)
 
         super().__init__(*args, **kwargs)
+
+
+class IsoDateTimeFromToRangeFilter(filters.IsoDateTimeFromToRangeFilter):
+    def get_schema_operation_parameters(self, field_name):
+        return [
+            {
+                "name": field_name + "_before",
+                "required": self.extra["required"],
+                "in": "query",
+                "description": self.label + " formatted according to ISO 8601"
+                if self.label is not None
+                else field_name,
+                "schema": {"type": "string", "format": "dateTime"},
+            },
+            {
+                "name": field_name + "_after",
+                "required": self.extra["required"],
+                "in": "query",
+                "description": self.label + " formatted according to ISO 8601"
+                if self.label is not None
+                else field_name,
+                "schema": {"type": "string", "format": "dateTime"},
+            },
+        ]

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -11,6 +11,7 @@ from django_filters import compat, filters
 from django_filters.rest_framework import (
     DjangoFilterBackend,
     FilterSet,
+    IsoDateTimeFromToRangeFilter,
     backends
 )
 
@@ -268,6 +269,18 @@ class GetSchemaOperationParametersTests(TestCase):
 
             }]
         )
+
+    def test_get_schema_operation_parameters_from_filterset(self):
+
+        class Filter(FilterSet):
+            date = IsoDateTimeFromToRangeFilter()
+
+        backend = DjangoFilterBackend()
+        schema = backend.get_schema_operation_parameters_from_filterset(Filter)
+
+        fields = [f['name'] for f in schema]
+
+        self.assertEqual(fields, ['date_before', 'date_after'])
 
 
 class TemplateTests(TestCase):


### PR DESCRIPTION
In version 2.2 the `get_schema_operation_parameters()` is added for the `DjangoFilterBackend`. But at the moment there is no flexibility for the different filters, they all result in the same schema.  

To be more flexibel, this pull request adds the ability to let filters override the default operation parameter schema. It contains an implementation for the `IsoDateTimeFromToRangeFilter` as demonstration. 