### PR TITLE
Allow easy overriding of 'Unknown' in BooleanWidget

### DIFF
--- a/django_filters/widgets.py
+++ b/django_filters/widgets.py
@@ -156,8 +156,8 @@ class BooleanWidget(forms.Select):
     This can be used for AJAX queries that pass true/false from JavaScript's
     internal types through.
     """
-    def __init__(self, attrs=None):
-        choices = (('', _('Unknown')),
+    def __init__(self, attrs=None, empty_label=None):
+        choices = (('', empty_label if empty_label else _('Unknown')),
                    ('true', _('Yes')),
                    ('false', _('No')))
         super().__init__(attrs, choices)

--- a/django_filters/widgets.py
+++ b/django_filters/widgets.py
@@ -157,7 +157,7 @@ class BooleanWidget(forms.Select):
     internal types through.
     """
     def __init__(self, attrs=None, empty_label=None):
-        choices = (('', empty_label if empty_label else _('Unknown')),
+        choices = (('', empty_label or _('Unknown')),
                    ('true', _('Yes')),
                    ('false', _('No')))
         super().__init__(attrs, choices)


### PR DESCRIPTION
I've encountered situation where client wanted "Not selected" instead of "Unknown" so I had to copy paste entire class just to override the string. This little PR adds ability to easily override the text like this
```python
is_active = django_filters.BooleanFilter(widget=BooleanWidget(empty_label='Not selected'))
```