### PR TITLE
remove `...` in rest_framework.txt to make life easy

### DIFF
--- a/docs/guide/rest_framework.txt
+++ b/docs/guide/rest_framework.txt
@@ -39,7 +39,6 @@ If you want to use the django-filter backend by default, add it to the ``DEFAULT
 
     # settings.py
     INSTALLED_APPS = [
-        ...
         'rest_framework',
         'django_filters',
     ]
@@ -47,7 +46,6 @@ If you want to use the django-filter backend by default, add it to the ``DEFAULT
     REST_FRAMEWORK = {
         'DEFAULT_FILTER_BACKENDS': (
             'django_filters.rest_framework.DjangoFilterBackend',
-            ...
         ),
     }
 

--- a/docs/guide/rest_framework.txt
+++ b/docs/guide/rest_framework.txt
@@ -39,6 +39,7 @@ If you want to use the django-filter backend by default, add it to the ``DEFAULT
 
     # settings.py
     INSTALLED_APPS = [
+        # ...
         'rest_framework',
         'django_filters',
     ]
@@ -46,6 +47,7 @@ If you want to use the django-filter backend by default, add it to the ``DEFAULT
     REST_FRAMEWORK = {
         'DEFAULT_FILTER_BACKENDS': (
             'django_filters.rest_framework.DjangoFilterBackend',
+            # ...
         ),
     }
 


### PR DESCRIPTION
Someone silly like me, who just copies and posts the code snippet with the ..., will get an exception `AttributeError: 'ellipsis' object has no attribute 'rsplit'`. So let's just remove it and make life easy.