### PR TITLE
usage.txt: Add required arguments to DecimalField constructor

### DIFF
--- a/docs/guide/usage.txt
+++ b/docs/guide/usage.txt
@@ -20,7 +20,7 @@ Let's start with our model::
 
     class Product(models.Model):
         name = models.CharField(max_length=255)
-        price = models.DecimalField()
+        price = models.DecimalField(max_digits=5, decimal_places=2)
         description = models.TextField()
         release_date = models.DateField()
         manufacturer = models.ForeignKey(Manufacturer)


### PR DESCRIPTION
I noted that these were missing because `System check identified some issues`. I guess it makes sense to make these examples be "reasonably complete" so they can easily be copy-pasted and tested by our users.