### PR TITLE
GitHub Actions - speed and efficiency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,13 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: actions/cache@v2
+        name: Configure pip caching
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Ensure latest setuptools
         run: |
           python -m pip install --upgrade pip setuptools
@@ -45,6 +52,13 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+      - uses: actions/cache@v2
+        name: Configure pip caching
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Ensure latest setuptools
         run: |
           python -m pip install --upgrade pip setuptools
@@ -66,6 +80,13 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+      - uses: actions/cache@v2
+        name: Configure pip caching
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Ensure latest setuptools
         run: |
           python -m pip install --upgrade pip setuptools

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
         name: Configure pip caching
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/text-ci.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
       - name: Ensure latest setuptools
@@ -62,7 +62,7 @@ jobs:
         name: Configure pip caching
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/text-ci.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
       - name: Ensure latest setuptools
@@ -90,7 +90,7 @@ jobs:
         name: Configure pip caching
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/text-ci.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
       - name: Ensure latest setuptools

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
         name: Configure pip caching
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/text-ci.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/text-ci.txt', '**/tox.ini') }}
           restore-keys: |
             ${{ runner.os }}-pip-
       - name: Ensure latest setuptools
@@ -62,7 +62,7 @@ jobs:
         name: Configure pip caching
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/text-ci.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/text-ci.txt', '**/tox.ini') }}
           restore-keys: |
             ${{ runner.os }}-pip-
       - name: Ensure latest setuptools
@@ -90,7 +90,7 @@ jobs:
         name: Configure pip caching
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/text-ci.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/text-ci.txt', '**/tox.ini') }}
           restore-keys: |
             ${{ runner.os }}-pip-
       - name: Ensure latest setuptools

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,12 @@
 ---
 name: Tests
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   tests:

--- a/requirements/test-ci.txt
+++ b/requirements/test-ci.txt
@@ -1,8 +1,8 @@
-markdown==3.2.2
-coreapi==2.3.3
-django-crispy-forms==1.9.2
+markdown
+coreapi
+django-crispy-forms
 
-coverage==5.3
-mock==4.0.2
-pytz==2020.1
-unittest-xml-reporting==3.0.2
+coverage
+mock
+pytz
+unittest-xml-reporting

--- a/requirements/test-ci.txt
+++ b/requirements/test-ci.txt
@@ -1,8 +1,8 @@
-markdown
-coreapi
-django-crispy-forms
+markdown==3.2.2
+coreapi==2.3.3
+django-crispy-forms==1.9.2
 
-coverage
-mock
-pytz
-unittest-xml-reporting
+coverage==5.3
+mock==4.0.2
+pytz==2020.1
+unittest-xml-reporting==3.0.2


### PR DESCRIPTION
Hi @michael-k -- Thanks for your work on getting GitHub actions setup here. 

I've proposed a couple of small changes, do you have any comments on these?

The first is to enable caching of dependencies. This should reduce the run times and help reduce the amount of data transfer. 

The second is to reduce the scope of the actions so they are trigger on either push to master or a pull request to master - but not both. This is to reduce the amount of duplicate running, as seen here -- https://github.com/carltongibson/django-filter/pull/1272/checks. 

The second of these changes is supported by comments by GitHub Staff here -- https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662