### PR TITLE
Fix 1275: Make MaxValueValidator default an integer

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -358,11 +358,16 @@ class ModelMultipleChoiceFilter(QuerySetRequestMixin, MultipleChoiceFilter):
 class NumberFilter(Filter):
     field_class = forms.DecimalField
 
+    def __init__(self, *args, **kwargs):
+        self.max_value = kwargs.get('max_value', int(1e50))
+        super().__init__(*args, **kwargs)
+
     def get_max_validator(self):
         """
         Return a MaxValueValidator for the field, or None to disable.
         """
-        return MaxValueValidator(1e50)
+        if self.max_value is not None:
+            return MaxValueValidator(self.max_value)
 
     @property
     def field(self):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -267,5 +267,7 @@ class FilterSetValidityTests(TestCase):
         self.assertFalse(f.is_valid())
         self.assertEqual(
             f.errors,
-            {'average_rating': ['Ensure this value is less than or equal to 1e+50.']}
+            {'average_rating': [
+                f'Ensure this value is less than or equal to {int(1e+50)}.'
+                ]}
         )


### PR DESCRIPTION
This should fix the issue #1275 by making the default value an integer and providing the option to set the max value per filter instance