### PR TITLE
Updated url in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     author_email='alex.gaynor@gmail.com',
     maintainer='Carlton Gibson',
     maintainer_email='carlton.gibson@noumenal.es',
-    url='https://github.com/carltongibson/django-filter/tree/master',
+    url='https://github.com/carltongibson/django-filter/tree/main',
     packages=find_packages(exclude=['tests*']),
     include_package_data=True,
     license='BSD',


### PR DESCRIPTION
Hey Carlton --  just a small change as part of the migration to `main`.

I noticed that RTD continues to refer to `master`, I think that may need updating in their admin? 🕵️ 

https://django-filter.readthedocs.io/en/master/index.html