### PR TITLE
Fix docs example about Model[Multiple]ChoiceFilter

### DIFF
--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -378,7 +378,7 @@ To use a custom field name for the lookup, you can use ``to_field_name``::
 
     class FooFilter(BaseFilterSet):
         foo = django_filters.filters.ModelMultipleChoiceFilter(
-            field_name='attr__uuid',
+            field_name='attr',
             to_field_name='uuid',
             queryset=Foo.objects.all(),
         )


### PR DESCRIPTION
This PR simply changes the documentation example. In this case, as I explained in this [this issue](https://github.com/carltongibson/django-filter/issues/1661), the `__uuid` suffix for the `field_name` attribute is not necessary!