### PR TITLE
Add support for Django 5.0 GeneratedField

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -8,6 +8,10 @@ from django.db import models
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.fields.related import ManyToManyRel, ManyToOneRel, OneToOneRel
 from django.http import QueryDict
+try:
+    from django.db.models import GeneratedField
+except ImportError:
+    GeneratedField = None
 
 from .conf import settings
 from .constants import ALL_FIELDS
@@ -396,6 +400,13 @@ class BaseFilterSet:
     def filter_for_field(cls, field, field_name, lookup_expr=None):
         if lookup_expr is None:
             lookup_expr = settings.DEFAULT_LOOKUP_EXPR
+
+        # Handle GeneratedField by extracting the underlying output_field
+        if GeneratedField is not None and isinstance(field, GeneratedField):
+            output_field = field.output_field
+            output_field.model = field.model
+            field = output_field
+
         field, lookup_type = resolve_field(field, lookup_expr)
 
         default = {

--- a/tests/models.py
+++ b/tests/models.py
@@ -210,3 +210,23 @@ class SpacewalkRecord(models.Model):
 
     astronaut = models.CharField(max_length=100)
     duration = models.DurationField()
+
+
+# GeneratedField test model (Django 5.0+)
+try:
+    from django.db.models import GeneratedField
+    from django.db.models.functions import Round
+
+    class Rectangle(models.Model):
+        """Test model for GeneratedField support."""
+        width = models.FloatField()
+        height = models.FloatField()
+        area = GeneratedField(
+            expression=Round(models.F("width") * models.F("height"), precision=2),
+            output_field=models.FloatField(),
+            db_persist=True,
+        )
+
+except ImportError:
+    # GeneratedField not available (Django < 5.0)
+    Rectangle = None

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -48,6 +48,10 @@ from .models import (
     Worker,
 )
 from .utils import MockQuerySet
+try:
+    from .models import Rectangle
+except ImportError:
+    Rectangle = None
 
 
 class HelperMethodsTests(TestCase):
@@ -207,6 +211,17 @@ class FilterSetFilterForFieldTests(TestCase):
         result = FilterSet.filter_for_field(f, "username")
         self.assertIsInstance(result, CharFilter)
         self.assertEqual(result.lookup_expr, "icontains")
+
+    def test_filter_found_for_generatedfield(self):
+        """Test that GeneratedField is properly handled by extracting output_field."""
+        if Rectangle is None:
+            self.skipTest("GeneratedField requires Django 5.0+")
+
+        f = Rectangle._meta.get_field("area")
+        result = FilterSet.filter_for_field(f, "area")
+        # GeneratedField with FloatField output should produce NumberFilter
+        self.assertIsInstance(result, NumberFilter)
+        self.assertEqual(result.field_name, "area")
 
     @unittest.skip("todo")
     def test_filter_overrides(self):


### PR DESCRIPTION
## Summary
Adds support for filtering on Django 5.0's `GeneratedField` type.

## Problem
When using `GeneratedField` in a model, django-filter raises:
> "AssertionError: FilterSet resolved field 'field_name' with 'exact' lookup to an unrecognized field type GeneratedField"

Fixes #1673

## Solution
- Detect `GeneratedField` instances in `filter_for_field()`
- Extract the underlying `output_field` attribute
- Copy the `model` attribute to the output field
- Use the output field type to determine the appropriate filter class
- Backward compatible: gracefully handles Django < 5.0

## Testing
- Added `Rectangle` test model with computed `area` field
- Added test `test_filter_found_for_generatedfield()`
- Tests skip gracefully on Django < 5.0

## Checklist
- [x] Tests added
- [x] Backward compatible with Django < 5.0
- [x] Passes all CI checks