### PR TITLE
Add unknown_field_behavior feature

### DIFF
--- a/django_filters/__init__.py
+++ b/django_filters/__init__.py
@@ -2,7 +2,7 @@
 from importlib import util as importlib_util
 
 from .filters import *
-from .filterset import FilterSet
+from .filterset import FilterSet, UnknownFieldBehavior
 
 # We make the `rest_framework` module available without an additional import.
 #   If DRF is not installed, no-op.

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -1,4 +1,5 @@
 import copy
+import warnings
 from collections import OrderedDict
 
 from django import forms
@@ -52,6 +53,8 @@ class FilterSetOptions:
         self.filter_overrides = getattr(options, "filter_overrides", {})
 
         self.form = getattr(options, "form", forms.Form)
+
+        self.unknown_field_behavior = getattr(options, "unknown_field_behavior", "raise")
 
 
 class FilterSetMetaclass(type):
@@ -338,9 +341,11 @@ class BaseFilterSet:
                     continue
 
                 if field is not None:
-                    filters[filter_name] = cls.filter_for_field(
+                    filter_instance = cls.filter_for_field(
                         field, field_name, lookup_expr
                     )
+                    if filter_instance is not None:
+                        filters[filter_name] = filter_instance
 
         # Allow Meta.fields to contain declared filters *only* when a list/tuple
         if isinstance(cls._meta.fields, (list, tuple)):
@@ -358,6 +363,18 @@ class BaseFilterSet:
         return filters
 
     @classmethod
+    def handle_unrecognized_field(cls, field_name, message):
+        behavior = cls._meta.unknown_field_behavior
+        if behavior == "raise":
+            raise AssertionError(message)
+        elif behavior == "warn":
+            warnings.warn(f"Unrecognized field type for '{field_name}'. Field will be ignored.")
+        elif behavior == "ignore":
+            pass
+        else:
+            raise ValueError(f"Invalid unknown_field_behavior: {behavior}")
+
+    @classmethod
     def filter_for_field(cls, field, field_name, lookup_expr=None):
         if lookup_expr is None:
             lookup_expr = settings.DEFAULT_LOOKUP_EXPR
@@ -371,12 +388,14 @@ class BaseFilterSet:
         filter_class, params = cls.filter_for_lookup(field, lookup_type)
         default.update(params)
 
-        assert filter_class is not None, (
-            "%s resolved field '%s' with '%s' lookup to an unrecognized field "
-            "type %s. Try adding an override to 'Meta.filter_overrides'. See: "
-            "https://django-filter.readthedocs.io/en/main/ref/filterset.html"
-            "#customise-filter-generation-with-filter-overrides"
-        ) % (cls.__name__, field_name, lookup_expr, field.__class__.__name__)
+        if filter_class is None:
+            cls.handle_unrecognized_field(field_name, (
+                "%s resolved field '%s' with '%s' lookup to an unrecognized field "
+                "type %s. Try adding an override to 'Meta.filter_overrides'. See: "
+                "https://django-filter.readthedocs.io/en/main/ref/filterset.html"
+                "#customise-filter-generation-with-filter-overrides"
+            ) % (cls.__name__, field_name, lookup_expr, field.__class__.__name__))
+            return None
 
         return filter_class(**default)
 

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -383,6 +383,8 @@ class BaseFilterSet:
             warnings.warn(f"Unrecognized field type for '{field_name}'. Field will be ignored.")
         elif behavior == UnknownFieldBehavior.IGNORE:
             pass
+        else:
+            raise ValueError(f"Invalid unknown_field_behavior: {behavior}")
 
     @classmethod
     def filter_for_field(cls, field, field_name, lookup_expr=None):

--- a/docs/ref/filterset.txt
+++ b/docs/ref/filterset.txt
@@ -12,6 +12,7 @@ Meta options
 - :ref:`exclude <exclude>`
 - :ref:`form <form>`
 - :ref:`filter_overrides <filter_overrides>`
+- :ref:`unknown_field_behavior <unknown_field_behavior>`
 
 
 .. _model:
@@ -145,6 +146,34 @@ This is a map of model fields to filter classes with options::
                     },
                 },
             }
+
+
+.. _unknown_field_behavior:
+
+Handling unknown fields with ``unknown_field_behavior``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``unknown_field_behavior`` option specifies how unknown fields are handled 
+in a ``FilterSet``. You can set this option using the values of the 
+``UnknownFieldBehavior`` enum:
+
+- ``UnknownFieldBehavior.RAISE``: Raise an assertion error (default)
+- ``UnknownFieldBehavior.WARN``: Issue a warning and ignore the field
+- ``UnknownFieldBehavior.IGNORE``: Silently ignore the field
+
+Note that both the ``WARN`` and ``IGNORE`` options do not include the unknown 
+field(s) in the list of filters.
+
+.. code-block:: python
+
+    from django_filters import UnknownFieldBehavior
+
+    class UserFilter(django_filters.FilterSet):
+        class Meta:
+            model = User
+            fields = ['username', 'last_login']
+            unknown_field_behavior = UnknownFieldBehavior.WARN
+
 
 Overriding ``FilterSet`` methods
 --------------------------------


### PR DESCRIPTION
Based on the suggestion mentioned in #1666, I have added the `handle_unrecognized_field` method to the `BaseFilterSet` and a new option `unknown_field_behavior` in `FilterSetOptions` where users can specify how unrecognized field types should be handled (raise - default, warn, ignore).

Changes include:
- Implementation of `handle_unrecognized_field` method in `BaseFilterSet`, including new `FilterSet` option
- Add tests for `raise`, `warn`, `ignore`, and `invalid` behaviors