### PR TITLE
Fix model field defined filter labels fetching for schema

### DIFF
--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -154,7 +154,7 @@ class DjangoFilterBackend(metaclass=RenameAttributes):
             return []
 
         parameters = []
-        for field_name, field in filterset_class().base_filters.items():
+        for field_name, field in filterset_class().filters.items():
             parameter = {
                 'name': field_name,
                 'required': field.extra['required'],

--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -154,7 +154,7 @@ class DjangoFilterBackend(metaclass=RenameAttributes):
             return []
 
         parameters = []
-        for field_name, field in filterset_class.base_filters.items():
+        for field_name, field in filterset_class().base_filters.items():
             parameter = {
                 'name': field_name,
                 'required': field.extra['required'],

--- a/tests/rest_framework/models.py
+++ b/tests/rest_framework/models.py
@@ -29,4 +29,4 @@ class DjangoFilterOrderingModel(models.Model):
 
 
 class CategoryItem(BaseFilterableItem):
-    category = models.CharField(max_length=10, choices=(("home", "Home"), ("office", "Office")))
+    category = models.CharField('item category', max_length=10, choices=(("home", "Home"), ("office", "Office")))

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -260,7 +260,7 @@ class GetSchemaOperationParametersTests(TestCase):
                 'name': 'category',
                 'required': False,
                 'in': 'query',
-                'description': 'category',
+                'description': 'Item category',
                 'schema': {
                     'type': 'string',
                     'enum': ['home', 'office']


### PR DESCRIPTION
- 1. There is [automatic filter label fetching from model fields](https://github.com/carltongibson/django-filter/blob/main/django_filters/filters.py#L117) based on `Filter.model` attribute.

- 2. `Filter.model` attribute [is set by `FilterSet.__init__()`](https://github.com/carltongibson/django-filter/blob/main/django_filters/filterset.py#L205) so it requires instantiation. 

- 3. `RestFrameworkFilterBackend.get_schema_operation_parameters` [uses `FilterSet` class instead of instance](https://github.com/carltongibson/django-filter/blob/main/django_filters/rest_framework/backends.py#L157).

To fix `RestFrameworkFilterBackend.get_schema_operation_parameters` we need `FilterSet` instance inspection instead of class.
