### PR TITLE
Added ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,18 @@ jobs:
       env: TOXENV=isort,lint,docs
     - python: "3.8"
       env: TOXENV=warnings
+    - { python: "3.5", env: TOXFACTOR=py35, arch: ppc64le }
+    - { python: "3.6", env: TOXFACTOR=py36, arch: ppc64le }
+    - { python: "3.7", env: TOXFACTOR=py37, arch: ppc64le }
+    - { python: "3.8", env: TOXFACTOR=py38, arch: ppc64le }
+
+    - python: "3.8"
+      env: TOXENV=isort,lint,docs
+      arch: ppc64le
+    - python: "3.8"
+      env: TOXENV=warnings
+      arch: ppc64le
+
   allow_failures:
     - env: TOXENV=warnings
 


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/django-filter/builds/186498238

Please have a look.

Regards,
Kishor Kunal Raj