### PR TITLE
feat: Update supported Python and Django versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v2

--- a/django_filters/compat.py
+++ b/django_filters/compat.py
@@ -1,11 +1,4 @@
-import django
 from django.conf import settings
-from django.test import TestCase
-
-if django.VERSION < (4, 2):
-    class TestCase(TestCase):
-        assertQuerySetEqual = TestCase.assertQuerysetEqual
-
 
 # django-crispy-forms is optional
 try:

--- a/django_filters/utils.py
+++ b/django_filters/utils.py
@@ -231,18 +231,14 @@ def resolve_field(model_field, lookup_expr):
 
 def handle_timezone(value, is_dst=None):
     if settings.USE_TZ and timezone.is_naive(value):
-        # Pre-4.x versions of Django have is_dst. Later Django versions have
-        # zoneinfo where the is_dst argument has no meaning. is_dst will be
-        # removed in the 5.x series.
-        #
-        # On intermediate versions, the default is to use zoneinfo, but pytz
+        # On pre-5.x versions, the default is to use zoneinfo, but pytz
         # is still available under USE_DEPRECATED_PYTZ, and is_dst is
         # meaningful there. Under those versions we should only use is_dst
         # if USE_DEPRECATED_PYTZ is present and True; otherwise, we will cause
         # deprecation warnings, and we should not. See #1580.
         #
-        # This can be removed once 3.2 is no longer supported upstream.
-        if django.VERSION < (4, 0) or (django.VERSION < (5, 0) and settings.USE_DEPRECATED_PYTZ):
+        # This can be removed once 4.2 is no longer supported upstream.
+        if django.VERSION < (5, 0) and settings.USE_DEPRECATED_PYTZ:
             return timezone.make_aware(value, timezone.get_current_timezone(), is_dst)
         return timezone.make_aware(value, timezone.get_current_timezone())
     elif not settings.USE_TZ and timezone.is_aware(value):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,22 +16,18 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.7"
-dependencies = ["Django>=3.2"]
+requires-python = ">=3.8"
+dependencies = ["Django>=4.2"]
 dynamic = ["version"]
 
 [project.urls]

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -7,11 +7,10 @@ from unittest import mock
 import django
 from django import forms
 from django.http import QueryDict
-from django.test import override_settings
+from django.test import TestCase, override_settings
 from django.utils import timezone
 from django.utils.timezone import make_aware, now
 
-from django_filters.compat import TestCase
 from django_filters.filters import (
     AllValuesFilter,
     AllValuesMultipleFilter,

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
 envlist =
-       {py38,py39,py310}-django32,
-       {py38,py39}-{django42},
-       {py310, py311}-{django42,latest},
-       {py310, py311, py312}-{django42,django50,latest},
+       {py38, py39, py310, py311, py312}-django42,
+       {py310, py311, py312}-django50,
+       {py310, py311, py312}-latest,
        isort,lint,docs,warnings,
 isolated_build = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-       {py37,py38,py39,py310}-django32,
-       {py38,py39}-{django40,django41,django42},
-       {py310, py311}-{django41,django42,latest},
-       {py310, py311, py312}-{django41,django42,django50,latest},
+       {py38,py39,py310}-django32,
+       {py38,py39}-{django42},
+       {py310, py311}-{django42,latest},
+       {py310, py311, py312}-{django42,django50,latest},
        isort,lint,docs,warnings,
 isolated_build = true
 
@@ -18,9 +18,6 @@ commands = coverage run --parallel-mode --source django_filters ./runtests.py --
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
-    django32: django~=3.2.0
-    django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<4.2
     django42: Django>=4.2rc1,<5.0
     django50: Django>=5.0b1,<5.1
     !latest: djangorestframework


### PR DESCRIPTION
Minimal Django version is now 4.2 (oldest supported version upstream [1]) Minimal Python version is now 3.8 (oldest Python version supported by Django 4.2)

[1] https://www.djangoproject.com/download/#supported-versions