### PR TITLE
fix #1475 - filter_overrides extra now applied when field has choices

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -404,7 +404,7 @@ class BaseFilterSet:
 
         # perform lookup specific checks
         if lookup_type == 'exact' and getattr(field, 'choices', None):
-            return ChoiceFilter, {'choices': field.choices}
+            return ChoiceFilter, {'choices': field.choices, **params}
 
         if lookup_type == 'isnull':
             data = try_dbfield(DEFAULTS.get, models.BooleanField)

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -2,6 +2,8 @@ import unittest
 from unittest import mock
 
 from django.db import models
+from django.db.models import IntegerField
+from django.forms.widgets import Select
 from django.test import TestCase, override_settings
 
 from django_filters.exceptions import FieldLookupError
@@ -241,6 +243,25 @@ class FilterSetFilterForLookupTests(TestCase):
         result, params = OFilterSet.filter_for_lookup(f, 'isnull')
         self.assertEqual(result, BooleanFilter)
         self.assertEqual(params['widget'], BooleanWidget)
+
+    def test_filter_overrides_extra_when_field_has_choices(self):
+        select = Select(attrs={'class': 'form-select'})
+
+        class OFilterSet(FilterSet):
+            class Meta:
+                filter_overrides = {
+                    IntegerField: {
+                        'filter_class': ChoiceFilter,
+                        'extra': lambda f: {
+                            'widget': select
+                        },
+                    },
+                }
+
+        f = User._meta.get_field('status')
+        result, params = OFilterSet.filter_for_lookup(f, 'exact')
+        self.assertEqual(result, ChoiceFilter)
+        self.assertEqual(params['widget'], select)
 
 
 class ReverseFilterSetFilterForFieldTests(TestCase):


### PR DESCRIPTION
Code change compatible with older python versions (`{**a, **b}` rather than `a | b` used for combining dictionaries), as I spotted via running tox on your project it wants to run back to 3.6.

Test added for this case, checked it fails without the change, passes with.