### PR TITLE
introduce inert helper parameter for schema generation

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -133,6 +133,8 @@ class Filter:
 
             if settings.DISABLE_HELP_TEXT:
                 field_kwargs.pop('help_text', None)
+            # non-functional parameter to support schema generation in ambiguous cases
+            field_kwargs.pop('schema', None)
 
             self._field = self.field_class(label=self.label, **field_kwargs)
         return self._field


### PR DESCRIPTION
Hi @carltongibson,

we are facing an issue with under-specified filters when when generating schemas (e.g. `RangeFilter`).
We already got pretty decent support for `django-filter` in `drf-spectacular`, but certain fields simply lack the information to do a proper schema. For model fields we can retrieve the type ourselves, but transient fields added with `annotate()` are harder to estimate properly.

This introduces an unopinionated and inert parameter that can be freely used by schema generation to allow things like

```python
class ProductFilter(FilterSet):
    price_range_vat = RangeFilter(
        field_name='some_annotated_transient_qs_field', 
        schema=float
    )
```

The reason we need to `pop` it is because otherwise filter `__init__` would bail with an "unknown argument" exception due to `extra` simply being handed through.

Thanks for considering this PR.