### PR TITLE
Increase the version upper limit for flit_core to 5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
+requires = ["flit_core >=3.2,<5"]
 build-backend = "flit_core.buildapi"
 
 [project]


### PR DESCRIPTION
Downstreams that attempt to build with latest flit_core (4.0.0) will not be able to (this is currently blocking us on Arch Linux to build/rebuild this project as a package).

In addition, an upper version limit does not seem to be very useful when it comes to the build backend.