### PR TITLE
Fix DeprecationWarning for pkgutil.find_loader

### DIFF
--- a/django_filters/__init__.py
+++ b/django_filters/__init__.py
@@ -1,14 +1,14 @@
 # flake8: noqa
-import pkgutil
+from importlib import util as importlib_util
 
 from .filters import *
 from .filterset import FilterSet
 
 # We make the `rest_framework` module available without an additional import.
 #   If DRF is not installed, no-op.
-if pkgutil.find_loader("rest_framework") is not None:
+if importlib_util.find_spec("rest_framework"):
     from . import rest_framework
-del pkgutil
+del importlib_util
 
 __version__ = "23.3"
 


### PR DESCRIPTION
The `find_loader` function is deprecated in Python 3.12 and slated for removal in Python 3.14. The function is a wrapper around `importlib.util.find_spec`, and returning the `loader` attribute from that call. The code isn't using the loader, and only checking that the import path exists, so we may use the wrapped function directly, instead.

fixes: #1616