### PR TITLE
22.1 introduced a backwards incompatible change that is not listed in the changelog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Version 22.1 (2022-6-17)
 
 * Removed outdated deprecated warnings for code removed in version 2.1.
 
+* Removed `filter_class` (use `filterset_class`) and `filter_fields`
+  (`filterset_fields`) that were deprecated in [version 2.0
+  (2018)](https://django-filter.readthedocs.io/en/main/guide/migration.html#view-attributes-renamed-867).
+
 * The code base is now formatted with Black.
 
 Version 21.1 (2021-9-24)


### PR DESCRIPTION
Release 22.1 removed compatibility fallbacks that were originally scheduled to be removed in release 2.1
* `filter_class` could still be used instead of `filterset_class`
* `filter_fields` could still be used instead of `filterset_fields`

Both were mentioned in the [2.0 migration guide](https://django-filter.readthedocs.io/en/main/guide/migration.html#view-attributes-renamed-867) but then forgotten to be removed in 2.1.

IMHO this should be mentioned in the changelog as someone (e.g. me :smiling_face_with_tear:) might still have used them.

Thanks