### PR TITLE
README.rst: Fix readthedocs URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,6 @@ Support
 If you have questions about usage or development you can join the
 `mailing list`_.
 
-.. _`read the docs`: https://django-filter.readthedocs.io/en/master/
+.. _`read the docs`: https://django-filter.readthedocs.io/en/main/
 .. _`mailing list`: http://groups.google.com/group/django-filter
 .. _`DRF integration docs`: https://django-filter.readthedocs.io/en/master/guide/rest_framework.html


### PR DESCRIPTION
Thanks for an interesting library. I noted this was broken (presumably since `master` was renamed to `main` at some point, but couldn't find any issue about this). This PR fixes the link.