### PR TITLE
Enable FilterMixin to work with non-GET methods

### DIFF
--- a/django_filters/views.py
+++ b/django_filters/views.py
@@ -49,7 +49,7 @@ class FilterMixin(metaclass=FilterMixinRenames):
         Returns the keyword arguments for instantiating the filterset.
         """
         kwargs = {
-            'data': self.request.GET or None,
+            'data': getattr(self.request, self.request.method, None) or None,
             'request': self.request,
         }
         try:

--- a/docs/guide/tips.txt
+++ b/docs/guide/tips.txt
@@ -288,3 +288,20 @@ using a simple FilterSet base class::
           filter = super(HelpfulFilterSet, cls).filter_for_field(f, name, lookup_expr)
           filter.extra['help_text'] = f.help_text
           return filter
+
+
+Accepting filters via POST
+--------------------------
+
+django-filter is designed to work with ``GET`` requests, but in
+certain cases it may be useful to process filters sent via other HTTP
+methods such as ``POST``. One such case would be if your web server
+restricts URL length and rejects requests with a large number of
+filters applied via ``GET``.
+
+To create a filter view that accepts ``POST`` requests, define a
+``post`` method that proxies through to ``get``::
+
+  class MyFilterView(FilterView):
+      def post(self, request, *args, **kwargs):
+          return super().get(request, *args, **kwargs)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -137,6 +137,21 @@ class GenericClassBasedViewTests(GenericViewTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(titles, ['Snowcrash'])
 
+    def test_view_with_post_method(self):
+        class MyFilterView(FilterView):
+            def post(self, request, *args, **kwargs):
+                return super().get(request, *args, **kwargs)
+
+        factory = RequestFactory()
+        request = factory.post(self.base_url, data={'title': 'Snowcrash'})
+        filterset = filterset_factory(Book)
+        view = MyFilterView.as_view(filterset_class=filterset)
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        for b in ["Ender's Game", 'Rainbow Six']:
+            self.assertNotContains(response, html.escape(b))
+        self.assertContains(response, 'Snowcrash')
+
 
 class GenericFunctionalViewTests(GenericViewTestCase):
     base_url = '/books-legacy/'


### PR DESCRIPTION
This implements a suggestion brought up in issue https://github.com/carltongibson/django-filter/issues/454#issuecomment-617583035 to make it easier for subclasses of `FilterView` to support HTTP post.

I've encountered a similar issue to @tadeo where our filters exceed the accepted URL length and had to be moved to post instead.

From reading #51 I understand that first-class post support is not endorsed so I stopped short of adding `def post` to `BaseFilterView`. I hope this alternative approach is more acceptable :) Thanks to @tadeo for the idea.