### PR TITLE
Fixed #1243 -- isort v5.1 compatibility

### DIFF
--- a/django_filters/utils.py
+++ b/django_filters/utils.py
@@ -309,7 +309,7 @@ def translate_validation(error_dict):
     """
     # it's necessary to lazily import the exception, as it can otherwise create
     # an import loop when importing django_filters inside the project settings.
-    from rest_framework.exceptions import ValidationError, ErrorDetail
+    from rest_framework.exceptions import ErrorDetail, ValidationError
 
     exc = OrderedDict(
         (key, [ErrorDetail(e.message % (e.params or ()), code=e.code)

--- a/docs/dev/tests.txt
+++ b/docs/dev/tests.txt
@@ -81,7 +81,7 @@ the module imports with the appropriate `tox` env, or with `isort` directly.
     # or
 
     $ pip install isort
-    $ isort --check-only --recursive django_filters tests
+    $ isort --check --diff django_filters tests
 
 To sort the imports, simply remove the ``--check-only`` option.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ license-file = LICENSE
 skip=.tox
 atomic=true
 multi_line_output=3
-known_standard_library=mock
+extra_standard_library=mock
 known_third_party=django,pytz,rest_framework
 known_first_party=django_filters
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
     -rrequirements/test-ci.txt
 
 [testenv:isort]
-commands = isort --check-only --recursive django_filters tests {posargs}
+commands = isort --check-only --diff django_filters tests {posargs}
 deps = isort
 
 [testenv:lint]


### PR DESCRIPTION
* ordered imports with isort v5.1
* --recursive flag is no long required
* added --diff to output any errors to console
* use extra_standard_library to add module to known_standard_library (known_standard_library now overrides standard library modules)

Fixed #1243

