### PR TITLE
Use Furo theme

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,5 +14,4 @@ build:
 
 python:
   install:
-    - method: pip
-      path: .
+    - requirements: requirements/docs.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,7 +94,7 @@ pygments_style = "sphinx"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = "default"
+html_theme = "furo"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -257,15 +257,3 @@ texinfo_documents = [
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 # texinfo_show_urls = 'footnote'
-
-
-# see:
-# https://github.com/snide/sphinx_rtd_theme#using-this-theme-locally-then-building-on-read-the-docs
-on_rtd = os.environ.get("READTHEDOCS", None) == "True"
-
-# only import and set the theme if we're building docs locally
-if not on_rtd:
-    import sphinx_rtd_theme
-
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,0 +1,3 @@
+Sphinx
+furo
+.


### PR DESCRIPTION
Add 'furo' dependency to a new documentation-specific requirements.txt to have it available during the build process on ReadTheDocs and configure Sphinx to use it.

Configuration directives for the sphinx-rtd theme are no longer required.

Closes #1610

A preview is available on [django-filter-furo.readthedocs.io](https://django-filter-furo.readthedocs.io) as long as this pull request is open.