### PR TITLE
Remove hardcode of rest_framework crispy form template_pack

### DIFF
--- a/django_filters/rest_framework/filterset.py
+++ b/django_filters/rest_framework/filterset.py
@@ -34,7 +34,6 @@ class FilterSet(filterset.FilterSet):
             ]
             helper = FormHelper()
             helper.form_method = "GET"
-            helper.template_pack = "bootstrap3"
             helper.layout = Layout(*layout_components)
 
             form.helper = helper


### PR DESCRIPTION
Fixes #1537.

The template_pack is hardcoded to 'bootstrap3' in rest_framework's FilterSet. This change simply removes the setter allowing crispy forms to determine what the template pack should be based on the crispy forms configuration or whichever the default pack is for the installed version of crispy forms.

The Layout objects used are generic and should be compatible with any template pack, but as before if users want to customize the crispy form they can override the form property.

This change is necessary because some template packs step on each other. In this case bootstrap3 and bootstrap5 are incompatible. Simply installing the bootstrap5 template pack is enough to crash browsable DRF rendering.

