### PR TITLE
Allow `is_valid` to raise a validation error when invalid

### DIFF
--- a/django_filters/rest_framework/filterset.py
+++ b/django_filters/rest_framework/filterset.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 
 from django.db import models
 from django.utils.translation import gettext_lazy as _
+from rest_framework.exceptions import ValidationError
 
 from django_filters import filterset
 
@@ -18,6 +19,8 @@ FILTER_FOR_DBFIELD_DEFAULTS.update({
 
 class FilterSet(filterset.FilterSet):
     FILTER_DEFAULTS = FILTER_FOR_DBFIELD_DEFAULTS
+
+    validation_error_class = ValidationError
 
     @property
     def form(self):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
 
 from django_filters.filters import CharFilter, ChoiceFilter
@@ -269,3 +270,10 @@ class FilterSetValidityTests(TestCase):
             f.errors,
             {'average_rating': ['Ensure this value is less than or equal to 1e+50.']}
         )
+
+    def test_raise_exception(self):
+        f = self.F({'price': 'four dollars'})
+        self.assertFalse(f.is_valid())
+
+        with self.assertRaises(ValidationError):
+            f.is_valid(raise_exception=True)


### PR DESCRIPTION
In the context of a DRF view, this allows `is_valid` to short-circuit the view and return a response stating the filter errors.

Currently this is possible to achieve with:

```python
        if not filterset.is_valid():
            raise ValidationError(filterset.errors)
```

But would be nice if the library could do that for you.
