### PR TITLE
Run tests against Python 3.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9.0-rc - 3.9]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9.0-rc - 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Full documentation on `read the docs`_.
 Requirements
 ------------
 
-* **Python**: 3.5, 3.6, 3.7, 3.8
+* **Python**: 3.5, 3.6, 3.7, 3.8, 3.9
 * **Django**: 2.2, 3.0, 3.1
 * **DRF**: 3.10+
 

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Framework :: Django',
     ],
     zip_safe=False,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,13 +3,19 @@ from unittest import mock
 from django.db import models
 
 
+class QuerySet(models.QuerySet):
+
+    def __bool__(self):
+        return True
+
+
 class MockQuerySet:
     """
     Generate a mock that is suitably similar to a QuerySet
     """
 
     def __new__(self):
-        m = mock.Mock(spec_set=models.QuerySet())
+        m = mock.Mock(spec_set=QuerySet())
         m.filter.return_value = m
         m.all.return_value = m
         return m

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
        {py35,py36,py37}-django22,
        {py36,py37,py38}-django30,
-       {py36,py37,py38}-django31,
-       {py36,py37,py38}-latest,
+       {py36,py37,py38,py39}-django31,
+       {py36,py37,py38,py39}-latest,
        isort,lint,docs,warnings,
 
 


### PR DESCRIPTION
The tests are currently failing.  I couldn't figure out why, but I haven't spent much time looking into it.

If someone else wants to address this, go for it.  Otherwise I'll free some time before Python 3.9.0 is released and try to fix this.

----

Python 3.9.0 final is expected on Monday, 2020-10-05, see https://www.python.org/dev/peps/pep-0596/#schedule