### PR TITLE
Add types for DjangoFilterBackend

### DIFF
--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, Dict, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from django.template import loader
 
@@ -10,8 +10,6 @@ from . import filters, filterset
 
 if TYPE_CHECKING:
     from django.db.models.query import QuerySet
-    from django.http.request import QueryDict
-    from django.utils.safestring import SafeString
     from rest_framework.generics import GenericAPIView
     from rest_framework.request import Request
 
@@ -28,7 +26,7 @@ class DjangoFilterBackend:
             return "django_filters/rest_framework/crispy_form.html"
         return "django_filters/rest_framework/form.html"
 
-    def get_filterset(self, request: Request, queryset: Q, view: Any) -> Optional[filterset.FilterSet]:
+    def get_filterset(self, request: Request, queryset: QuerySet[Any], view: GenericAPIView) -> filterset.FilterSet | None:
         filterset_class = self.get_filterset_class(view, queryset)
         if filterset_class is None:
             return None
@@ -36,7 +34,7 @@ class DjangoFilterBackend:
         kwargs = self.get_filterset_kwargs(request, queryset, view)
         return filterset_class(**kwargs)
 
-    def get_filterset_class(self, view: GenericAPIView, queryset: Optional[QuerySet]=None) -> Optional[type[filterset.FilterSet]]:
+    def get_filterset_class(self, view: GenericAPIView, queryset: QuerySet[Any] | None=None) -> type[filterset.FilterSet] | None:
         """
         Return the `FilterSet` class used to filter the queryset.
         """
@@ -69,7 +67,7 @@ class DjangoFilterBackend:
 
         return None
 
-    def get_filterset_kwargs(self, request: Request, queryset: QuerySet, view: GenericAPIView) -> Dict[str, Union[QueryDict, QuerySet, Request]]:
+    def get_filterset_kwargs(self, request: Request, queryset: QuerySet[Any], view: GenericAPIView) -> dict[str, Any]:
         return {
             "data": request.query_params,
             "queryset": queryset,
@@ -85,7 +83,7 @@ class DjangoFilterBackend:
             raise utils.translate_validation(filterset.errors)
         return filterset.qs
 
-    def to_html(self, request: Request, queryset: QuerySet, view: GenericAPIView) -> Optional[SafeString]:
+    def to_html(self, request: Request, queryset: QuerySet, view: GenericAPIView) -> str | None:
         filterset = self.get_filterset(request, queryset, view)
         if filterset is None:
             return None

--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -34,7 +34,7 @@ class DjangoFilterBackend:
         kwargs = self.get_filterset_kwargs(request, queryset, view)
         return filterset_class(**kwargs)
 
-    def get_filterset_class(self, view: GenericAPIView, queryset: QuerySet[Any] | None=None) -> type[filterset.FilterSet] | None:
+    def get_filterset_class(self, view: GenericAPIView, queryset: QuerySet[Any] | None = None) -> type[filterset.FilterSet] | None:
         """
         Return the `FilterSet` class used to filter the queryset.
         """

--- a/django_filters/rest_framework/backends.py
+++ b/django_filters/rest_framework/backends.py
@@ -1,9 +1,21 @@
+from __future__ import annotations
+
 import warnings
+from typing import TYPE_CHECKING, Any, Dict, Optional, TypeVar, Union
 
 from django.template import loader
 
 from .. import compat, utils
 from . import filters, filterset
+
+if TYPE_CHECKING:
+    from django.db.models.query import QuerySet
+    from django.http.request import QueryDict
+    from django.utils.safestring import SafeString
+    from rest_framework.generics import GenericAPIView
+    from rest_framework.request import Request
+
+    Q = TypeVar("Q", bound=QuerySet[Any])
 
 
 class DjangoFilterBackend:
@@ -11,12 +23,12 @@ class DjangoFilterBackend:
     raise_exception = True
 
     @property
-    def template(self):
+    def template(self) -> str:
         if compat.is_crispy():
             return "django_filters/rest_framework/crispy_form.html"
         return "django_filters/rest_framework/form.html"
 
-    def get_filterset(self, request, queryset, view):
+    def get_filterset(self, request: Request, queryset: Q, view: Any) -> Optional[filterset.FilterSet]:
         filterset_class = self.get_filterset_class(view, queryset)
         if filterset_class is None:
             return None
@@ -24,7 +36,7 @@ class DjangoFilterBackend:
         kwargs = self.get_filterset_kwargs(request, queryset, view)
         return filterset_class(**kwargs)
 
-    def get_filterset_class(self, view, queryset=None):
+    def get_filterset_class(self, view: GenericAPIView, queryset: Optional[QuerySet]=None) -> Optional[type[filterset.FilterSet]]:
         """
         Return the `FilterSet` class used to filter the queryset.
         """
@@ -57,14 +69,14 @@ class DjangoFilterBackend:
 
         return None
 
-    def get_filterset_kwargs(self, request, queryset, view):
+    def get_filterset_kwargs(self, request: Request, queryset: QuerySet, view: GenericAPIView) -> Dict[str, Union[QueryDict, QuerySet, Request]]:
         return {
             "data": request.query_params,
             "queryset": queryset,
             "request": request,
         }
 
-    def filter_queryset(self, request, queryset, view):
+    def filter_queryset(self, request: Request, queryset: Q, view: Any) -> Q:
         filterset = self.get_filterset(request, queryset, view)
         if filterset is None:
             return queryset
@@ -73,7 +85,7 @@ class DjangoFilterBackend:
             raise utils.translate_validation(filterset.errors)
         return filterset.qs
 
-    def to_html(self, request, queryset, view):
+    def to_html(self, request: Request, queryset: QuerySet, view: GenericAPIView) -> Optional[SafeString]:
         filterset = self.get_filterset(request, queryset, view)
         if filterset is None:
             return None
@@ -129,7 +141,7 @@ class DjangoFilterBackend:
             ]
         )
 
-    def get_schema_operation_parameters(self, view):
+    def get_schema_operation_parameters(self, view: GenericAPIView) -> Any:
         from django_filters import RemovedInDjangoFilter25Warning
         warnings.warn(
             "Built-in schema generation is deprecated. Use drf-spectacular.",


### PR DESCRIPTION
After recent changes to pyright, we need to add proper types for django-filters for it to pass type-checking.

**Required** changes is only `filter_queryset` types, but i have added other as well.

~~This is draft, and it still not working as expected, but i will update this and djangoresframework-types after some discussion in pyright repo, on how to do this better.~~

~~Main problem is that `djangorestframework-types` have included MongoQuerySet in it's types, and i don't want to drag it here. Maybe it's better to replace it with some sort protocol there.~~