### PR TITLE
Fixed OrderingFilter handling of empty values.

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -759,7 +759,11 @@ class OrderingFilter(BaseCSVFilter, ChoiceFilter):
         if value in EMPTY_VALUES:
             return qs
 
-        ordering = [self.get_ordering_value(param) for param in value]
+        ordering = [
+            self.get_ordering_value(param)
+            for param in value
+            if param not in EMPTY_VALUES
+        ]
         return qs.order_by(*ordering)
 
     @classmethod


### PR DESCRIPTION
A trailing comma would cause a crash trying to map an empty value to a field name. Ensure sub-values are filtered for EMPTY_VALUES in addition to the main filter data.

Closes #1597.

Hi @munnsmunns, @scott-8. Sorry for the slow uptake: it was a while getting the bandwidth. 

Here's an alternate take on #1598. 

The behaviour of `CSVWidget` to map `","` to `["",""]` is [covered by regression tests](https://github.com/carltongibson/django-filter/blob/b9ded7423f8c6848a9a389e8ce63ed1b0ebe3cfb/tests/test_widgets.py#L394-L396), so `OrderingFilter` needs to filter these prior to filtering. The natural place for such is in the `filter` method, where the empty check occurs for all filters. 

If you have the space, could you give it a run and let me know if it works for you? Thanks. 

