### PR TITLE
Fix broken documentaion links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Updating to 2.0? Did you read the migration guide? https://django-filter.readthedocs.io/en/master/guide/migration.html#migration-guide
+about: Updating to 2.0? Did you read the migration guide? https://django-filter.readthedocs.io/en/main/guide/migration.html#migration-guide
 
 ---
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,7 +66,7 @@ Version 2.0 (2018-7-13)
 2.0 introduced a number of small changes and tidy-ups.
 Please see the migration guide:
 
-https://django-filter.readthedocs.io/en/master/guide/migration.html#migrating-to-2-0
+https://django-filter.readthedocs.io/en/main/guide/migration.html#migrating-to-2-0
 
 * Added testing for Python 3.7 (#944)
 * Improve exception message for invalid filter result (#943)

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -462,7 +462,7 @@ class DateRangeFilter(ChoiceFilter):
         # TODO: remove assertion in 2.1
         assert not hasattr(self, 'options'), \
             "The 'options' attribute has been replaced by 'choices' and 'filters'. " \
-            "See: https://django-filter.readthedocs.io/en/master/guide/migration.html"
+            "See: https://django-filter.readthedocs.io/en/main/guide/migration.html"
 
         # null choice not relevant
         kwargs.setdefault('null_label', None)

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -74,7 +74,7 @@ class FilterSetMetaclass(type):
         assert not hasattr(new_class, 'filter_for_reverse_field'), (
             "`%(cls)s.filter_for_reverse_field` has been removed. "
             "`%(cls)s.filter_for_field` now generates filters for reverse fields. "
-            "See: https://django-filter.readthedocs.io/en/master/guide/migration.html"
+            "See: https://django-filter.readthedocs.io/en/main/guide/migration.html"
             % {'cls': new_class.__name__}
         )
 
@@ -382,7 +382,7 @@ class BaseFilterSet:
         assert filter_class is not None, (
             "%s resolved field '%s' with '%s' lookup to an unrecognized field "
             "type %s. Try adding an override to 'Meta.filter_overrides'. See: "
-            "https://django-filter.readthedocs.io/en/master/ref/filterset.html"
+            "https://django-filter.readthedocs.io/en/main/ref/filterset.html"
             "#customise-filter-generation-with-filter-overrides"
         ) % (cls.__name__, field_name, lookup_expr, field.__class__.__name__)
 

--- a/django_filters/utils.py
+++ b/django_filters/utils.py
@@ -20,7 +20,7 @@ def deprecate(msg, level_modifier=0):
 
 
 class MigrationNotice(DeprecationWarning):
-    url = 'https://django-filter.readthedocs.io/en/master/guide/migration.html'
+    url = 'https://django-filter.readthedocs.io/en/main/guide/migration.html'
 
     def __init__(self, message):
         super().__init__('%s See: %s' % (message, self.url))

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -377,7 +377,7 @@ class ValidationErrorTests(TestCase):
 class RenamedBackendAttributesTests(TestCase):
     def test_get_filter_class(self):
         expected = "`Backend.get_filter_class` method should be renamed `get_filterset_class`. " \
-                   "See: https://django-filter.readthedocs.io/en/master/guide/migration.html"
+                   "See: https://django-filter.readthedocs.io/en/main/guide/migration.html"
         with warnings.catch_warnings(record=True) as recorded:
             warnings.simplefilter('always')
 
@@ -391,7 +391,7 @@ class RenamedBackendAttributesTests(TestCase):
 
     def test_default_filter_set(self):
         expected = "`Backend.default_filter_set` attribute should be renamed `filterset_base`. " \
-                   "See: https://django-filter.readthedocs.io/en/master/guide/migration.html"
+                   "See: https://django-filter.readthedocs.io/en/main/guide/migration.html"
         with warnings.catch_warnings(record=True) as recorded:
             warnings.simplefilter('always')
 
@@ -407,7 +407,7 @@ class RenamedViewSetAttributesTests(TestCase):
 
     def test_filter_class(self):
         expected = "`View.filter_class` attribute should be renamed `filterset_class`. " \
-                   "See: https://django-filter.readthedocs.io/en/master/guide/migration.html"
+                   "See: https://django-filter.readthedocs.io/en/main/guide/migration.html"
         with warnings.catch_warnings(record=True) as recorded:
             warnings.simplefilter('always')
 
@@ -424,7 +424,7 @@ class RenamedViewSetAttributesTests(TestCase):
 
     def test_filter_fields(self):
         expected = "`View.filter_fields` attribute should be renamed `filterset_fields`. " \
-                   "See: https://django-filter.readthedocs.io/en/master/guide/migration.html"
+                   "See: https://django-filter.readthedocs.io/en/main/guide/migration.html"
         with warnings.catch_warnings(record=True) as recorded:
             warnings.simplefilter('always')
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1008,7 +1008,7 @@ class DateRangeFilterTests(TestCase):
 
     def test_options_removed(self):
         msg = "The 'options' attribute has been replaced by 'choices' and 'filters'. " \
-              "See: https://django-filter.readthedocs.io/en/master/guide/migration.html"
+              "See: https://django-filter.readthedocs.io/en/main/guide/migration.html"
 
         class F(DateRangeFilter):
             options = None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,7 +40,7 @@ class MigrationNoticeTests(TestCase):
     def test_message(self):
         self.assertEqual(
             str(MigrationNotice('Message.')),
-            'Message. See: https://django-filter.readthedocs.io/en/master/guide/migration.html'
+            'Message. See: https://django-filter.readthedocs.io/en/main/guide/migration.html'
         )
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -113,7 +113,7 @@ class GenericClassBasedViewTests(GenericViewTestCase):
 
     def test_filter_fields_removed(self):
         expected = "`View.filter_fields` attribute should be renamed `filterset_fields`. " \
-                   "See: https://django-filter.readthedocs.io/en/master/guide/migration.html"
+                   "See: https://django-filter.readthedocs.io/en/main/guide/migration.html"
         with warnings.catch_warnings(record=True) as recorded:
             warnings.simplefilter('always')
 


### PR DESCRIPTION
Since the primary branch has been renamed from master to main, many
documentation links are now dead. This change is a find replace for all
https://django-filter.readthedocs.io/en/master references to
https://django-filter.readthedocs.io/en/main