### PR TITLE
Changed model to use BooleanField(null=True)

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -47,7 +47,7 @@ class User(models.Model):
     status = models.IntegerField(choices=STATUS_CHOICES, default=0)
 
     is_active = models.BooleanField(default=False)
-    is_employed = models.NullBooleanField(default=False)
+    is_employed = models.BooleanField(null=True, default=False)
 
     favorite_books = models.ManyToManyField('Book', related_name='lovers')
 


### PR DESCRIPTION
* models.NullBooleanField is deprecated in Django 3.1

Fixes #1250 