### PR TITLE
runtests.py: Use python3 in shebang

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 from django.core.management import execute_from_command_line


### PR DESCRIPTION
Background: newer distros (like Debian Bullseye in my case) do not provide a `python` binary unless you install the `python-is-python3` package.

[PEP 0394](https://www.python.org/dev/peps/pep-0394/) describes this at length but obviously, this may not be an easy choice since there may be systems where the opposite is true (i.e. `python` exists but `python3` does not. :grimacing:) Hence, I am quite open to this being rejected on these grounds.