### PR TITLE
fix openapi fields rendering for range type filters

### DIFF
--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -131,7 +131,10 @@ class DjangoFilterBackend(metaclass=RenameAttributes):
         except AttributeError:
             return [field_name]
         else:
-            return [field_name] if not suffixes else [f'{field_name}_{suffix}' for suffix in suffixes if suffix]
+            return [field_name] if not suffixes else [
+                '{}_{}'.format(field_name, suffix)
+                for suffix in suffixes if suffix
+            ]
 
     def get_schema_fields(self, view):
         # This is not compatible with widgets where the query param differs from the

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -8,11 +8,7 @@ from rest_framework import generics, serializers
 from rest_framework.test import APIRequestFactory
 
 from django_filters import compat, filters
-from django_filters.rest_framework import (
-    DjangoFilterBackend,
-    FilterSet,
-    backends
-)
+from django_filters.rest_framework import DjangoFilterBackend, FilterSet, backends
 
 from ..models import Article
 from .models import CategoryItem, FilterableItem

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -241,6 +241,45 @@ class GetSchemaFieldsTests(TestCase):
 
         self.assertEqual(fields, ['text', 'decimal', 'date', 'f'])
 
+    def test_fields_with_range_type_filter_default_suffixes(self):
+
+        class F(SeveralFieldsFilter):
+            date = filters.DateFromToRangeFilter()
+
+        class View(FilterClassRootView):
+            filterset_class = F
+
+        view = View()
+        backend = DjangoFilterBackend()
+        fields = backend.get_schema_fields(view)
+        field_names = [f.name for f in fields]
+
+        self.assertIn("date_after", field_names)
+        self.assertIn("date_before", field_names)
+
+    def test_fields_with_range_type_filter_with_custom_suffixes(self):
+        custom_suffixes = ['previous', 'later']
+
+        mock_widget = mock.Mock(suffixes=custom_suffixes)
+        mock_field_class = mock.Mock(widget=mock_widget)
+
+        class CustomDateFromtoRangeFilter(filters.DateFromToRangeFilter):
+            field_class = mock_field_class
+
+        class F(SeveralFieldsFilter):
+            date = CustomDateFromtoRangeFilter()
+
+        class View(FilterClassRootView):
+            filterset_class = F
+
+        view = View()
+
+        backend = DjangoFilterBackend()
+        fields = backend.get_schema_fields(view)
+        field_names = [f.name for f in fields]
+
+        for custom_suffix in custom_suffixes:
+            self.assertIn('date_{}'.format(custom_suffix), field_names)
 
 class GetSchemaOperationParametersTests(TestCase):
     def test_get_operation_parameters_with_filterset_fields_list(self):

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -277,6 +277,7 @@ class GetSchemaFieldsTests(TestCase):
         for custom_suffix in custom_suffixes:
             self.assertIn('date_{}'.format(custom_suffix), field_names)
 
+
 class GetSchemaOperationParametersTests(TestCase):
     def test_get_operation_parameters_with_filterset_fields_list(self):
         backend = DjangoFilterBackend()

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -8,7 +8,11 @@ from rest_framework import generics, serializers
 from rest_framework.test import APIRequestFactory
 
 from django_filters import compat, filters
-from django_filters.rest_framework import DjangoFilterBackend, FilterSet, backends
+from django_filters.rest_framework import (
+    DjangoFilterBackend,
+    FilterSet,
+    backends
+)
 
 from ..models import Article
 from .models import CategoryItem, FilterableItem


### PR DESCRIPTION
This fix is aimed at [Issue 1292](https://github.com/carltongibson/django-filter/issues/1292).

Within the ```get_schema_fields``` method on ```DjangoFilterBackend```. The coreapi field named tuples are made by looping over the filters retrieved from the filterset class. This change adds a check to see if there is widget which has been declared which in turn will provide us with the suffixes used to build range type fields. If no ```suffixes``` have been declared or the list is empty, then a single field will be rendered as normal with reference to the ```field_name```.

For example, the ```DateFromToRangeFilter``` requires 2 fields to be rendered on swagger. If say the field name is ```created_at``` then we would expect ```created_at_after``` and ```created_at_before``` to be rendered. The current implementation will only render a single field as ```created_at``` which won't work.
 