### PR TITLE
Changed `url` to `path`

### DIFF
--- a/tests/rest_framework/test_integration.py
+++ b/tests/rest_framework/test_integration.py
@@ -1,10 +1,9 @@
 import datetime
 from decimal import Decimal
 
-from django.conf.urls import url
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.urls import reverse
+from django.urls import path, reverse
 from django.utils.dateparse import parse_date
 from rest_framework import generics, serializers, status
 from rest_framework.test import APIRequestFactory
@@ -111,9 +110,9 @@ class GetQuerysetView(generics.ListCreateAPIView):
 
 
 urlpatterns = [
-    url(r'^(?P<pk>\d+)/$', FilterClassDetailView.as_view(), name='detail-view'),
-    url(r'^$', FilterClassRootView.as_view(), name='root-view'),
-    url(r'^get-queryset/$', GetQuerysetView.as_view(), name='get-queryset-view'),
+    path('<int:pk>/', FilterClassDetailView.as_view(), name='detail-view'),
+    path('', FilterClassRootView.as_view(), name='root-view'),
+    path('get-queryset/', GetQuerysetView.as_view(), name='get-queryset-view'),
 ]
 
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path
 
 from django_filters.views import FilterView, object_filter
 
@@ -10,6 +10,6 @@ def _foo():
 
 
 urlpatterns = [
-    url(r'^books-legacy/$', object_filter, {'model': Book, 'extra_context': {'foo': _foo, 'bar': 'foo'}}),
-    url(r'^books/$', FilterView.as_view(model=Book)),
+    path('books-legacy/', object_filter, {'model': Book, 'extra_context': {'foo': _foo, 'bar': 'foo'}}),
+    path('books/', FilterView.as_view(model=Book)),
 ]


### PR DESCRIPTION
* `url()` is deprecated in Django 3.1

Tests on Django master (and 3.1) are failing as `url()` is deprecated. 

https://travis-ci.org/github/carltongibson/django-filter/jobs/710026692