### PR TITLE
Add NullFilter for null/non-null filtering with docs and test

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -69,6 +69,7 @@ __all__ = [
     "TypedChoiceFilter",
     "TypedMultipleChoiceFilter",
     "UUIDFilter",
+    "NullFilter",
 ]
 
 
@@ -174,6 +175,25 @@ class CharFilter(Filter):
 
 class BooleanFilter(Filter):
     field_class = forms.NullBooleanField
+
+
+class NullFilter(BooleanFilter):
+    """
+    Here the fitler checks wheather a field is null or not based on the boolean value provided.
+
+    usage: deleted=Nullfilter(field_name='deleted_at')
+
+    query params:
+        ?deleted=true -> feild is Null
+        ?deleted=false -> field is not Null
+    
+    """
+    def filter(self, qs, value):
+        if value is None:
+            return qs
+        
+        lookup=f"{self.field_name}__isnull"
+        return qs.filter(**{lookup: bool(value)})
 
 
 class ChoiceFilter(Filter):

--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -184,6 +184,36 @@ This filter matches UUID values, used with :class:`~django.db.models.UUIDField` 
 This filter matches a boolean, either ``True`` or ``False``, used with
 :class:`~django.db.models.BooleanField` and ``NullBooleanField`` by default.
 
+.. class:: NullFilter
+
+This filter checks whether a field is ``NULL`` or not based on a boolean value.
+It uses the ``isnull`` lookup expression and is useful for filtering records
+with null/empty datetime fields (such as soft-delete timestamps).
+
+The filter accepts a boolean value:
+
+* ``true`` - matches records where the field IS NULL
+* ``false`` - matches records where the field IS NOT NULL
+
+Example usage::
+
+    class Article(models.Model):
+        title = models.CharField(max_length=100)
+        deleted_at = models.DateTimeField(null=True, blank=True)
+
+    class ArticleFilter(django_filters.FilterSet):
+        is_deleted = NullFilter(field_name='deleted_at')
+
+        class Meta:
+            model = Article
+            fields = []
+
+    # Filter for deleted articles (deleted_at IS NULL)
+    f = ArticleFilter({'is_deleted': 'true'})
+
+    # Filter for active articles (deleted_at IS NOT NULL)
+    f = ArticleFilter({'is_deleted': 'false'})
+
 .. _choice-filter:
 .. class:: ChoiceFilter
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -49,7 +49,11 @@ from django_filters.filters import (
     TypedMultipleChoiceFilter,
     UUIDFilter,
 )
+from django_filters.filters import NullFilter 
 from tests.models import Book, User
+from django_filters import FilterSet
+from django.db import models
+
 
 
 class ModuleImportTests(TestCase):
@@ -1727,3 +1731,44 @@ class OrderingFilterTests(TestCase):
         # regression test for #756 - the usual CSV help_text is not relevant to ordering filters.
         self.assertEqual(OrderingFilter().field.help_text, "")
         self.assertEqual(OrderingFilter(help_text="a").field.help_text, "a")
+
+"""
+Null filter tests
+"""
+
+
+class TempModel(models.Model):
+    title = models.CharField(max_length=100)
+    deleted_at = models.DateTimeField(null=True, blank=True)
+
+
+class NullFilterTests(TestCase):
+
+    class TempFilter(FilterSet):
+        deleted = NullFilter(field_name="deleted_at")
+
+        class Meta:
+            model = TempModel
+            fields = []
+
+    def test_nullfilter_true(self):
+        item1 = TempModel.objects.create(title="A", deleted_at=None)
+        item2 = TempModel.objects.create(title="B", deleted_at="2025-01-01")
+
+        f = self.TempFilter({"deleted": "true"}, queryset=TempModel.objects.all())
+        qs = f.qs
+
+        self.assertEqual(qs.count(), 1)
+        self.assertIn(item1, qs)
+        self.assertNotIn(item2, qs)
+
+    def test_nullfilter_false(self):
+        item1 = TempModel.objects.create(title="A", deleted_at=None)
+        item2 = TempModel.objects.create(title="B", deleted_at="2025-01-01")
+
+        f = self.TempFilter({"deleted": "false"}, queryset=TempModel.objects.all())
+        qs = f.qs
+
+        self.assertEqual(qs.count(), 1)
+        self.assertIn(item2, qs)
+        self.assertNotIn(item1, qs)


### PR DESCRIPTION
### Summary
This PR introduces a new `NullFilter` class that enables filtering queryset
results based on whether a field is NULL or NOT NULL. This provides a clean,
first-class API for handling null checks without the need for custom filter
methods.

### Reason
Null filtering is a common requirement in Django applications, especially in
soft-delete patterns where a nullable timestamp (e.g., `deleted_at`) is used to
indicate deleted objects. While Django provides the `isnull` lookup, there is
currently no dedicated filter that maps boolean input values to the appropriate
`isnull` behavior.

`NullFilter` addresses this need by extending `BooleanFilter` and applying the
lookup internally.

### Usage

```python
class ProductFilter(FilterSet):
    deleted = NullFilter(field_name="deleted_at")