### PR TITLE
Fix JSON serialize for UUIDfield

### DIFF
--- a/django_filters/rest_framework/filterset.py
+++ b/django_filters/rest_framework/filterset.py
@@ -6,13 +6,14 @@ from django.utils.translation import gettext_lazy as _
 from django_filters import filterset
 
 from .. import compat
-from .filters import BooleanFilter, IsoDateTimeFilter
+from .filters import BooleanFilter, IsoDateTimeFilter, CharFilter
 
 FILTER_FOR_DBFIELD_DEFAULTS = deepcopy(filterset.FILTER_FOR_DBFIELD_DEFAULTS)
 FILTER_FOR_DBFIELD_DEFAULTS.update({
     models.DateTimeField: {'filter_class': IsoDateTimeFilter},
     models.BooleanField: {'filter_class': BooleanFilter},
     models.NullBooleanField: {'filter_class': BooleanFilter},
+    models.UUIDField: {'filter_class': CharFilter},
 })
 
 

--- a/django_filters/rest_framework/filterset.py
+++ b/django_filters/rest_framework/filterset.py
@@ -6,7 +6,7 @@ from django.utils.translation import gettext_lazy as _
 from django_filters import filterset
 
 from .. import compat
-from .filters import BooleanFilter, IsoDateTimeFilter, CharFilter
+from .filters import BooleanFilter, CharFilter, IsoDateTimeFilter
 
 FILTER_FOR_DBFIELD_DEFAULTS = deepcopy(filterset.FILTER_FOR_DBFIELD_DEFAULTS)
 FILTER_FOR_DBFIELD_DEFAULTS.update({


### PR DESCRIPTION
We have ```uid``` filed in ```FormModel```:
```python3
from django.db.models import Model, UUIDField

class FormModel(Model):
  ...
  uid = UUIDField()
  ...
```
And we have ```formData``` filed in ```UserDataModel```:
```python3
from django.db.models import Model, JSONField

class UserDataModel(Model):
  ...
  formData = JSONField()
  ...
```
And we have ```UserDataViewSet```:
```python3
from rest_framework.viewsets import ViewSet
from django_filters.rest_framework import DjangoFilterBackend

class UserDataViewSet(ViewSet):
  ...
  queryset = UserDataModel.objects.all()
  filter_backends = [DjangoFilterBackend]
  filterset_fields = ['formData__uid']
  ...
```
We put ```FormModel``` object serialized data to ```UserDataModel``` to ```formData``` filed like JSON.
For example:
```json
"formData": {"uid": "bb104046-7dbb-4105-aeb9-2e39de52e98e"}
```
And now we want to filter ```UserDataModel``` by ```formData__uid``` in ower ```UserDataViewSet```:
```python3
http://127.0.0.1/api/user_data/?formData__uid=bb104046-7dbb-4105-aeb9-2e39de52e98e
```
We get JSON serialize error:
```python3
Object of type UUID is not JSON serializable
```
