### PR TITLE
Deprecated Schema generations 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,17 @@
+Version 23.2 (UNRELEASED)
+-------------------------
+
+* Deprecated the schema generation methods of the DRF related ``DjangoFilterBackend``.
+  These will be removed in version 25.1.
+
+  You should use `drf-spectacular <https://drf-spectacular.readthedocs.io/en/latest/>`_
+  for generating OpenAPI schemas with DRF.
+
+* In addition, stopped testing against the (very old now) ``coreapi`` schema generation.
+  These methods should continue to work if you're using them until v25.1, but
+  ``coreapi`` is no longer maintained, and is raising warnings against the current
+  versions of Python. To workaround this is not worth the effort at this point.
+
 Version 23.1 (2023-3-26)
 ------------------------
 

--- a/django_filters/__init__.py
+++ b/django_filters/__init__.py
@@ -29,3 +29,11 @@ def parse_version(version):
 
 
 VERSION = parse_version(__version__)
+
+
+
+assert VERSION < (25,0), "Remove deprecated code"
+
+
+class RemovedInDjangoFilter25Warning(DeprecationWarning):
+    pass

--- a/django_filters/compat.py
+++ b/django_filters/compat.py
@@ -1,4 +1,11 @@
+import django
 from django.conf import settings
+from django.test import TestCase
+
+if django.VERSION < (4, 2):
+    class TestCase(TestCase):
+        assertQuerySetEqual = TestCase.assertQuerysetEqual
+
 
 # django-crispy-forms is optional
 try:

--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -93,6 +93,11 @@ class DjangoFilterBackend:
         # This is not compatible with widgets where the query param differs from the
         # filter's attribute name. Notably, this includes `MultiWidget`, where query
         # params will be of the format `<name>_0`, `<name>_1`, etc...
+        from django_filters import RemovedInDjangoFilter25Warning
+        warnings.warn(
+            "Built-in schema generation is deprecated. Use drf-spectacular.",
+            category=RemovedInDjangoFilter25Warning,
+        )
         assert (
             compat.coreapi is not None
         ), "coreapi must be installed to use `get_schema_fields()`"
@@ -125,6 +130,11 @@ class DjangoFilterBackend:
         )
 
     def get_schema_operation_parameters(self, view):
+        from django_filters import RemovedInDjangoFilter25Warning
+        warnings.warn(
+            "Built-in schema generation is deprecated. Use drf-spectacular.",
+            category=RemovedInDjangoFilter25Warning,
+        )
         try:
             queryset = view.get_queryset()
         except Exception:

--- a/requirements/test-ci.txt
+++ b/requirements/test-ci.txt
@@ -1,5 +1,4 @@
 markdown
-coreapi
 django-crispy-forms
 
 coverage

--- a/tests/rest_framework/test_backends.py
+++ b/tests/rest_framework/test_backends.py
@@ -3,11 +3,11 @@ from unittest import mock, skipIf
 
 from django.db.models import BooleanField
 from django.test import TestCase
-from django.test.utils import override_settings
+from django.test.utils import ignore_warnings, override_settings
 from rest_framework import generics, serializers
 from rest_framework.test import APIRequestFactory
 
-from django_filters import compat, filters
+from django_filters import RemovedInDjangoFilter25Warning, compat, filters
 from django_filters.rest_framework import DjangoFilterBackend, FilterSet, backends
 
 from ..models import Article
@@ -245,6 +245,7 @@ class GetSchemaFieldsTests(TestCase):
 
 
 class GetSchemaOperationParametersTests(TestCase):
+    @ignore_warnings(category=RemovedInDjangoFilter25Warning)
     def test_get_operation_parameters_with_filterset_fields_list(self):
         backend = DjangoFilterBackend()
         fields = backend.get_schema_operation_parameters(FilterFieldsRootView())
@@ -252,6 +253,7 @@ class GetSchemaOperationParametersTests(TestCase):
 
         self.assertEqual(fields, ["decimal", "date"])
 
+    @ignore_warnings(category=RemovedInDjangoFilter25Warning)
     def test_get_operation_parameters_with_filterset_fields_list_with_choices(self):
         backend = DjangoFilterBackend()
         fields = backend.get_schema_operation_parameters(CategoryItemView())
@@ -268,6 +270,12 @@ class GetSchemaOperationParametersTests(TestCase):
                 }
             ],
         )
+
+    def test_deprecation_warning(self):
+        backend = DjangoFilterBackend()
+        msg = "Built-in schema generation is deprecated. Use drf-spectacular."
+        with self.assertWarnsMessage(RemovedInDjangoFilter25Warning, msg):
+            backend.get_schema_operation_parameters(FilterFieldsRootView())
 
 
 class TemplateTests(TestCase):
@@ -407,6 +415,7 @@ class DjangoFilterBackendTestCase(TestCase):
         html = self.backend.to_html(mock.Mock(), mock.Mock(), mock.Mock())
         self.assertIsNone(html)
 
+    @ignore_warnings(category=RemovedInDjangoFilter25Warning)
     def test_get_schema_operation_parameters_userwarning(self):
         with self.assertWarns(UserWarning):
             view = mock.Mock()

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -7,10 +7,11 @@ from unittest import mock
 import django
 from django import forms
 from django.http import QueryDict
-from django.test import TestCase, override_settings
+from django.test import override_settings
 from django.utils import timezone
 from django.utils.timezone import make_aware, now
 
+from django_filters.compat import TestCase
 from django_filters.filters import (
     AllValuesFilter,
     AllValuesMultipleFilter,
@@ -65,11 +66,11 @@ class CharFilterTests(TestCase):
 
         qs = Book.objects.all()
         f = F(queryset=qs)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs, [b1.pk, b2.pk, b3.pk], lambda o: o.pk, ordered=False
         )
         f = F({"title": "Snowcrash"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [b3.pk], lambda o: o.pk)
+        self.assertQuerySetEqual(f.qs, [b3.pk], lambda o: o.pk)
 
 
 class IntegerFilterTest(TestCase):
@@ -89,13 +90,13 @@ class IntegerFilterTest(TestCase):
 
         qs = BankAccount.objects.all()
         f = F(queryset=qs)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs, [b1.pk, b2.pk, b3.pk], lambda o: o.pk, ordered=False
         )
         f = F({"amount_saved": "10"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [b3.pk], lambda o: o.pk)
+        self.assertQuerySetEqual(f.qs, [b3.pk], lambda o: o.pk)
         f = F({"amount_saved": "0"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [b1.pk], lambda o: o.pk)
+        self.assertQuerySetEqual(f.qs, [b1.pk], lambda o: o.pk)
 
 
 class BooleanFilterTests(TestCase):
@@ -113,13 +114,13 @@ class BooleanFilterTests(TestCase):
 
         # '2' and '3' are how the field expects the data from the browser
         f = F({"is_active": "2"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["jacob"], lambda o: o.username, False)
+        self.assertQuerySetEqual(f.qs, ["jacob"], lambda o: o.username, False)
 
         f = F({"is_active": "3"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["alex", "aaron"], lambda o: o.username, False)
+        self.assertQuerySetEqual(f.qs, ["alex", "aaron"], lambda o: o.username, False)
 
         f = F({"is_active": "1"}, queryset=qs)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs, ["alex", "aaron", "jacob"], lambda o: o.username, False
         )
 
@@ -145,17 +146,17 @@ class ChoiceFilterTests(TestCase):
                 fields = ["status"]
 
         f = F()
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs, ["aaron", "alex", "jacob", "carl"], lambda o: o.username, False
         )
         f = F({"status": "1"})
-        self.assertQuerysetEqual(f.qs, ["alex"], lambda o: o.username, False)
+        self.assertQuerySetEqual(f.qs, ["alex"], lambda o: o.username, False)
 
         f = F({"status": "2"})
-        self.assertQuerysetEqual(f.qs, ["jacob", "aaron"], lambda o: o.username, False)
+        self.assertQuerySetEqual(f.qs, ["jacob", "aaron"], lambda o: o.username, False)
 
         f = F({"status": "0"})
-        self.assertQuerysetEqual(f.qs, ["carl"], lambda o: o.username, False)
+        self.assertQuerySetEqual(f.qs, ["carl"], lambda o: o.username, False)
 
     def test_filtering_on_explicitly_defined_field(self):
         """
@@ -172,17 +173,17 @@ class ChoiceFilterTests(TestCase):
                 fields = ["status"]
 
         f = F()
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs, ["aaron", "alex", "jacob", "carl"], lambda o: o.username, False
         )
         f = F({"status": "1"})
-        self.assertQuerysetEqual(f.qs, ["alex"], lambda o: o.username, False)
+        self.assertQuerySetEqual(f.qs, ["alex"], lambda o: o.username, False)
 
         f = F({"status": "2"})
-        self.assertQuerysetEqual(f.qs, ["jacob", "aaron"], lambda o: o.username, False)
+        self.assertQuerySetEqual(f.qs, ["jacob", "aaron"], lambda o: o.username, False)
 
         f = F({"status": "0"})
-        self.assertQuerysetEqual(f.qs, ["carl"], lambda o: o.username, False)
+        self.assertQuerySetEqual(f.qs, ["carl"], lambda o: o.username, False)
 
     def test_filtering_on_empty_choice(self):
         class F(FilterSet):
@@ -191,7 +192,7 @@ class ChoiceFilterTests(TestCase):
                 fields = ["status"]
 
         f = F({"status": ""})
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs, ["aaron", "alex", "jacob", "carl"], lambda o: o.username, False
         )
 
@@ -211,10 +212,10 @@ class ChoiceFilterTests(TestCase):
 
         # sanity check to make sure the filter is setup correctly
         f = F({"author": "1"})
-        self.assertQuerysetEqual(f.qs, ["alex"], lambda o: str(o.author), False)
+        self.assertQuerySetEqual(f.qs, ["alex"], lambda o: str(o.author), False)
 
         f = F({"author": "null"})
-        self.assertQuerysetEqual(f.qs, [None], lambda o: o.author, False)
+        self.assertQuerySetEqual(f.qs, [None], lambda o: o.author, False)
 
 
 class MultipleChoiceFilterTests(TestCase):
@@ -233,18 +234,18 @@ class MultipleChoiceFilterTests(TestCase):
 
         qs = User.objects.all().order_by("username")
         f = F(queryset=qs)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs, ["aaron", "jacob", "alex", "carl"], lambda o: o.username, False
         )
 
         f = F({"status": ["0"]}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["carl"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["carl"], lambda o: o.username)
 
         f = F({"status": ["0", "1"]}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["alex", "carl"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["alex", "carl"], lambda o: o.username)
 
         f = F({"status": ["0", "1", "2"]}, queryset=qs)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs, ["aaron", "alex", "carl", "jacob"], lambda o: o.username
         )
 
@@ -275,13 +276,13 @@ class MultipleChoiceFilterTests(TestCase):
 
         # sanity check to make sure the filter is setup correctly
         f = F({"author": ["1"]})
-        self.assertQuerysetEqual(f.qs, ["alex"], lambda o: str(o.author), False)
+        self.assertQuerySetEqual(f.qs, ["alex"], lambda o: str(o.author), False)
 
         f = F({"author": ["null"]})
-        self.assertQuerysetEqual(f.qs, [None], lambda o: o.author, False)
+        self.assertQuerySetEqual(f.qs, [None], lambda o: o.author, False)
 
         f = F({"author": ["1", "null"]})
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs, ["alex", None], lambda o: o.author and str(o.author), False
         )
 
@@ -304,18 +305,18 @@ class TypedMultipleChoiceFilterTests(TestCase):
 
         qs = User.objects.all().order_by("username")
         f = F(queryset=qs)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs, ["aa", "ja", "al", "ca"], lambda o: o.username[0:2], False
         )
 
         f = F({"status": ["0"]}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["ca"], lambda o: o.username[0:2])
+        self.assertQuerySetEqual(f.qs, ["ca"], lambda o: o.username[0:2])
 
         f = F({"status": ["0", "1"]}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["al", "ca"], lambda o: o.username[0:2])
+        self.assertQuerySetEqual(f.qs, ["al", "ca"], lambda o: o.username[0:2])
 
         f = F({"status": ["0", "1", "2"]}, queryset=qs)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs, ["aa", "al", "ca", "ja"], lambda o: o.username[0:2]
         )
 
@@ -339,7 +340,7 @@ class DateFilterTests(TestCase):
 
         f = F({"date": check_date}, queryset=Comment.objects.all())
         self.assertEqual(len(f.qs), 2)
-        self.assertQuerysetEqual(f.qs, [2, 4], lambda o: o.pk, False)
+        self.assertQuerySetEqual(f.qs, [2, 4], lambda o: o.pk, False)
 
 
 class TimeFilterTests(TestCase):
@@ -362,7 +363,7 @@ class TimeFilterTests(TestCase):
 
         f = F({"time": check_time}, queryset=Comment.objects.all())
         self.assertEqual(len(f.qs), 2)
-        self.assertQuerysetEqual(f.qs, [2, 4], lambda o: o.pk, False)
+        self.assertQuerySetEqual(f.qs, [2, 4], lambda o: o.pk, False)
 
 
 class DateTimeFilterTests(TestCase):
@@ -388,14 +389,14 @@ class DateTimeFilterTests(TestCase):
         qs = Article.objects.all()
         f = F({"published": ten_min_ago}, queryset=qs)
         self.assertEqual(len(f.qs), 1)
-        self.assertQuerysetEqual(f.qs, [2], lambda o: o.pk)
+        self.assertQuerySetEqual(f.qs, [2], lambda o: o.pk)
 
         # this is how it would come through a browser
         f = F({"published": check_dt}, queryset=qs)
         self.assertEqual(
             len(f.qs), 1, "%s isn't matching %s when cleaned" % (check_dt, ten_min_ago)
         )
-        self.assertQuerysetEqual(f.qs, [2], lambda o: o.pk)
+        self.assertQuerySetEqual(f.qs, [2], lambda o: o.pk)
 
 
 class DurationFilterTests(TestCase):
@@ -442,19 +443,19 @@ class DurationFilterTests(TestCase):
 
         # Django style: 3 days, 10 hours, 22 minutes.
         f = F({"duration": "3 10:22:00"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [self.r1], lambda x: x)
+        self.assertQuerySetEqual(f.qs, [self.r1], lambda x: x)
 
         # ISO 8601: 3 days, 10 hours, 22 minutes.
         f = F({"duration": "P3DT10H22M"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [self.r1], lambda x: x)
+        self.assertQuerySetEqual(f.qs, [self.r1], lambda x: x)
 
         # Django style: 82 hours, 22 minutes.
         f = F({"duration": "82:22:00"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [self.r1], lambda x: x)
+        self.assertQuerySetEqual(f.qs, [self.r1], lambda x: x)
 
         # ISO 8601: 82 hours, 22 minutes.
         f = F({"duration": "PT82H22M"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [self.r1], lambda x: x)
+        self.assertQuerySetEqual(f.qs, [self.r1], lambda x: x)
 
     def test_filtering_with_single_lookup_expr_dictionary(self):
         class F(FilterSet):
@@ -465,18 +466,18 @@ class DurationFilterTests(TestCase):
         qs = SpacewalkRecord.objects.order_by("-duration")
 
         f = F({"duration__gt": "PT58H30M"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [self.r1, self.r2, self.r3], lambda x: x)
+        self.assertQuerySetEqual(f.qs, [self.r1, self.r2, self.r3], lambda x: x)
 
         f = F({"duration__gte": "PT58H30M"}, queryset=qs)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs, [self.r1, self.r2, self.r3, self.r4], lambda x: x
         )
 
         f = F({"duration__lt": "PT58H30M"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [self.r5], lambda x: x)
+        self.assertQuerySetEqual(f.qs, [self.r5], lambda x: x)
 
         f = F({"duration__lte": "PT58H30M"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [self.r4, self.r5], lambda x: x)
+        self.assertQuerySetEqual(f.qs, [self.r4, self.r5], lambda x: x)
 
     def test_filtering_with_multiple_lookup_exprs(self):
         class F(FilterSet):
@@ -490,7 +491,7 @@ class DurationFilterTests(TestCase):
         qs = SpacewalkRecord.objects.order_by("duration")
 
         f = F({"min_duration": "PT55H", "max_duration": "PT60H"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [self.r4, self.r3], lambda x: x)
+        self.assertQuerySetEqual(f.qs, [self.r4, self.r3], lambda x: x)
 
 
 class ModelChoiceFilterTests(TestCase):
@@ -510,7 +511,7 @@ class ModelChoiceFilterTests(TestCase):
 
         qs = Comment.objects.all()
         f = F({"author": jacob.pk}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [1, 3], lambda o: o.pk, False)
+        self.assertQuerySetEqual(f.qs, [1, 3], lambda o: o.pk, False)
 
     @override_settings(FILTERS_NULL_CHOICE_LABEL="No Author")
     def test_filtering_null(self):
@@ -525,7 +526,7 @@ class ModelChoiceFilterTests(TestCase):
 
         qs = Article.objects.all()
         f = F({"author": "null"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [None], lambda o: o.author, False)
+        self.assertQuerySetEqual(f.qs, [None], lambda o: o.author, False)
 
     def test_callable_queryset(self):
         # Sanity check for callable queryset arguments.
@@ -549,11 +550,11 @@ class ModelChoiceFilterTests(TestCase):
 
         request.user = jacob
         f = F(queryset=qs, request=request).filters["author"].field
-        self.assertQuerysetEqual(f.queryset, [1], lambda o: o.pk, False)
+        self.assertQuerySetEqual(f.queryset, [1], lambda o: o.pk, False)
 
         request.user = aaron
         f = F(queryset=qs, request=request).filters["author"].field
-        self.assertQuerysetEqual(f.queryset, [1, 2], lambda o: o.pk, False)
+        self.assertQuerySetEqual(f.queryset, [1, 2], lambda o: o.pk, False)
 
 
 class ModelMultipleChoiceFilterTests(TestCase):
@@ -580,16 +581,16 @@ class ModelMultipleChoiceFilterTests(TestCase):
 
         qs = User.objects.all().order_by("username")
         f = F({"favorite_books": ["1"]}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["aaron", "alex"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["aaron", "alex"], lambda o: o.username)
 
         f = F({"favorite_books": ["1", "3"]}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["aaron", "alex"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["aaron", "alex"], lambda o: o.username)
 
         f = F({"favorite_books": ["2"]}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["alex"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["alex"], lambda o: o.username)
 
         f = F({"favorite_books": ["4"]}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, [], lambda o: o.username)
 
     @override_settings(FILTERS_NULL_CHOICE_LABEL="No Favorites")
     def test_filtering_null(self):
@@ -601,7 +602,7 @@ class ModelMultipleChoiceFilterTests(TestCase):
         qs = User.objects.all()
         f = F({"favorite_books": ["null"]}, queryset=qs)
 
-        self.assertQuerysetEqual(f.qs, ["jacob"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["jacob"], lambda o: o.username)
 
     def test_filtering_dictionary(self):
         class F(FilterSet):
@@ -611,16 +612,16 @@ class ModelMultipleChoiceFilterTests(TestCase):
 
         qs = User.objects.all().order_by("username")
         f = F({"favorite_books": ["1"]}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["aaron", "alex"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["aaron", "alex"], lambda o: o.username)
 
         f = F({"favorite_books": ["1", "3"]}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["aaron", "alex"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["aaron", "alex"], lambda o: o.username)
 
         f = F({"favorite_books": ["2"]}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["alex"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["alex"], lambda o: o.username)
 
         f = F({"favorite_books": ["4"]}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, [], lambda o: o.username)
 
     def test_filtering_on_all_of_subset_of_choices(self):
         class F(FilterSet):
@@ -643,7 +644,7 @@ class ModelMultipleChoiceFilterTests(TestCase):
         f = F({"favorite_books": ["1", "2"]}, queryset=qs)
 
         # The results should only include matching users - not Jacob.
-        self.assertQuerysetEqual(f.qs, ["aaron", "alex"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["aaron", "alex"], lambda o: o.username)
 
     def test_filtering_on_non_required_fields(self):
         # See issue #132 - filtering with all options on a non-required
@@ -692,7 +693,7 @@ class NumberFilterTests(TestCase):
                 fields = ["price"]
 
         f = F({"price": 10}, queryset=Book.objects.all())
-        self.assertQuerysetEqual(f.qs, ["Ender's Game"], lambda o: o.title)
+        self.assertQuerySetEqual(f.qs, ["Ender's Game"], lambda o: o.title)
 
 
 class RangeFilterTests(TestCase):
@@ -719,31 +720,31 @@ class RangeFilterTests(TestCase):
 
         qs = Book.objects.all().order_by("title")
         f = F(queryset=qs)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs,
             ["Ender's Game", "Free Book", "Rainbow Six", "Refund", "Snowcrash"],
             lambda o: o.title,
         )
         f = F({"price_min": "5", "price_max": "15"}, queryset=qs)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs, ["Ender's Game", "Rainbow Six"], lambda o: o.title
         )
 
         f = F({"price_min": "11"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["Rainbow Six", "Snowcrash"], lambda o: o.title)
+        self.assertQuerySetEqual(f.qs, ["Rainbow Six", "Snowcrash"], lambda o: o.title)
         f = F({"price_max": "19"}, queryset=qs)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs,
             ["Ender's Game", "Free Book", "Rainbow Six", "Refund"],
             lambda o: o.title,
         )
 
         f = F({"price_min": "0", "price_max": "12"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["Ender's Game", "Free Book"], lambda o: o.title)
+        self.assertQuerySetEqual(f.qs, ["Ender's Game", "Free Book"], lambda o: o.title)
         f = F({"price_min": "-11", "price_max": "0"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["Free Book", "Refund"], lambda o: o.title)
+        self.assertQuerySetEqual(f.qs, ["Free Book", "Refund"], lambda o: o.title)
         f = F({"price_min": "0", "price_max": "0"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["Free Book"], lambda o: o.title)
+        self.assertQuerySetEqual(f.qs, ["Free Book"], lambda o: o.title)
 
 
 class DateRangeFilterTests(TestCase):
@@ -779,27 +780,27 @@ class DateRangeFilterTests(TestCase):
     def test_filtering_for_year(self):
         f = self.CommentFilter({"date": "year"})
         with self.relative_to(datetime.datetime(now().year, 4, 1)):
-            self.assertQuerysetEqual(f.qs, [1, 3, 4, 5, 6], lambda o: o.pk, False)
+            self.assertQuerySetEqual(f.qs, [1, 3, 4, 5, 6], lambda o: o.pk, False)
 
     def test_filtering_for_month(self):
         f = self.CommentFilter({"date": "month"})
         with self.relative_to(datetime.datetime(now().year, 4, 21)):
-            self.assertQuerysetEqual(f.qs, [1, 3, 4, 5], lambda o: o.pk, False)
+            self.assertQuerySetEqual(f.qs, [1, 3, 4, 5], lambda o: o.pk, False)
 
     def test_filtering_for_week(self):
         f = self.CommentFilter({"date": "week"})
         with self.relative_to(datetime.datetime(now().year, 1, 1)):
-            self.assertQuerysetEqual(f.qs, [3, 4, 5], lambda o: o.pk, False)
+            self.assertQuerySetEqual(f.qs, [3, 4, 5], lambda o: o.pk, False)
 
     def test_filtering_for_yesterday(self):
         f = self.CommentFilter({"date": "yesterday"})
         with self.relative_to(datetime.datetime(now().year, 1, 1)):
-            self.assertQuerysetEqual(f.qs, [5], lambda o: o.pk, False)
+            self.assertQuerySetEqual(f.qs, [5], lambda o: o.pk, False)
 
     def test_filtering_for_today(self):
         f = self.CommentFilter({"date": "today"})
         with self.relative_to(datetime.datetime(now().year, 1, 1)):
-            self.assertQuerysetEqual(f.qs, [4], lambda o: o.pk, False)
+            self.assertQuerySetEqual(f.qs, [4], lambda o: o.pk, False)
 
 
 class DateFromToRangeFilterTests(TestCase):
@@ -1179,7 +1180,7 @@ class O2ORelationshipTests(TestCase):
 
         f = F({"account": 1})
         self.assertEqual(f.qs.count(), 1)
-        self.assertQuerysetEqual(f.qs, [1], lambda o: o.pk)
+        self.assertQuerySetEqual(f.qs, [1], lambda o: o.pk)
 
     def test_o2o_relation_dictionary(self):
         class F(FilterSet):
@@ -1194,7 +1195,7 @@ class O2ORelationshipTests(TestCase):
 
         f = F({"account": 1})
         self.assertEqual(f.qs.count(), 1)
-        self.assertQuerysetEqual(f.qs, [1], lambda o: o.pk)
+        self.assertQuerySetEqual(f.qs, [1], lambda o: o.pk)
 
     def test_reverse_o2o_relation(self):
         class F(FilterSet):
@@ -1207,7 +1208,7 @@ class O2ORelationshipTests(TestCase):
 
         f = F({"profile": 1})
         self.assertEqual(f.qs.count(), 1)
-        self.assertQuerysetEqual(f.qs, [1], lambda o: o.pk)
+        self.assertQuerySetEqual(f.qs, [1], lambda o: o.pk)
 
     def test_o2o_relation_attribute(self):
         class F(FilterSet):
@@ -1220,7 +1221,7 @@ class O2ORelationshipTests(TestCase):
 
         f = F({"account__in_good_standing": "2"})
         self.assertEqual(f.qs.count(), 2)
-        self.assertQuerysetEqual(f.qs, [2, 3], lambda o: o.pk, False)
+        self.assertQuerySetEqual(f.qs, [2, 3], lambda o: o.pk, False)
 
     def test_o2o_relation_attribute2(self):
         class F(FilterSet):
@@ -1236,7 +1237,7 @@ class O2ORelationshipTests(TestCase):
 
         f = F({"account__in_good_standing": "2", "account__friendly": "2"})
         self.assertEqual(f.qs.count(), 1)
-        self.assertQuerysetEqual(f.qs, [2], lambda o: o.pk)
+        self.assertQuerySetEqual(f.qs, [2], lambda o: o.pk)
 
     def test_reverse_o2o_relation_attribute(self):
         class F(FilterSet):
@@ -1249,7 +1250,7 @@ class O2ORelationshipTests(TestCase):
 
         f = F({"profile__likes_coffee": "2"})
         self.assertEqual(f.qs.count(), 2)
-        self.assertQuerysetEqual(f.qs, [1, 3], lambda o: o.pk, False)
+        self.assertQuerySetEqual(f.qs, [1, 3], lambda o: o.pk, False)
 
     def test_reverse_o2o_relation_attribute2(self):
         class F(FilterSet):
@@ -1262,7 +1263,7 @@ class O2ORelationshipTests(TestCase):
 
         f = F({"profile__likes_coffee": "2", "profile__likes_tea": "2"})
         self.assertEqual(f.qs.count(), 1)
-        self.assertQuerysetEqual(f.qs, [3], lambda o: o.pk)
+        self.assertQuerySetEqual(f.qs, [3], lambda o: o.pk)
 
 
 class FKRelationshipTests(TestCase):
@@ -1283,7 +1284,7 @@ class FKRelationshipTests(TestCase):
 
         f = F({"company": 1})
         self.assertEqual(f.qs.count(), 2)
-        self.assertQuerysetEqual(f.qs, [1, 3], lambda o: o.pk, False)
+        self.assertQuerySetEqual(f.qs, [1, 3], lambda o: o.pk, False)
 
     def test_reverse_fk_relation(self):
         alex = User.objects.create(username="alex")
@@ -1301,7 +1302,7 @@ class FKRelationshipTests(TestCase):
 
         qs = User.objects.all()
         f = F({"comments": [2]}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["alex"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["alex"], lambda o: o.username)
 
         class F(FilterSet):
             comments = AllValuesFilter()
@@ -1311,7 +1312,7 @@ class FKRelationshipTests(TestCase):
                 fields = ["comments"]
 
         f = F({"comments": 2}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["alex"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["alex"], lambda o: o.username)
 
     def test_fk_relation_attribute(self):
         now_dt = now()
@@ -1357,7 +1358,7 @@ class FKRelationshipTests(TestCase):
 
         qs = User.objects.all()
         f = F({"comments__text": "comment 2"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["alex"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["alex"], lambda o: o.username)
 
         class F(FilterSet):
             comments__text = AllValuesFilter()
@@ -1367,7 +1368,7 @@ class FKRelationshipTests(TestCase):
                 fields = ["comments__text"]
 
         f = F({"comments__text": "comment 2"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["alex"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["alex"], lambda o: o.username)
 
     @unittest.skip("todo - need correct models")
     def test_fk_relation_multiple_attributes(self):
@@ -1410,16 +1411,16 @@ class M2MRelationshipTests(TestCase):
 
         qs = User.objects.all().order_by("username")
         f = F({"favorite_books": ["1"]}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["aaron", "alex"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["aaron", "alex"], lambda o: o.username)
 
         f = F({"favorite_books": ["1", "3"]}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["aaron", "alex"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["aaron", "alex"], lambda o: o.username)
 
         f = F({"favorite_books": ["2"]}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["alex"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["alex"], lambda o: o.username)
 
         f = F({"favorite_books": ["4"]}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, [], lambda o: o.username)
 
     def test_reverse_m2m_relation(self):
         class F(FilterSet):
@@ -1429,7 +1430,7 @@ class M2MRelationshipTests(TestCase):
 
         qs = Book.objects.all().order_by("title")
         f = F({"lovers": [1]}, queryset=qs)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs, ["Ender's Game", "Rainbow Six"], lambda o: o.title
         )
 
@@ -1441,7 +1442,7 @@ class M2MRelationshipTests(TestCase):
                 fields = ["lovers"]
 
         f = F({"lovers": 1}, queryset=qs)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs, ["Ender's Game", "Rainbow Six"], lambda o: o.title
         )
 
@@ -1453,10 +1454,10 @@ class M2MRelationshipTests(TestCase):
 
         qs = User.objects.all().order_by("username")
         f = F({"favorite_books__title": "Ender's Game"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["aaron", "alex"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["aaron", "alex"], lambda o: o.username)
 
         f = F({"favorite_books__title": "Rainbow Six"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["alex"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["alex"], lambda o: o.username)
 
         class F(FilterSet):
             favorite_books__title = MultipleChoiceFilter()
@@ -1469,7 +1470,7 @@ class M2MRelationshipTests(TestCase):
         self.assertEqual(len(f.filters["favorite_books__title"].field.choices), 0)
         # f = F({'favorite_books__title': ['1', '3']},
         #     queryset=qs)
-        # self.assertQuerysetEqual(
+        # self.assertQuerySetEqual(
         #     f.qs, ['aaron', 'alex'], lambda o: o.username)
 
         class F(FilterSet):
@@ -1480,7 +1481,7 @@ class M2MRelationshipTests(TestCase):
                 fields = ["favorite_books__title"]
 
         f = F({"favorite_books__title": "Snowcrash"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["aaron"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["aaron"], lambda o: o.username)
 
     def test_reverse_m2m_relation_attribute(self):
         class F(FilterSet):
@@ -1490,12 +1491,12 @@ class M2MRelationshipTests(TestCase):
 
         qs = Book.objects.all().order_by("title")
         f = F({"lovers__username": "alex"}, queryset=qs)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs, ["Ender's Game", "Rainbow Six"], lambda o: o.title
         )
 
         f = F({"lovers__username": "jacob"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [], lambda o: o.title)
+        self.assertQuerySetEqual(f.qs, [], lambda o: o.title)
 
         class F(FilterSet):
             lovers__username = MultipleChoiceFilter()
@@ -1508,7 +1509,7 @@ class M2MRelationshipTests(TestCase):
         self.assertEqual(len(f.filters["lovers__username"].field.choices), 0)
         # f = F({'lovers__username': ['1', '3']},
         #     queryset=qs)
-        # self.assertQuerysetEqual(
+        # self.assertQuerySetEqual(
         #     f.qs, ["Ender's Game", "Rainbow Six"], lambda o: o.title)
 
         class F(FilterSet):
@@ -1519,7 +1520,7 @@ class M2MRelationshipTests(TestCase):
                 fields = ["lovers__username"]
 
         f = F({"lovers__username": "alex"}, queryset=qs)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs, ["Ender's Game", "Rainbow Six"], lambda o: o.title
         )
 
@@ -1535,13 +1536,13 @@ class M2MRelationshipTests(TestCase):
             {"favorite_books__price": "1.00", "favorite_books__average_rating": 4.0},
             queryset=qs,
         )
-        self.assertQuerysetEqual(f.qs, ["aaron"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["aaron"], lambda o: o.username)
 
         f = F(
             {"favorite_books__price": "3.00", "favorite_books__average_rating": 4.0},
             queryset=qs,
         )
-        self.assertQuerysetEqual(f.qs, [], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, [], lambda o: o.username)
 
     @unittest.expectedFailure
     def test_reverse_m2m_relation_multiple_attributes(self):
@@ -1552,12 +1553,12 @@ class M2MRelationshipTests(TestCase):
 
         qs = Book.objects.all().order_by("title")
         f = F({"lovers__status": 1, "lovers__username": "alex"}, queryset=qs)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs, ["Ender's Game", "Rainbow Six"], lambda o: o.title
         )
 
         f = F({"lovers__status": 1, "lovers__username": "jacob"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [], lambda o: o.title)
+        self.assertQuerySetEqual(f.qs, [], lambda o: o.title)
 
     @unittest.skip("todo")
     def test_fk_relation_on_m2m_relation(self):
@@ -1587,7 +1588,7 @@ class SymmetricalSelfReferentialRelationshipTests(TestCase):
 
         qs = Node.objects.all().order_by("pk")
         f = F({"adjacents": ["1"]}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [2, 4], lambda o: o.pk)
+        self.assertQuerySetEqual(f.qs, [2, 4], lambda o: o.pk)
 
 
 class NonSymmetricalSelfReferentialRelationshipTests(TestCase):
@@ -1609,7 +1610,7 @@ class NonSymmetricalSelfReferentialRelationshipTests(TestCase):
 
         qs = DirectedNode.objects.all().order_by("pk")
         f = F({"outbound_nodes": ["1"]}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [4], lambda o: o.pk)
+        self.assertQuerySetEqual(f.qs, [4], lambda o: o.pk)
 
     def test_reverse_relation(self):
         class F(FilterSet):
@@ -1619,7 +1620,7 @@ class NonSymmetricalSelfReferentialRelationshipTests(TestCase):
 
         qs = DirectedNode.objects.all().order_by("pk")
         f = F({"inbound_nodes": ["1"]}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [2], lambda o: o.pk)
+        self.assertQuerySetEqual(f.qs, [2], lambda o: o.pk)
 
 
 @override_settings(TIME_ZONE="UTC")
@@ -1641,7 +1642,7 @@ class TransformedQueryExpressionFilterTests(TestCase):
         qs = Article.objects.all()
         f = F({"published__hour__gte": 17}, queryset=qs)
         self.assertEqual(len(f.qs), 1)
-        self.assertQuerysetEqual(f.qs, [a.pk], lambda o: o.pk)
+        self.assertQuerySetEqual(f.qs, [a.pk], lambda o: o.pk)
 
 
 class LookupChoiceFilterTests(TestCase):
@@ -1670,12 +1671,12 @@ class LookupChoiceFilterTests(TestCase):
         F = self.BookFilter
 
         f = F({"price": "15", "price_lookup": "lt"})
-        self.assertQuerysetEqual(f.qs, ["Ender's Game"], lambda o: o.title)
+        self.assertQuerySetEqual(f.qs, ["Ender's Game"], lambda o: o.title)
         f = F({"price": "15", "price_lookup": "lt"})
-        self.assertQuerysetEqual(f.qs, ["Ender's Game"], lambda o: o.title)
+        self.assertQuerySetEqual(f.qs, ["Ender's Game"], lambda o: o.title)
         f = F({"price": "", "price_lookup": "lt"})
         self.assertTrue(f.is_valid())
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs,
             ["Ender's Game", "Rainbow Six", "Snowcrash"],
             lambda o: o.title,
@@ -1683,7 +1684,7 @@ class LookupChoiceFilterTests(TestCase):
         )
         f = F({"price": "15"})
         self.assertFalse(f.is_valid())
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs,
             ["Ender's Game", "Rainbow Six", "Snowcrash"],
             lambda o: o.title,
@@ -1779,7 +1780,7 @@ class CSVFilterTests(TestCase):
 
         for params, expected in cases:
             with self.subTest(params=params, expected=expected):
-                self.assertQuerysetEqual(
+                self.assertQuerySetEqual(
                     F(params, queryset=qs).qs, expected, attrgetter("pk")
                 )
 
@@ -1800,7 +1801,7 @@ class CSVFilterTests(TestCase):
 
         for params, expected in cases:
             with self.subTest(params=params, expected=expected):
-                self.assertQuerysetEqual(
+                self.assertQuerySetEqual(
                     F(params, queryset=qs).qs, expected, attrgetter("pk")
                 )
 
@@ -1842,7 +1843,7 @@ class CSVFilterTests(TestCase):
 
         for params, expected in cases:
             with self.subTest(params=params, expected=expected):
-                self.assertQuerysetEqual(
+                self.assertQuerySetEqual(
                     F(params, queryset=qs).qs, expected, attrgetter("pk")
                 )
 
@@ -1863,7 +1864,7 @@ class CSVFilterTests(TestCase):
 
         for params, expected in cases:
             with self.subTest(params=params, expected=expected):
-                self.assertQuerysetEqual(
+                self.assertQuerySetEqual(
                     F(params, queryset=qs).qs, expected, attrgetter("pk")
                 )
 
@@ -2001,7 +2002,7 @@ class MiscFilterSetTests(TestCase):
             username = CharFilter()
 
         f = F({"username": "alex"}, queryset=User.objects.all())
-        self.assertQuerysetEqual(f.qs, ["alex"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["alex"], lambda o: o.username)
 
     def test_filtering_with_multiple_filters(self):
         class F(FilterSet):
@@ -2012,10 +2013,10 @@ class MiscFilterSetTests(TestCase):
         qs = User.objects.all()
 
         f = F({"username": "alex", "status": "1"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["alex"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["alex"], lambda o: o.username)
 
         f = F({"username": "alex", "status": "2"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [], lambda o: o.pk)
+        self.assertQuerySetEqual(f.qs, [], lambda o: o.pk)
 
     def test_filter_with_initial(self):
         # Initial values are a form presentation option - the FilterSet should
@@ -2031,10 +2032,10 @@ class MiscFilterSetTests(TestCase):
         users = ["alex", "jacob", "aaron", "carl"]
 
         f = F(queryset=qs)
-        self.assertQuerysetEqual(f.qs.order_by("pk"), users, lambda o: o.username)
+        self.assertQuerySetEqual(f.qs.order_by("pk"), users, lambda o: o.username)
 
         f = F({"status": 0}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["carl"], lambda o: o.username)
+        self.assertQuerySetEqual(f.qs, ["carl"], lambda o: o.username)
 
     def test_qs_count(self):
         class F(FilterSet):
@@ -2074,20 +2075,20 @@ class MiscFilterSetTests(TestCase):
         qs = User.objects.all()
 
         f = F({"last_name": ["johnson"]}, queryset=qs)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs, ["alex", "jacob"], lambda o: o.username, ordered=False
         )
 
         f = F({"last_name": ["johnson"], "username": "carl"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, [], lambda o: o.username, ordered=False)
+        self.assertQuerySetEqual(f.qs, [], lambda o: o.username, ordered=False)
 
         f = F({"last_name": ["johnson"], "username": "jacob"}, queryset=qs)
-        self.assertQuerysetEqual(f.qs, ["jacob"], lambda o: o.username, ordered=False)
+        self.assertQuerySetEqual(f.qs, ["jacob"], lambda o: o.username, ordered=False)
 
         f = F(
             {"last_name": ["johnson", "white"], "username": "jacob, carl, aaron"},
             queryset=qs,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             f.qs, ["jacob", "aaron"], lambda o: o.username, ordered=False
         )


### PR DESCRIPTION
* To be removed in v25.
* Use drf-spectacular.

Closes [#1432](https://github.com/carltongibson/django-filter/issues/1432). Closes [#1573](https://github.com/carltongibson/django-filter/issues/1573).

Related deprecations fix: 

* Updated to use assertQuerySetEqual for Django 4.2+
   Add TestCase with fallback.