### PR TITLE
Small patch to OrderingFilter to allow for using query expressions instead of plain field names

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -723,8 +723,10 @@ class OrderingFilter(BaseCSVFilter, ChoiceFilter):
       parameter names are exposed in the choices and mask/alias the field
       names used in the ``order_by()`` call. Similar to field ``choices``,
       ``fields`` accepts the 'list of two-tuples' syntax that retains order.
-      ``fields`` may also just be an iterable of strings. In this case, the
-      field names simply double as the exposed parameter names.
+      The two-tuples syntax additionally allows for specifying query
+      expressions like ``Coalesce("summary", "headline")`` instead of field
+      names. ``fields`` may also just be an iterable of strings. In this case,
+      the field names simply double as the exposed parameter names.
 
     * ``field_labels`` is an optional argument that allows you to customize
       the display label for the corresponding parameter. It accepts a mapping
@@ -767,7 +769,13 @@ class OrderingFilter(BaseCSVFilter, ChoiceFilter):
         param = param[1:] if descending else param
         field_name = self.param_map.get(param, param)
 
-        return "-%s" % field_name if descending else field_name
+        if not descending:
+            return field_name
+        elif isinstance(field_name, str):
+            return "-%s" % field_name
+        else:
+            # assume field_name is a query expression
+            return field_name.desc()
 
     def filter(self, qs, value):
         if value in EMPTY_VALUES:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import django
 from django import forms
+from django.db.models import F
 from django.test import TestCase, override_settings
 from django.utils import translation
 from django.utils.translation import gettext as _
@@ -1573,6 +1574,18 @@ class OrderingFilterTests(TestCase):
         f = OrderingFilter(fields={"a": "b"})
         f.filter(qs, ["b", "-b"])
         qs.order_by.assert_called_once_with("a", "-a")
+
+    def test_filtering_with_query_expression(self):
+        qs = mock.Mock(spec=["order_by"])
+        f = OrderingFilter(fields=((F("a"), "a"),))
+        f.filter(qs, ["a"])
+        qs.order_by.assert_called_once_with(F("a"))
+
+    def test_filtering_with_query_expression_descending(self):
+        qs = mock.Mock(spec=["order_by"])
+        f = OrderingFilter(fields=((F("a"), "a"),))
+        f.filter(qs, ["-a"])
+        qs.order_by.assert_called_once_with(F("a").desc())
 
     def test_filtering_skipped_with_none_value(self):
         qs = mock.Mock(spec=["order_by"])


### PR DESCRIPTION
Hi there,

I found that I can *nearly* use the `OrderingFilter` with query expressions and not only field names, just like in the [documentation of Django's `order_by()` method](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#django.db.models.query.QuerySet.order_by), when using it with a list of tuples like this:

```python
o = django_filters.OrderingFilter(fields = [
  (Coalesce("last_name", "first_name"), "name")
])
```

The only issue with this is that reversing sort order fails. If I try to sort by `"-name"` then, the current implementation of the `OrderingFilter` tries to call `.order_by()` with a parameter constructed as `"-%s" % Coalesce("last_name", "first_name")"` - which fails of course.

For my own use case, I have just subclassed `OrderFilter` and could override the `get_ordering_value()` method with a patched implementation, but I guess it could be helpful to others, too.

I've updated the doc string to mention that query expressions can be used, and I've added two test cases. The one with ascending order already works with the current implementation, the one with the descending order only with this pull request. For easy verification, I've committed the test case first, so if you check out rev fe1d4f1 and run the tests, you will see the fail.

I guess #1021 can be closed with this patch, and maybe #1118 too - the functionality seems available, you just need to use the list of tuples syntax. Or am I missing something?

Thanks for reviewing,
Mark