### PR TITLE
Run tests with GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,78 @@
+---
+name: Tests
+on: [push, pull_request]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Ensure latest setuptools
+        run: |
+          python -m pip install --upgrade pip setuptools
+      - name: Install dependencies
+        run: |
+          python -m pip install coverage tox tox-factor unittest-xml-reporting
+      - name: Run tox
+        run: |
+          python -m pip --version
+          python -m tox --version
+          python -m tox -f py$(python --version 2>&1 | cut -c 8,10)
+      - name: Coverage reporting
+        run: |
+          coverage combine
+          coverage report -m
+          coverage xml
+          coverage html
+      - name: Publish coverage results
+        uses: codecov/codecov-action@v1
+
+
+  isort:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Ensure latest setuptools
+        run: |
+          python -m pip install --upgrade pip setuptools
+      - name: Install dependencies
+        run: |
+          python -m pip install tox
+      - name: Run tox
+        run: |
+          python -m pip --version
+          python -m tox --version
+          python -m tox -e isort,lint,docs
+
+
+  warnings:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Ensure latest setuptools
+        run: |
+          python -m pip install --upgrade pip setuptools
+      - name: Install dependencies
+        run: |
+          python -m pip install tox
+      - name: Run tox
+        run: |
+          python -m pip --version
+          python -m tox --version
+          python -m tox -e warnings

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ setenv =
 deps =
     django22: django~=2.2.0
     django30: django~=3.0.0
-    django31: django>=3.1rc1,<3.2
+    django31: django~=3.1.0
     djangorestframework~=3.11.0
     latest: {[latest]deps}
     -rrequirements/test-ci.txt


### PR DESCRIPTION
If I've [understood correctly](https://github.com/microsoft/azure-pipelines-image-generation#former-repository-for-azure-pipelines-vm-images-for-microsoft-hosted-cicd), Azure Pipelines are deprecated in favor of GitHub Actions.

My actual goal was to run the tests against Python 3.9, but they are currently failing.  Therefore I've extracted the switch to GitHub Actions and will provide the rest in a separate PR.  (If you're interested in the failing test, see https://github.com/michael-k/django-filter/runs/1144983249?check_suite_focus=true)