### PR TITLE
fix field_name of BooleanFilter

### DIFF
--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -66,7 +66,7 @@ transformation and empty value checking should be unnecessary.
 
     class F(FilterSet):
         """Filter for Books by if books are published or not"""
-        published = BooleanFilter(field_name='published_on', method='filter_published')
+        published = BooleanFilter(field_name='published', method='filter_published')
 
         def filter_published(self, queryset, name, value):
             # construct the full lookup expression.
@@ -74,7 +74,7 @@ transformation and empty value checking should be unnecessary.
             return queryset.filter(**{lookup: False})
 
             # alternatively, you could opt to hardcode the lookup. e.g.,
-            # return queryset.filter(published_on__isnull=False)
+            # return queryset.filter(published__isnull=False)
 
         class Meta:
             model = Book
@@ -88,7 +88,7 @@ transformation and empty value checking should be unnecessary.
 
     class F(FilterSet):
         """Filter for Books by if books are published or not"""
-        published = BooleanFilter(field_name='published_on', method=filter_not_empty)
+        published = BooleanFilter(field_name='published', method=filter_not_empty)
 
         class Meta:
             model = Book


### PR DESCRIPTION
First, please see the Issue #1440.
This is about #1440  "1. published field exists in Book model".
I think it would be better to change it as following. 
```
# published = BooleanFilter(field_name='published_on', method='filter_published')
published = BooleanFilter(field_name='published', method='filter_published')
```
Modified code was tested with following change on the test section of #.

```
# views.py
from django_filters import BooleanFilter
from django_filters import rest_framework as filters
from rest_framework import generics
from .serializers import BookSerializer
from .models import Book


class F(filters.FilterSet):

    # published = BooleanFilter(field_name="published_on", method="filter_published")
    published = BooleanFilter(field_name="published", method="filter_published")
   ....

```
The result was successful.
```
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
published_on__isnull
.
----------------------------------------------------------------------
Ran 1 test in 0.469s

OK
Destroying test database for alias 'default'...
```