### PR TITLE
Fixed tox setup for 'lastest' env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
     django22: django~=2.2.0
     django30: django~=3.0.0
     django31: django~=3.1.0
-    !latest: djangorestframework~=3.11.0
+    !latest: djangorestframework~=3.12.0
     latest: {[latest]deps}
     -rrequirements/test-ci.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
     django22: django~=2.2.0
     django30: django~=3.0.0
     django31: django~=3.1.0
-    djangorestframework~=3.11.0
+    !latest: djangorestframework~=3.11.0
     latest: {[latest]deps}
     -rrequirements/test-ci.txt
 


### PR DESCRIPTION
Hi All -- I've been going fairly deep into the cache/github action topic. I think I've spotted something not quite right with the current tox setup.

With the current `tox` config the `latest` environment installs DRF from PyPI and "main branch" and PyPI "wins". Here are the relevant lines from a recent [test run](https://github.com/carltongibson/django-filter/runs/1186316036?check_suite_focus=true#step:6:52).

```py38-latest installdeps: djangorestframework~=3.11.0, https://github.com/django/django/archive/master.tar.gz, https://github.com/encode/django-rest-framework/archive/master.tar.gz, -rrequirements/test-ci.txt```

And a few lines lower down `py38-latest installed: ... djangorestframework==3.11.1`

The warnings [environment](https://github.com/carltongibson/django-filter/runs/1186316112?check_suite_focus=true#step:6:14) is set up differently and correctly installs from 'main branch' for both Django and DRF. 

I _think_ this is the fix required. This should install DRF from PyPI in all environments except `latest`. 

