### PR TITLE
Update german Translation and init inlang Config

### DIFF
--- a/inlang.config.js
+++ b/inlang.config.js
@@ -1,0 +1,67 @@
+// init the inlang.config
+
+/**
+ * @type {import("@inlang/core/config").DefineConfig}
+ */
+export async function defineConfig(env) {
+  // importing plugin from local file for testing purposes
+  const plugin = await env.$import(
+    "https://cdn.jsdelivr.net/gh/jannesblobel/inlang-plugin-po@1/dist/index.js"
+  );
+  const pluginConfig = {
+    // language mean the name of you file
+    pathPattern: "./django_filters/locale/{language}/LC_MESSAGES/django.po",
+    //definte the referenacePath. If you haven't one enter "null"
+    referenceResourcePath: null,
+  };
+
+  return {
+    // if your project use a pot file use the pot as the reference Language
+    // !! do not add the pot file in the Languages array
+    /**
+   * @example
+   * example files: en.pot, de.po, es.po, fr.po
+   *  referenceLanguage: "en",
+      languages: ["de","es","fr"],
+   */
+    referenceLanguage: "en",
+    languages: await getLanguages(env),
+    // languages: await getLanguages(env),
+
+    readResources: (args) =>
+      plugin.readResources({ ...args, ...env, pluginConfig }),
+    writeResources: (args) =>
+      plugin.writeResources({ ...args, ...env, pluginConfig }),
+  };
+}
+
+// /**
+//  * Automatically derives the languages in this repository.
+//  */
+async function getLanguages(env) {
+  // languagePath is the place where the languages are stored
+  // @example translationsStoredIn = "./translations/" don't forget the / at the end of a path
+  const translationsStoredIn = "./django_filters/locale/";
+  //get all folders / files which are stored in the translationsStoredIn
+  const files = await env.$fs.readdir(translationsStoredIn);
+  // files that end with .po
+  // remove the .po extension to only get language name
+  const languages = [];
+  // filter all folder by po files
+  for (const language of files) {
+    //try to read a po file
+    try {
+      const file = await env.$fs.readdir(
+        translationsStoredIn + language + "/LC_MESSAGES/"
+      );
+      // somtime are more than 1 file in the folder example: messages.mo and messages.po
+      for (const _file of file) {
+        if (_file.endsWith(".po")) {
+          //if the po file is recognised, the language code is entered into the array languages returned by the function getLangauges
+          languages.push(language);
+        }
+      }
+    } catch (error) {}
+  }
+  return languages;
+}


### PR DESCRIPTION
Hi,
Changes

- added an inlang.config.js file to the root of the repo
- updated and fix German translations


I saw your german translation was broken. To make it easier for me to contribute to your translation, I added the tool [inlang/inlang](https://github.com/inlang/inlang). I am opening this PR as a draft to discuss the tool. Maintainers or contributors would have no overhead as inlang is built on git. No accounts (login with GitHub), no sync, and no pipelines are required. Contributions open a PR.

Would a UI over the translations in this repo be of benefit to the Django-filter community? There are a couple of issues regarding this topic. [Translations #1512
](https://github.com/carltongibson/django-filter/discussions/1512) or [PR #1516 ](https://github.com/carltongibson/django-filter/pull/1516) 

Issue  #1510 is still open, although you merged the PR #1515. I guess you can reduce your issue counter and can close this issue :) 

You can try it out on my fork and post your feedback under this draft.
https://inlang.com/editor/github.com/jannesblobel/django-filter


You can see a short preview in the video. While translating, I noticed that some translations still need to be included; maybe someone from the community can correct them. 
Need to include translation in this Language. 
es_AR = Spanish Argentina, 
zh_CN = Chinese

The PR is theoretically ready for review.


https://user-images.githubusercontent.com/72493222/215597007-e1ff0236-5437-4227-9256-9fefb9cd71aa.mp4

