### PR TITLE
Add URLFilter for URLField.

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -59,6 +59,7 @@ __all__ = [
     'TimeRangeFilter',
     'TypedChoiceFilter',
     'TypedMultipleChoiceFilter',
+    'URLFilter',
     'UUIDFilter',
 ]
 
@@ -149,6 +150,10 @@ class Filter:
 
 class CharFilter(Filter):
     field_class = forms.CharField
+
+
+class URLFilter(Filter):
+    field_class = forms.URLField
 
 
 class BooleanFilter(Filter):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -45,6 +45,7 @@ from django_filters.filters import (
     TimeFilter,
     TimeRangeFilter,
     TypedMultipleChoiceFilter,
+    URLFilter,
     UUIDFilter
 )
 from tests.models import Book, User
@@ -179,6 +180,14 @@ class CharFilterTests(TestCase):
         f = CharFilter()
         field = f.field
         self.assertIsInstance(field, forms.CharField)
+
+
+class URLFilterTests(TestCase):
+
+    def test_default_field(self):
+        f = URLFilter()
+        field = f.field
+        self.assertIsInstance(field, forms.URLField)
 
 
 class UUIDFilterTests(TestCase):


### PR DESCRIPTION
### Problem
Consider this fragment:
```
class GrantFilter(filters.FilterSet):
    """Filter grants by principal, scope, or role."""
    principal = CharFilter(method="filter_by_principal", label="Filter by principal (User).")
```

With drf_spectacular emitting a string type out, we lose the uri formatting designation.  Due to the way drf_spectacular works, once it matches `CharFilter` (see: [code](https://github.com/tfranzel/drf-spectacular/blob/1246bceed8bb947a7f3c7c0e9c081743fa12fba4/drf_spectacular/contrib/django_filters.py#L52-L66)) then it assumes a standard OpenApiTypes.STR type.  There is no way to annotate your way around it due to the logic there.

Resulting generated web client with swagger-typescript-api shows:
```
+  /** Filter by principal (User). */
+  principal?: string
```

### Solution

1. Add a django_filters.filters.URLFilter with a field type of URLField.
2. drf_spectacular has no match for this currently (a follow-up to this work will be to remedy that) so it falls back to looking at type annotations on the method's value argument.
3. Add a type hint to the filter method value argument so that it is an OpenApiTypes.URI (note: this will be unnecessary when item 2 is done).
4. It is up to the filter method to figure out the type, identity, and manipulate the queryset appropriately.

Resulting generated web client with swagger-typescript-api shows:
```
+  /**
+   * Filter by principal (User).
+   * @format uri
+   */
+  principal?: string
```