### PR TITLE
Allow greater flexibility with the queryset

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -236,13 +236,16 @@ class BaseFilterSet:
     @property
     def qs(self):
         if not hasattr(self, '_qs'):
-            qs = self.queryset.all()
+            qs = self.get_queryset()
             if self.is_bound:
                 # ensure form validation before filtering
                 self.errors
                 qs = self.filter_queryset(qs)
             self._qs = qs
         return self._qs
+    
+    def get_queryset(self):
+        return self.queryset.all()
 
     def get_form_class(self):
         """


### PR DESCRIPTION
I've needed to override `BaseFilterSet.qs` multiple times completely (no super) because of union queries.

I'd rather keep the underlying behavior from Base to be more resilient against updates, and it's a very simple fix.

Thanks!