### PR TITLE
add project_urls to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,12 @@ setup(
     maintainer_email='carlton.gibson@noumenal.es',
     url='https://github.com/carltongibson/django-filter/tree/main',
     packages=find_packages(exclude=['tests*']),
+    project_urls={
+        "Documentation": "https://django-filter.readthedocs.io/en/main/",
+        "Changelog": "https://github.com/carltongibson/django-filter/blob/main/CHANGES.rst",
+        "Bug Tracker": "https://github.com/carltongibson/django-filter/issues",
+        "Source Code": "https://github.com/carltongibson/django-filter",
+    },
     include_package_data=True,
     license='BSD',
     classifiers=[


### PR DESCRIPTION
This PR adds a `project_urls` section to setup.py that will make important links appear the left hand side of pypi for docs, changelog, bug tracking, and source code.

Here's an example of how it looks on the attrs project:
<img width="549" alt="Screen Shot 2021-05-07 at 7 15 54 PM" src="https://user-images.githubusercontent.com/992533/117519308-93853a00-af92-11eb-832c-5a5614a51e22.png">
