### PR TITLE
Fix error when a comma is given as input for an OrderingFilter

### DIFF
--- a/django_filters/fields.py
+++ b/django_filters/fields.py
@@ -190,6 +190,15 @@ class BaseCSVField(forms.Field):
         return [super(BaseCSVField, self).clean(v) for v in value]
 
 
+class BaseOrderingField(BaseCSVField):
+    # Remove empty strings from the value, as attempting to order
+    # by an empty string causes a FieldError.
+
+    def clean(self, value):
+        value = super().clean(value)
+        return [v for v in value if v != ""]
+
+
 class BaseRangeField(BaseCSVField):
     # Force use of text input, as range must always have two inputs. A date
     # input would only allow a user to input one value and would always fail.

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -14,6 +14,7 @@ from .conf import settings
 from .constants import EMPTY_VALUES
 from .fields import (
     BaseCSVField,
+    BaseOrderingField,
     BaseRangeField,
     ChoiceField,
     DateRangeField,
@@ -24,7 +25,6 @@ from .fields import (
     ModelChoiceField,
     ModelMultipleChoiceField,
     MultipleChoiceField,
-    BaseOrderingField,
     RangeField,
     TimeRangeField,
 )

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -24,6 +24,7 @@ from .fields import (
     ModelChoiceField,
     ModelMultipleChoiceField,
     MultipleChoiceField,
+    BaseOrderingField,
     RangeField,
     TimeRangeField,
 )
@@ -718,6 +719,7 @@ class OrderingFilter(BaseCSVFilter, ChoiceFilter):
 
     """
 
+    base_field_class = BaseOrderingField
     descending_fmt = _("%s (descending)")
 
     def __init__(self, *args, **kwargs):

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1977,6 +1977,19 @@ class OrderingFilterTests(TestCase):
         names = f.qs.values_list("username", flat=True)
         self.assertEqual(list(names), ["aaron", "alex", "carl", "jacob"])
 
+    def test_csv_input(self):
+        class F(FilterSet):
+            o = OrderingFilter(widget=forms.Select, fields=("username",))
+
+            class Meta:
+                model = User
+                fields = ["username"]
+
+        qs = User.objects.all()
+        f = F({"o": ","}, queryset=qs)
+        f.qs
+        value = f.form.cleaned_data["o"]
+        self.assertEqual(value, [])
 
 class MiscFilterSetTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
Fix FieldError when `","` is given as the value for an OrderingFilter. Issue #1597 