### PR TITLE
Make verbose_field_name also work for rels without related_name

### DIFF
--- a/django_filters/utils.py
+++ b/django_filters/utils.py
@@ -245,6 +245,9 @@ def verbose_field_name(model, field_name):
         if isinstance(part, ForeignObjectRel):
             if part.related_name:
                 names.append(part.related_name.replace('_', ' '))
+            elif part.related_model:
+                meta = part.related_model._meta
+                names.append(force_str(meta.verbose_name))
             else:
                 return '[invalid name]'
         else:


### PR DESCRIPTION
Addresses #1089 by also trying the `related_model._meta.verbose_name` if there is not `related_name`.

Would probably be more correct to always use the `related_model._meta.verbose_name` considering that the `related_name` is not a translatable and needs additional mangling to remove `_`, but this addition would be backwards compatible and only fix the failing case.