### PR TITLE
fix: Move compatibility TestCase implementation to test utils

### DIFF
--- a/django_filters/compat.py
+++ b/django_filters/compat.py
@@ -1,11 +1,4 @@
-import django
 from django.conf import settings
-from django.test import TestCase
-
-if django.VERSION < (4, 2):
-    class TestCase(TestCase):
-        assertQuerySetEqual = TestCase.assertQuerysetEqual
-
 
 # django-crispy-forms is optional
 try:

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -11,7 +11,6 @@ from django.test import override_settings
 from django.utils import timezone
 from django.utils.timezone import make_aware, now
 
-from django_filters.compat import TestCase
 from django_filters.filters import (
     AllValuesFilter,
     AllValuesMultipleFilter,
@@ -50,7 +49,7 @@ from .models import (
     SpacewalkRecord,
     User,
 )
-from .utils import MockQuerySet
+from .utils import MockQuerySet, TestCase
 
 
 class CharFilterTests(TestCase):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,12 @@
 from unittest import mock
 
+import django
 from django.db import models
+from django.test import TestCase
+
+if django.VERSION < (4, 2):
+    class TestCase(TestCase):
+        assertQuerySetEqual = TestCase.assertQuerysetEqual
 
 
 class QuerySet(models.QuerySet):


### PR DESCRIPTION
Having the `TestCase` class as part of `compat` makes applications require to import the `django.test` path and any downstream dependencies.

This is adding import time to time-sensitive executions, which can be avoided as `TestCase` is only used for internal testing.

![image](https://github.com/carltongibson/django-filter/assets/3867850/046c24f9-d05a-488a-8838-fa770b8ffd35)
