### PR TITLE
docs: Fix a few typos

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -598,7 +598,7 @@ class LookupChoiceFilter(Filter):
     A combined filter that allows users to select the lookup expression from a dropdown.
 
     * ``lookup_choices`` is an optional argument that accepts multiple input
-      formats, and is ultimately normlized as the choices used in the lookup
+      formats, and is ultimately normalized as the choices used in the lookup
       dropdown. See ``.get_lookup_choices()`` for more information.
 
     * ``field_class`` is an optional argument that allows you to set the inner

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1087,7 +1087,7 @@ class DateRangeFilterTests(TestCase):
         self.assertEqual(qs, result)
 
     def test_filtering_skipped_with_out_of_range_value(self):
-        # Field validation should prevent this from occuring
+        # Field validation should prevent this from occurring
         qs = mock.Mock(spec=[])
         f = DateRangeFilter()
         with self.assertRaises(AssertionError):

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -510,7 +510,7 @@ class FilterSetClassCreationTests(TestCase):
 
     def test_meta_fields_invalid_lookup(self):
         # We want to ensure that non existent lookups (or just simple misspellings)
-        # throw a useful exception containg the field and lookup expr.
+        # throw a useful exception containing the field and lookup expr.
         msg = "Unsupported lookup 'flub' for field 'tests.User.username'."
 
         with self.assertRaisesMessage(FieldLookupError, msg):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -213,7 +213,7 @@ class GetFieldPartsTests(TestCase):
         """
         This simulates trying to create a FilterSet before the app registry has
         been populated. Lazy relationships have not yet been resolved from their
-        strings into their remote model referencess.
+        strings into their remote model references.
         """
 
         class TestModel(models.Model):
@@ -248,7 +248,7 @@ class ResolveFieldTests(TestCase):
         model_field = User._meta.get_field("username")
         lookups = model_field.class_lookups.keys()
 
-        # This is simple - the final ouput of an untransformed field is itself.
+        # This is simple - the final output of an untransformed field is itself.
         # The lookups are the default lookups registered to the class.
         for term in lookups:
             field, lookup = resolve_field(model_field, term)


### PR DESCRIPTION
There are small typos in:
- django_filters/filters.py
- tests/test_filters.py
- tests/test_filterset.py
- tests/test_utils.py

Fixes:
- Should read `references` rather than `referencess`.
- Should read `output` rather than `ouput`.
- Should read `occurring` rather than `occuring`.
- Should read `normalized` rather than `normlized`.
- Should read `containing` rather than `containg`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md