### PR TITLE
Change dummy queryset qualifier from "all" to "none"

### DIFF
--- a/django_filters/utils.py
+++ b/django_filters/utils.py
@@ -201,7 +201,7 @@ def resolve_field(model_field, lookup_expr):
     https://docs.djangoproject.com/en/stable/ref/models/lookups/
 
     """
-    query = model_field.model._default_manager.all().query
+    query = model_field.model._default_manager.none().query
     lhs = Expression(model_field)
     lookups = lookup_expr.split(LOOKUP_SEP)
 


### PR DESCRIPTION
As is, django-filter is not compatible with [django-scopes](https://github.com/raphaelm/django-scopes). Django-scopes is an additional guardrail which prevents accidental data exposure. It replaces the default manager of a model with a specialized manager that will refuse queries, unless a scope is active, that is there is a restriction along the critical dimensions are present.

This breaks most usages of the `.all()` queryset. But luckily, many usages that only care about the queryset itself and not the contents can be replaced with `.none()`.

This pull request replaces the critical all usage with none. Nothing else is changed.

Example exception fixed by this PR:

````
 [...]
  File "venv\Lib\site-packages\django_filters\rest_framework\backends.py", line 51, in get_filterset_class
    class AutoFilterSet(self.filterset_base):
  File "venv\Lib\site-packages\django_filters\filterset.py", line 62, in __new__
    new_class.base_filters = new_class.get_filters()
                             ^^^^^^^^^^^^^^^^^^^^^^^
  File "venv\Lib\site-packages\django_filters\filterset.py", line 340, in get_filters
    filters[filter_name] = cls.filter_for_field(
                           ^^^^^^^^^^^^^^^^^^^^^
  File "venv\Lib\site-packages\django_filters\filterset.py", line 363, in filter_for_field
    field, lookup_type = resolve_field(field, lookup_expr)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "venv\Lib\site-packages\django_filters\utils.py", line 204, in resolve_field
    query = model_field.model._default_manager.all().query
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "venv\Lib\site-packages\django_scopes\manager.py", line 94, in all
    a = a.all()
        ^^^^^^^
  File "venv\Lib\site-packages\django_scopes\manager.py", line 14, in error
    raise ScopeError("A scope on dimension(s) {} needs to be active for this query.".format(
django_scopes.exceptions.ScopeError: A scope on dimension(s) XXX needs to be active for this query.
````