### PR TITLE
Update 'DateRangeWidget' in widgets.py

### DIFF
--- a/django_filters/widgets.py
+++ b/django_filters/widgets.py
@@ -123,8 +123,8 @@ class SuffixedMultiWidget(forms.MultiWidget):
         if value is None:
             return [None, None]
         return value
-
-
+    
+    
 class RangeWidget(SuffixedMultiWidget):
     template_name = "django_filters/widgets/multiwidget.html"
     suffixes = ["min", "max"]
@@ -138,9 +138,23 @@ class RangeWidget(SuffixedMultiWidget):
             return [value.start, value.stop]
         return [None, None]
 
-
-class DateRangeWidget(RangeWidget):
+    
+class DateInput(forms.DateInput):
+    input_type = 'date'
+    
+    
+class DateRangeWidget(SuffixedMultiWidget):
+    template_name = "django_filters/widgets/multiwidget.html"
     suffixes = ["after", "before"]
+
+    def __init__(self, attrs=None):
+        widgets = (DateInput, DateInput)
+        super().__init__(widgets=widgets, attrs=attrs)
+
+    def decompress(self, value):
+        if value:
+            return [value.start, value.stop]
+        return [None, None]
 
 
 class LookupChoiceWidget(SuffixedMultiWidget):


### PR DESCRIPTION
Rather than inherit the RangeWidget, DateRangeWidget directly inhreits the SuffixedMultiWidget and has DateInput widgets rather than TextInputs. This idea was brought up in the following discussion: https://github.com/carltongibson/django-filter/discussions/1568