### PR TITLE
fix: allow passing a filterset class to the filterset factory

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -458,9 +458,15 @@ class FilterSet(BaseFilterSet, metaclass=FilterSetMetaclass):
     pass
 
 
-def filterset_factory(model, fields=ALL_FIELDS):
-    meta = type(str("Meta"), (object,), {"model": model, "fields": fields})
-    filterset = type(
-        str("%sFilterSet" % model._meta.object_name), (FilterSet,), {"Meta": meta}
+def filterset_factory(model, filterset=FilterSet, fields=None):
+    attrs = {"model": model}
+    if fields is None:
+        if getattr(getattr(filterset, "Meta", {}), "fields", None) is None:
+            attrs["fields"] = ALL_FIELDS
+    else:
+        attrs["fields"] = fields
+    bases = (filterset.Meta,) if hasattr(filterset, "Meta") else ()
+    Meta = type("Meta", bases, attrs)
+    return type(filterset)(
+        str("%sFilterSet" % model._meta.object_name), (filterset,), {"Meta": Meta}
     )
-    return filterset

--- a/docs/ref/filterset.txt
+++ b/docs/ref/filterset.txt
@@ -199,3 +199,22 @@ filters for a model field, you can override ``filter_for_lookup()``. Ex::
 
             # use default behavior otherwise
             return super().filter_for_lookup(f, lookup_type)
+
+
+.. _filterset_factory:
+
+Using ``filterset_factory``
+---------------------------
+
+A ``FilterSet`` for a ``model`` can also be created by the
+``filterset_factory``, which creats a ``FilterSet`` with the ``model`` set in
+the FilterSets Meta. You can pass a customized ``FilterSet`` class to the
+``filterset_factory``, which then uses this class a a base for the created
+``FilterSet``. Ex::
+
+    class CustomFilterSet(django_filters.FilterSet):
+        class Meta:
+            form = CustomFilterSetForm
+
+
+    filterset = filterset_factory(Product, filterset=CustomFilterSet)


### PR DESCRIPTION
I've tried to reuse the variable name terminology from `django.forms.models.modelform_factory`

Closes: #1631