### PR TITLE
setup.cfg: Use underscore in license_file key

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-license-file = LICENSE
+license_file = LICENSE
 
 [isort]
 skip=.tox


### PR DESCRIPTION
Use underscore in the setup.cfg key to fix the following warning:

> Usage of dash-separated 'license-file' will not be supported in future versions. Please use the underscore name 'license_file' instead