### PR TITLE
Made tox use requirements/docs.txt

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,8 +36,7 @@ deps = flake8
 [testenv:docs]
 commands = sphinx-build -WE docs _docs
 deps =
-    sphinx
-    furo
+    -rrequirements/docs.txt
 
 [testenv:warnings]
 ignore_outcome = True


### PR DESCRIPTION
In 0fa5fed I missed that the dependencies for tox are installed separately. To prevent tox from breaking again with the next theme update, let's use the requirements file.

Sorry for the oversight.